### PR TITLE
add `*Self` aliases for context manager interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -1294,24 +1294,38 @@ Support for the `with` statement.
     <tr>
         <td>expression</td>
         <td>method(s)</td>
-        <th>type</th>
+        <th>type(s)</th>
     </tr>
     <tr>
         <td></td>
         <td><code>__enter__</code></td>
-        <td><code>CanEnter[C]</code></td>
+        <td>
+            <code>CanEnter[C]</code>, or
+            <code>CanEnterSelf</code>
+        </td>
     </tr>
     <tr>
         <td></td>
         <td><code>__exit__</code></td>
-        <td><code>CanExit[R = None]</code></td>
+        <td>
+            <code>CanExit[R = None]</code>
+        </td>
     </tr>
     <tr>
-        <td><code>with _ as v</code></td>
-        <td><code>__enter__</code>, <code>__exit__</code></td>
-        <td><code>CanWith[C, R = None]</code></td>
+        <td><code>with _ as c:</code></td>
+        <td>
+            <code>__enter__</code>, and <br>
+            <code>__exit__</code>
+        </td>
+        <td>
+            <code>CanWith[C, R = None]</code>, or<br>
+            <code>CanWithSelf[R = None]</code>
+        </td>
     </tr>
 </table>
+
+`CanEnterSelf` and `CanWithSelf` are (runtime-checkable) aliases for
+`CanEnter[Self]` and `CanWith[Self, R]`, respectively.
 
 For the `async with` statement the interfaces look very similar:
 

--- a/README.md
+++ b/README.md
@@ -1318,8 +1318,8 @@ Support for the `with` statement.
             <code>__exit__</code>
         </td>
         <td>
-            <code>CanWith[C, R = None]</code>, or<br>
-            <code>CanWithSelf[R = None]</code>
+            <code>CanWith[C, R=None]</code>, or<br>
+            <code>CanWithSelf[R=None]</code>
         </td>
     </tr>
 </table>
@@ -1337,22 +1337,31 @@ For the `async with` statement the interfaces look very similar:
     <tr>
         <td>expression</td>
         <td>method(s)</td>
-        <th>type</th>
+        <th>type(s)</th>
     </tr>
     <tr>
         <td></td>
         <td><code>__aenter__</code></td>
-        <td><code>CanAEnter[C]</code></td>
+        <td>
+            <code>CanAEnter[C]</code>, or<br>
+            <code>CanAEnterSelf</code>
+        </td>
     </tr>
     <tr>
         <td></td>
         <td><code>__aexit__</code></td>
-        <td><code>CanAExit[R = None]</code></td>
+        <td><code>CanAExit[R=None]</code></td>
     </tr>
     <tr>
-        <td><code>async with _ as v</code></td>
-        <td><code>__aenter__</code>, <code>__aexit__</code></td>
-        <td><code>CanAsyncWith[C, R = None]</code></td>
+        <td><code>async with _ as c:</code></td>
+        <td>
+            <code>__aenter__</code>, and<br>
+            <code>__aexit__</code>
+        </td>
+        <td>
+            <code>CanAsyncWith[C, R=None]</code>, or<br>
+            <code>CanAsyncWithSelf[R=None]</code>
+        </td>
     </tr>
 </table>
 

