### PR TITLE
Extract `copy`-related `Can*` protocols to  the new `optype.copy` namespace

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -15,6 +15,8 @@ MD033:
     - a
     - i
     - code
+    - sup
+    - sub
     - img
     - table
     - tr

--- a/README.md
+++ b/README.md
@@ -1554,15 +1554,18 @@ runtime-checkable interfaces:
     <tr>
         <td><code>copy.copy(_) -> R</code></td>
         <td><code>__copy__() -> R</code></td>
-        <td><code>_: CanCopy[R]</code></td>
+        <td><code>CanCopy[R]</code></td>
     </tr>
     <tr>
-        <td><code>copy.deepcopy(_, memo={})</code></td>
+        <td><code>copy.deepcopy(_, memo={}) -> R</code></td>
         <td><code>__deepcopy__(memo, /) -> R</code></td>
         <td><code>CanDeepcopy[R]</code></td>
     </tr>
     <tr>
-        <td><code>copy.replace(_, /, **changes: V)</code><sup>[1]</sup></td>
+        <td>
+            <code>copy.replace(_, /, **changes: V) -> R</code>
+            <sup>[1]</sup>
+        </td>
         <td><code>__replace__(**changes: V) -> R</code></td>
         <td><code>CanReplace[V, R]</code></td>
     </tr>

