### PR TITLE
Export `optype.types`

### DIFF
--- a/optype/__init__.py
+++ b/optype/__init__.py
@@ -317,10 +317,12 @@ __all__ = (
     'do_truediv',
     'do_trunc',
     'do_xor',
+    'types',
 )
 
 from importlib import metadata as _metadata
 
+from . import types
 from ._can import (
     CanAEnter,
     CanAEnterSelf,

--- a/tests/types/test_slice.py
+++ b/tests/types/test_slice.py
@@ -2,7 +2,7 @@
 import sys
 from typing import Literal, cast
 
-from optype.types import Slice
+import optype as opt
 
 
 if sys.version_info >= (3, 13):
@@ -14,31 +14,34 @@ else:
 def test_slice_obj():
     s = slice(42)
 
-    s_default_0: Slice = s
-    s_default_1: Slice[None] = s
-    s_default_2: Slice[None, int] = s
-    s_default_3: Slice[None, int, None] = s
+    s_default_0: opt.types.Slice = s
+    s_default_1: opt.types.Slice[None] = s
+    s_default_2: opt.types.Slice[None, int] = s
+    s_default_3: opt.types.Slice[None, int, None] = s
 
-    s_wrong_1: Slice[str] = s
-    s_wrong_2: Slice[None, str] = s
-    s_wrong_3: Slice[None, int, str] = s
+    s_wrong_1: opt.types.Slice[str] = s
+    s_wrong_2: opt.types.Slice[None, str] = s
+    s_wrong_3: opt.types.Slice[None, int, str] = s
 
-    assert isinstance(s, Slice)
+    assert isinstance(s, opt.types.Slice)
 
 
 def test_slice_indices():
-    s0 = cast(Slice[None, None, None], slice(None))
+    s0 = cast(opt.types.Slice[None, None, None], slice(None))
     i0 = s0.indices(32)
     assert_type(i0, tuple[Literal[0], int, Literal[1]])
 
-    s1 = cast(Slice[None, Literal[42], None], slice(42))
+    s1 = cast(opt.types.Slice[None, Literal[42], None], slice(42))
     i1 = s1.indices(32)
     assert_type(i1, tuple[Literal[0], int, Literal[1]])
 
-    s2 = cast(Slice[Literal[6], Literal[42], None], slice(6, 42))
+    s2 = cast(opt.types.Slice[Literal[6], Literal[42], None], slice(6, 42))
     i2 = s2.indices(32)
     assert_type(i2, tuple[int, int, Literal[1]])
 
-    s3 = cast(Slice[Literal[6], Literal[42], Literal[2]], slice(6, 42, 2))
+    s3 = cast(
+        opt.types.Slice[Literal[6], Literal[42], Literal[7]],
+        slice(6, 42, 7),
+    )
     i3 = s3.indices(32)
     assert_type(i3, tuple[int, int, int])


### PR DESCRIPTION
This ensures that `optype.types` is always available, e.g.

```pycon
>>> import optype as opt
>>> isinstance(slice(42), opt.types.Slice)
True
```