--- a/optype/__init__.py
+++ b/optype/__init__.py
@@ -27,6 +27,7 @@ __all__ = (
     'CanDir',
     'CanDivmod',
     'CanEnter',
+    'CanEnterSelf',
     'CanEq',
     'CanExit',
     'CanFloat',
@@ -131,6 +132,7 @@ __all__ = (
     'CanTruediv',
     'CanTrunc',
     'CanWith',
+    'CanWithSelf',
     'CanXor',
     'DoesAIter',
     'DoesANext',
@@ -346,6 +348,7 @@ from ._can import (
     CanDir,
     CanDivmod,
     CanEnter,
+    CanEnterSelf,
     CanEq,
     CanExit,
     CanFloat,
@@ -450,6 +453,7 @@ from ._can import (
     CanTruediv,
     CanTrunc,
     CanWith,
+    CanWithSelf,
     CanXor,
 )
 from ._do import (

--- a/optype/__init__.py
+++ b/optype/__init__.py
@@ -1,5 +1,6 @@
 __all__ = (
     'CanAEnter',
+    'CanAEnterSelf',
     'CanAExit',
     'CanAIter',
     'CanAIterSelf',
@@ -9,6 +10,7 @@ __all__ = (
     'CanAdd',
     'CanAnd',
     'CanAsyncWith',
+    'CanAsyncWithSelf',
     'CanAwait',
     'CanBool',
     'CanBuffer',
@@ -321,6 +323,7 @@ from importlib import metadata as _metadata
 
 from ._can import (
     CanAEnter,
+    CanAEnterSelf,
     CanAExit,
     CanAIter,
     CanAIterSelf,
@@ -330,6 +333,7 @@ from ._can import (
     CanAdd,
     CanAnd,
     CanAsyncWith,
+    CanAsyncWithSelf,
     CanAwait,
     CanBool,
     CanBuffer,

--- a/optype/_can.py
+++ b/optype/_can.py
@@ -1298,6 +1298,12 @@ class CanAEnter(Protocol[_C_aenter]):
     def __aenter__(self, /) -> CanAwait[_C_aenter]: ...
 
 
+@runtime_checkable
+class CanAEnterSelf(CanAEnter['CanAEnterSelf'], Protocol):
+    @override
+    def __aenter__(self, /) -> CanAwait[Self]: ...
+
+
 _E_aexit = TypeVar('_E_aexit', bound=BaseException)
 _R_aexit = TypeVar('_R_aexit', infer_variance=True, default=None)
 
@@ -1322,12 +1328,32 @@ class CanAExit(Protocol[_R_aexit]):
     ) -> CanAwait[_R_aexit]: ...
 
 
+_C_async_with = TypeVar('_C_async_with', infer_variance=True)
+_R_async_with = TypeVar('_R_async_with', infer_variance=True, default=None)
+
+
 @runtime_checkable
 class CanAsyncWith(
-    CanAEnter[_C_aenter],
-    CanAExit[_R_aexit],
-    Protocol[_C_aenter, _R_aexit],
-): ...
+    CanAEnter[_C_async_with],
+    CanAExit[_R_async_with],
+    Protocol[_C_async_with, _R_async_with],
+):
+    """
+    The intersection type of `CanAEnter` and `CanAExit`, i.e.
+    `CanAsyncWith[C, R=None] = CanAEnter[C] & CanAExit[R]`.
+    """
+
+
+@runtime_checkable
+class CanAsyncWithSelf(
+    CanAEnterSelf,
+    CanAExit[_R_async_with],
+    Protocol[_R_async_with],
+):
+    """
+    The intersection type of `CanAEnterSelf` and `CanAExit`, i.e.
+    `CanAsyncWithSelf[R=None] = CanAEnterSelf & CanAExit[R]`.
+    """
 
 
 #

--- a/optype/_can.py
+++ b/optype/_can.py
@@ -1233,6 +1233,12 @@ class CanEnter(Protocol[_C_enter]):
     def __enter__(self, /) -> _C_enter: ...
 
 
+@runtime_checkable
+class CanEnterSelf(CanEnter['CanEnterSelf'], Protocol):
+    @override
+    def __enter__(self, /) -> Self: ...  # pyright: ignore[reportMissingSuperCall]
+
+
 _E_exit = TypeVar('_E_exit', bound=BaseException)
 _R_exit = TypeVar('_R_exit', infer_variance=True, default=None)
 
@@ -1257,18 +1263,32 @@ class CanExit(Protocol[_R_exit]):
     ) -> _R_exit: ...
 
 
+_C_with = TypeVar('_C_with', infer_variance=True)
+_R_with = TypeVar('_R_with', infer_variance=True, default=None)
+
+
 @runtime_checkable
-class CanWith(
-    CanEnter[_C_enter],
-    CanExit[_R_exit],
-    Protocol[_C_enter, _R_exit],
-): ...
+class CanWith(CanEnter[_C_with], CanExit[_R_with], Protocol[_C_with, _R_with]):
+    """
+    The intersection type of `CanEnter` and `CanExit`, i.e.
+    `CanWith[C, R=None] = CanEnter[C] & CanExit[R]`.
+    """
+
+
+_R_with_self = TypeVar('_R_with_self', infer_variance=True, default=None)
+
+
+@runtime_checkable
+class CanWithSelf(CanEnterSelf, CanExit[_R_with_self], Protocol[_R_with_self]):
+    """
+    The intersection type of `CanEnterSelf` and `CanExit`, i.e.
+    `CanWithSelf[R=None] = CanEnterSelf & CanExit[R]`.
+    """
 
 
 #
 # Async context managers
 #
-
 
 _C_aenter = TypeVar('_C_aenter', infer_variance=True)
 

--- a/tests/test_protocols.py
+++ b/tests/test_protocols.py
@@ -87,7 +87,11 @@ def test_name_matches_dunder(cls: type):
     assert members
 
     own_members: frozenset[str]
-    parents = list(filter(is_protocol, cls.mro()[1:]))
+    parents = [
+        parent for parent in cls.mro()[1:]
+        if not parent.__name__.endswith('Self')
+        and is_protocol(parent)
+    ]
     if parents:
         overridden = {
             member for member in members
@@ -105,7 +109,7 @@ def test_name_matches_dunder(cls: type):
 
     if member_count > min(1, own_member_count):
         # ensure len(parent protocols) == len(members) (including inherited)
-        assert len(parents) == member_count
+        assert member_count == len(parents), own_members
 
         members_concrete = set(members)
         for parent in parents:


### PR DESCRIPTION
Added

- `CanEnterSelf`
- `CanWithSelf`

and 

- `CanAEnterSelf`
- `CanAsyncWithSelf`