### PR TITLE
Post ruff upgrade tweaks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ repos:
       - id: codespell
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.3.4
+    rev: v0.3.5
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]

--- a/optype/_can.py
+++ b/optype/_can.py
@@ -112,7 +112,7 @@ class CanLe[X, Y](Protocol):
 
 
 @runtime_checkable
-class CanEq[X, Y](Protocol):
+class CanEq[X, Y](Protocol):  # noqa: PLW1641
     """
     Unfortunately, `typeshed` incorrectly annotates `object.__eq__` as
     `(Self, object) -> bool`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -155,9 +155,6 @@ extend-ignore = [
     # flake8-pyi
     "PYI036",   # bad-exit-annotation (unreasonable)
 
-    # pylint
-    "PLW1641",  # eq-without-hash (buggy; doesn't consider super)
-
     # refurb
     "FURB118",  # reimplemented-operator (unreasonable)
 ]


### PR DESCRIPTION
- sync pre-commit ruff version with pyproject.toml
- re-enable `PLW1641` globally
