### PR TITLE
Prefer `typing_extensions` imports for `Protocol` and `runtime_checkable`

### DIFF
--- a/optype/_can.py
+++ b/optype/_can.py
@@ -1,27 +1,32 @@
 from __future__ import annotations
 
 import sys
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Literal,
-    Protocol,
-    TypeAlias,
-    overload,
-    runtime_checkable,
-)
+from typing import TYPE_CHECKING, Any, Literal, TypeAlias
 
 
 if sys.version_info >= (3, 13):
-    from typing import ParamSpec, Self, TypeVar, TypeVarTuple, Unpack, override
+    from typing import (
+        ParamSpec,
+        Protocol,
+        Self,
+        TypeVar,
+        TypeVarTuple,
+        Unpack,
+        overload,
+        override,
+        runtime_checkable,
+    )
 else:
     from typing_extensions import (
         ParamSpec,
+        Protocol,
         Self,  # noqa: TCH002
         TypeVar,
         TypeVarTuple,
         Unpack,
+        overload,
         override,
+        runtime_checkable,
     )
 
 

--- a/optype/_does.py
+++ b/optype/_does.py
@@ -1,16 +1,14 @@
+import sys
 from collections.abc import Callable
-from typing import (
-    Any,
-    Literal,
-    ParamSpec,
-    Protocol,
-    TypeAlias,
-    TypeVar,
-    final,
-    overload,
-)
+from typing import Any, Literal, TypeAlias
 
 import optype._can as _c
+
+
+if sys.version_info >= (3, 13):
+    from typing import ParamSpec, Protocol, TypeVar, final, overload
+else:
+    from typing_extensions import ParamSpec, Protocol, TypeVar, final, overload
 
 
 # iteration

--- a/optype/_has.py
+++ b/optype/_has.py
@@ -1,36 +1,32 @@
 from __future__ import annotations
 
 import sys
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    ClassVar,
-    Final,
-    Protocol,
-    TypeAlias,
-    runtime_checkable,
-)
+from typing import TYPE_CHECKING, Any, ClassVar, Final, TypeAlias
 
 
 if sys.version_info >= (3, 13):
     from typing import (
         Never,
         ParamSpec,
+        Protocol,
         Self,
         TypeVar,
         TypeVarTuple,
         Unpack,
         override,
+        runtime_checkable,
     )
 else:
     from typing_extensions import (
         Never,
         ParamSpec,
+        Protocol,
         Self,  # noqa: TCH002
         TypeVar,
         TypeVarTuple,
         Unpack,
         override,
+        runtime_checkable,
     )
 
 import optype._can as _c

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,30 +1,53 @@
+from __future__ import annotations
+
 import inspect
-from types import ModuleType
-from typing import Protocol, cast
-
-from optype import CanBool, CanLt
+import sys
+from typing import TYPE_CHECKING, Protocol as _typing_Protocol, cast
 
 
-def is_protocol(cls: type) -> bool:
+if sys.version_info >= (3, 13):
+    from typing import Protocol
+else:
+    from typing_extensions import Protocol
+
+
+if TYPE_CHECKING:
+    from types import ModuleType
+
+    from optype import CanBool, CanLt
+
+
+__all__ = (
+    'get_callable_members',
+    'get_protocol_members',
+    'get_protocols',
+    'is_dunder',
+    'is_protocol',
+    'pascamel_to_snake',
+)
+
+
+def is_protocol(cls: type, /) -> bool:
     """Based on `typing_extensions.is_protocol`."""
     return (
         isinstance(cls, type)
         and cls is not Protocol
-        and issubclass(cls, Protocol)
+        and cls is not _typing_Protocol
+        and (issubclass(cls, Protocol) or issubclass(cls, _typing_Protocol))
         and getattr(cls, '_is_protocol', False)
     )
 
 
-def is_runtime_protocol(cls: type) -> bool:
+def is_runtime_protocol(cls: type, /) -> bool:
     """Check if `cls` is a `@runtime_checkable` `typing.Protocol`."""
     return is_protocol(cls) and getattr(cls, '_is_runtime_protocol', False)
 
 
-def get_protocol_members(cls: type) -> frozenset[str]:
+def get_protocol_members(cls: type, /) -> frozenset[str]:
     """
     A variant of `typing_extensions.get_protocol_members()` that doesn't
-    hide e.g. `__dict__` and `__annotations`, or adds `__hash__` if there's an
-    `__eq__` method.
+    hide e.g. `__dict__` and `__annotations__`, or adds `__hash__` if there's
+    an `__eq__` method.
     Does not return method names of base classes defined in another module.
     """
     assert is_protocol(cls)

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -2,13 +2,13 @@ from __future__ import annotations
 
 import inspect
 import sys
-from typing import TYPE_CHECKING, Protocol as _typing_Protocol, cast
+from typing import TYPE_CHECKING, cast
 
 
 if sys.version_info >= (3, 13):
-    from typing import Protocol
+    from typing import is_protocol
 else:
-    from typing_extensions import Protocol
+    from typing_extensions import is_protocol
 
 
 if TYPE_CHECKING:
@@ -25,17 +25,6 @@ __all__ = (
     'is_protocol',
     'pascamel_to_snake',
 )
-
-
-def is_protocol(cls: type, /) -> bool:
-    """Based on `typing_extensions.is_protocol`."""
-    return (
-        isinstance(cls, type)
-        and cls is not Protocol
-        and cls is not _typing_Protocol
-        and (issubclass(cls, Protocol) or issubclass(cls, _typing_Protocol))
-        and getattr(cls, '_is_protocol', False)
-    )
 
 
 def is_runtime_protocol(cls: type, /) -> bool:


### PR DESCRIPTION
This'll make instance checks faster on `python<3.12`, and improves compatibility with Python 3.13.