--- a/optype/__init__.py
+++ b/optype/__init__.py
@@ -19,10 +19,6 @@ __all__ = (
     'CanCeil',
     'CanComplex',
     'CanContains',
-    'CanCopy',
-    'CanCopySelf',
-    'CanDeepcopy',
-    'CanDeepcopySelf',
     'CanDelattr',
     'CanDelete',
     'CanDelitem',
@@ -115,8 +111,6 @@ __all__ = (
     'CanReduce',
     'CanReduceEx',
     'CanReleaseBuffer',
-    'CanReplace',
-    'CanReplaceSelf',
     'CanRepr',
     'CanReversed',
     'CanRound',
@@ -235,6 +229,7 @@ __all__ = (
     'HasTypeParams',
     'HasWrapped',
     '__version__',
+    'copy',
     'do_abs',
     'do_add',
     'do_aiter',
@@ -322,7 +317,7 @@ __all__ = (
 
 from importlib import metadata as _metadata
 
-from . import types
+from . import copy, types
 from ._can import (
     CanAEnter,
     CanAEnterSelf,
@@ -344,10 +339,6 @@ from ._can import (
     CanCeil,
     CanComplex,
     CanContains,
-    CanCopy,
-    CanCopySelf,
-    CanDeepcopy,
-    CanDeepcopySelf,
     CanDelattr,
     CanDelete,
     CanDelitem,
@@ -440,8 +431,6 @@ from ._can import (
     CanReduce,
     CanReduceEx,
     CanReleaseBuffer,
-    CanReplace,
-    CanReplaceSelf,
     CanRepr,
     CanReversed,
     CanRound,

--- a/optype/_can.py
+++ b/optype/_can.py
@@ -36,8 +36,8 @@ if TYPE_CHECKING:
 
 
 _Ignored: TypeAlias = Any
-_IsFalse: TypeAlias = Literal[False]
-_IsTrue: TypeAlias = Literal[True]
+_JustFalse: TypeAlias = Literal[False]
+_JustTrue: TypeAlias = Literal[True]
 
 
 #
@@ -46,8 +46,8 @@ _IsTrue: TypeAlias = Literal[True]
 
 _R_bool = TypeVar(
     '_R_bool',
-    _IsFalse,
-    _IsTrue,
+    _JustFalse,
+    _JustTrue,
     bool,
     infer_variance=True,
     default=bool,
@@ -529,8 +529,8 @@ _K_contains = TypeVar(
 # could be set to e.g. _IsFalse empty (user-defined) container types
 _R_contains = TypeVar(
     '_R_contains',
-    _IsFalse,
-    _IsTrue,
+    _JustFalse,
+    _JustTrue,
     bool,
     infer_variance=True,
     default=bool,
@@ -1404,64 +1404,6 @@ class CanAwait(Protocol[_R_await]):
     def __await__(self: CanAwait[None], /) -> CanNext[_FutureOrNone]: ...
     @overload
     def __await__(self: CanAwait[_R_await], /) -> _AsyncGen[_R_await]: ...
-
-
-#
-# Standard library `copy`
-#
-
-_R_copy = TypeVar('_R_copy', infer_variance=True, bound=object)
-
-
-@runtime_checkable
-class CanCopy(Protocol[_R_copy]):
-    """Support for creating shallow copies through `copy.copy`."""
-    def __copy__(self, /) -> _R_copy: ...
-
-
-@runtime_checkable
-class CanCopySelf(CanCopy['CanCopySelf'], Protocol):
-    """Variant of `CanCopy` that returns `Self` (as it should)."""
-    @override
-    def __copy__(self, /) -> Self: ...
-
-
-_R_deepcopy = TypeVar('_R_deepcopy', infer_variance=True, bound=object)
-
-
-@runtime_checkable
-class CanDeepcopy(Protocol[_R_deepcopy]):
-    """Support for creating deep copies through `copy.deepcopy`."""
-    def __deepcopy__(self, memo: dict[int, Any], /) -> _R_deepcopy: ...
-
-
-class CanDeepcopySelf(CanDeepcopy['CanDeepcopySelf'], Protocol):
-    """Variant of `CanDeepcopy` that returns `Self` (as it should)."""
-    @override
-    def __deepcopy__(self, memo: dict[int, Any], /) -> Self: ...
-
-
-_V_replace = TypeVar('_V_replace', infer_variance=True)
-_R_replace = TypeVar('_R_replace', infer_variance=True)
-
-
-@runtime_checkable
-class CanReplace(Protocol[_V_replace, _R_replace]):
-    """Support for `copy.replace` in Python 3.13+."""
-    def __replace__(self, /, **changes: _V_replace) -> _R_replace: ...
-
-
-_V_replace_self = TypeVar('_V_replace_self', infer_variance=True)
-
-
-@runtime_checkable
-class CanReplaceSelf(
-    CanReplace[_V_replace_self, 'CanReplaceSelf[Any]'],
-    Protocol[_V_replace_self],
-):
-    """Variant of `CanReplace[V, Self]`."""
-    @override
-    def __replace__(self, /, **changes: _V_replace_self) -> Self: ...
 
 
 #

--- a/optype/copy.py
+++ b/optype/copy.py
@@ -1,0 +1,79 @@
+"""
+Runtime-protocols for the `copy` standard library.
+https://docs.python.org/3/library/copy.html
+"""
+from __future__ import annotations
+
+import sys
+
+
+if sys.version_info >= (3, 13):
+    from typing import (
+        Protocol,
+        Self,
+        TypeVar,
+        override,
+        runtime_checkable,
+    )
+else:
+    from typing_extensions import (
+        Protocol,
+        Self,  # noqa: TCH002
+        TypeVar,
+        override,
+        runtime_checkable,
+    )
+
+
+# fmt: off
+__all__ = (
+    'CanCopy', 'CanCopySelf',
+    'CanDeepcopy', 'CanDeepcopySelf',
+    'CanReplace', 'CanReplaceSelf',
+)
+# fmt: on
+
+_CopyT = TypeVar('_CopyT', infer_variance=True)
+_ValueT = TypeVar('_ValueT', infer_variance=True)
+
+
+@runtime_checkable
+class CanCopy(Protocol[_CopyT]):
+    """Support for creating shallow copies through `copy.copy`."""
+    def __copy__(self, /) -> _CopyT: ...
+
+
+@runtime_checkable
+class CanCopySelf(CanCopy['CanCopySelf'], Protocol):
+    """Variant of `CanCopy` that returns `Self` (as it should)."""
+    @override
+    def __copy__(self, /) -> Self: ...
+
+
+@runtime_checkable
+class CanDeepcopy(Protocol[_CopyT]):
+    """Support for creating deep copies through `copy.deepcopy`."""
+    def __deepcopy__(self, memo: dict[int, object], /) -> _CopyT: ...
+
+
+@runtime_checkable
+class CanDeepcopySelf(CanDeepcopy['CanDeepcopySelf'], Protocol):
+    """Variant of `CanDeepcopy` that returns `Self` (as it should)."""
+    @override
+    def __deepcopy__(self, memo: dict[int, object], /) -> Self: ...
+
+
+@runtime_checkable
+class CanReplace(Protocol[_ValueT, _CopyT]):
+    """Support for `copy.replace` in Python 3.13+."""
+    def __replace__(self, /, **changes: _ValueT) -> _CopyT: ...
+
+
+@runtime_checkable
+class CanReplaceSelf(
+    CanReplace[_ValueT, 'CanReplaceSelf[_ValueT]'],
+    Protocol[_ValueT],
+):
+    """Variant of `CanReplace[V, Self]`."""
+    @override
+    def __replace__(self, /, **changes: _ValueT) -> Self: ...

--- a/tests/numpy/test_copy.py
+++ b/tests/numpy/test_copy.py
@@ -1,0 +1,82 @@
+# ruff: noqa: F841
+import sys
+from datetime import date
+from fractions import Fraction
+from typing import Any, Final
+
+import pytest
+
+import optype as opt
+from optype.inspect import get_protocol_members, is_runtime_protocol
+
+
+require_py313: Final = pytest.mark.skipif(
+    sys.version_info < (3, 13),
+    reason='requires python>=3.13',
+)
+
+
+def get_type_params(cls: type) -> tuple[Any, ...]:
+    return getattr(cls, '__parameters__', ())
+
+
+@pytest.mark.parametrize(
+    'cls',
+    [getattr(opt.copy, k) for k in opt.copy.__all__ if not k.endswith('Self')],
+)
+def test_protocols(cls: type):
+    # ensure correct name
+    assert cls.__module__ == 'optype.copy'
+    assert cls.__name__ == cls.__qualname__
+    assert cls.__name__.startswith('Can')
+
+    # ensure exported
+    assert cls.__name__ in opt.copy.__all__
+
+    # ensure each `Can{}` has a corresponding `Can{}Self` sub-protocol
+    cls_self = getattr(opt.copy, f'{cls.__name__}Self')
+    assert cls_self is not cls
+    assert cls_self.__name__ in opt.copy.__all__
+    assert issubclass(cls_self, cls)
+    assert len(get_type_params(cls)) == len(get_type_params(cls_self)) + 1
+
+    # ensure single-method protocols
+    assert len(get_protocol_members(cls)) == 1
+    assert len(get_protocol_members(cls_self)) == 1
+
+    # ensure @runtime_checkable
+    assert is_runtime_protocol(cls)
+    assert is_runtime_protocol(cls_self)
+
+
+def test_can_copy():
+    a = Fraction(1, 137)
+
+    a_copy: opt.copy.CanCopy[Fraction] = a
+    a_copy_self: opt.copy.CanCopySelf = a
+
+    assert isinstance(a, opt.copy.CanCopy)
+    assert isinstance(a, opt.copy.CanCopySelf)
+
+
+def test_can_deepcopy():
+    a = Fraction(1, 137)
+
+    a_copy: opt.copy.CanDeepcopy[Fraction] = a
+    a_copy_self: opt.copy.CanDeepcopySelf = a
+
+    assert isinstance(a, opt.copy.CanDeepcopy)
+    assert isinstance(a, opt.copy.CanDeepcopySelf)
+
+
+@require_py313
+def test_can_replace():
+    d = date(2024, 10, 1)
+
+    # this seemingly redundant `if` statement prevents pyright errors
+    if sys.version_info >= (3, 13):
+        d_replace: opt.copy.CanReplace[opt.CanIndex, date] = d
+        d_copy_self: opt.copy.CanReplaceSelf[opt.CanIndex] = d
+
+    assert isinstance(d, opt.copy.CanReplace)
+    assert isinstance(d, opt.copy.CanReplaceSelf)


### PR DESCRIPTION
> [!IMPORTANT]
> This is a backwards-compatible breaking change! 

This moves the following runtime-protocols from `optype` to `optype.copy`:

- `CanCopy(Self)`
- `CanDeepcopy(Self)`
- `CanReplace(Self)`

> [!NOTE]
> The `optype.copy` is exported in `optype`.
> So `import optype as opt` will allow you to access e.g. `opt.copy.CanCopy`.



