### PR TITLE
Extract `pickle`-related `Can*` protocols to  the new `optype.pickle` namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,7 @@ The reference docs are structured as follows:
     - [Descriptors](#descriptors)
     - [Buffer types](#buffer-types)
 - [`optype.copy`](#optypecopy)
+- [`optype.pickle`](#optypepickle)
 - [`optype.types`](#optypetypes)
     - [`Slice`](#slice)
     - [`AnyIterable` and `is_iterable`](#anyiterable-and-is_iterable)
@@ -238,7 +239,6 @@ The reference docs are structured as follows:
     - [`LiteralBool`](#literalbool)
     - [`LiteralByte`](#literalbyte)
 - [Standard libs](#standard-libs)
-    - [`pickle`](#pickle)
     - [`dataclasses`](#dataclasses)
 - [NumPy](#numpy)
     - [Arrays](#arrays)
@@ -1589,53 +1589,7 @@ type CanReplaceSelf[V] = CanReplace[V, CanReplaceSelf[V]]
 
 [CP]: https://docs.python.org/3/library/copy.html
 
-### `optype.types`
-
-#### `Slice`
-
-The `optype.types.Slice` type is a generic runtime-protocol that's fully
-compatible with `builtins.slice` (from a typing perspective).
-
-Its type signature looks something like this:
-
-```python
-Slice[A = None, B = Any, S = None]
-```
-
-#### `AnyIterable` and `is_iterable`
-
-The `optype.types.AnyIterable[V = Any]` type is a type alias for anything that
-can be used in a for-loop and `builtins.iter`.
-
-But type aliases are not runtime-checkable.
-So if you want to check whether something can be iterated over, without
-actually trying to do so, you can use `optype.types.is_iterable`.
-
-### `AnyInt` / `AnyFloat` / `AnyComplex`
-
-Anything that can *always* be converted to `int` / `float` /`complex`,
-and that doesn't cause a deprecation warning (e.g. `__trunc__` delegation for
-`int`).
-
-Even though *some* `str` and `bytes` can be converted to `int` / `float` /
-`complex`, most of them can't, and are therefore not included in these
-type aliases.
-
-### `LiteralBool`
-
-The analogue of `typing.LiteralString`, but for booleans.
-`LiteralBool` is a type alias for `typing.Literal[False, True]`.
-
-### `LiteralByte`
-
-The analogue of `typing.LiteralString`, but for `int` values that make up
-a `bytes` or `bytearray` instance, i.e. `x: int` s.t. `0 <= x < 256`.
-`LiteralByte` is defined as the `typing.Literal` of the the integers in
-`range(256)`.
-
-### Standard libs
-
-#### `pickle`
+### `optype.pickle`
 
 For the [`pickle`][PK] standard library, `optype` provides the following
 interfaces:
@@ -1691,6 +1645,52 @@ interfaces:
         <td><code>CanGetnewargsEx[*Vs, V]</code></td>
     </tr>
 </table>
+
+### `optype.types`
+
+#### `Slice`
+
+The `optype.types.Slice` type is a generic runtime-protocol that's fully
+compatible with `builtins.slice` (from a typing perspective).
+
+Its type signature looks something like this:
+
+```python
+Slice[A = None, B = Any, S = None]
+```
+
+#### `AnyIterable` and `is_iterable`
+
+The `optype.types.AnyIterable[V = Any]` type is a type alias for anything that
+can be used in a for-loop and `builtins.iter`.
+
+But type aliases are not runtime-checkable.
+So if you want to check whether something can be iterated over, without
+actually trying to do so, you can use `optype.types.is_iterable`.
+
+### `AnyInt` / `AnyFloat` / `AnyComplex`
+
+Anything that can *always* be converted to `int` / `float` /`complex`,
+and that doesn't cause a deprecation warning (e.g. `__trunc__` delegation for
+`int`).
+
+Even though *some* `str` and `bytes` can be converted to `int` / `float` /
+`complex`, most of them can't, and are therefore not included in these
+type aliases.
+
+### `LiteralBool`
+
+The analogue of `typing.LiteralString`, but for booleans.
+`LiteralBool` is a type alias for `typing.Literal[False, True]`.
+
+### `LiteralByte`
+
+The analogue of `typing.LiteralString`, but for `int` values that make up
+a `bytes` or `bytearray` instance, i.e. `x: int` s.t. `0 <= x < 256`.
+`LiteralByte` is defined as the `typing.Literal` of the the integers in
+`range(256)`.
+
+### Standard libs
 
 #### `dataclasses`
 

--- a/README.md
+++ b/README.md
@@ -1591,7 +1591,7 @@ type CanReplaceSelf[V] = CanReplace[V, CanReplaceSelf[V]]
 
 ### `optype.pickle`
 
-For the [`pickle`][PK] standard library, `optype` provides the following
+For the [`pickle`][PK] standard library, `optype.pickle` provides the following
 interfaces:
 
 [PK]: https://docs.python.org/3/library/pickle.html
@@ -1605,22 +1605,22 @@ interfaces:
     <tr>
         <td><code>__reduce__</code></td>
         <td><code>() -> R</code></td>
-        <td><code>CanReduce[R: str | tuple = str | tuple]</code></td>
+        <td><code>CanReduce[R: str | tuple = ...]</code></td>
     </tr>
     <tr>
         <td><code>__reduce_ex__</code></td>
         <td><code>(CanIndex) -> R</code></td>
-        <td><code>CanReduceEx[R: str | tuple = str | tuple]</code></td>
+        <td><code>CanReduceEx[R: str | tuple = ...]</code></td>
     </tr>
     <tr>
         <td><code>__getstate__</code></td>
         <td><code>() -> S</code></td>
-        <td><code>CanGetstate[S: object]</code></td>
+        <td><code>CanGetstate[S]</code></td>
     </tr>
     <tr>
         <td><code>__setstate__</code></td>
         <td><code>(S) -> None</code></td>
-        <td><code>CanSetstate[S: object]</code></td>
+        <td><code>CanSetstate[S]</code></td>
     </tr>
     <tr>
         <td>
@@ -1628,10 +1628,10 @@ interfaces:
             <code>__new__</code>
         </td>
         <td>
-            <code>() -> tuple[*Vs]</code><br>
-            <code>(*Vs) -> Self</code><br>
+            <code>() -> tuple[V, ...]</code><br>
+            <code>(V) -> Self</code><br>
         </td>
-        <td><code>CanGetnewargs[*Vs]</code></td>
+        <td><code>CanGetnewargs[V]</code></td>
     </tr>
     <tr>
         <td>
@@ -1639,10 +1639,10 @@ interfaces:
             <code>__new__</code>
         </td>
         <td>
-            <code>() -> tuple[tuple[*Vs], dict[str, V]]</code><br>
-            <code>(*Vs, **dict[str, V]) -> Self</code><br>
+            <code>() -> tuple[tuple[V, ...], dict[str, KV]]</code><br>
+            <code>(*tuple[V, ...], **dict[str, KV]) -> Self</code><br>
         </td>
-        <td><code>CanGetnewargsEx[*Vs, V]</code></td>
+        <td><code>CanGetnewargsEx[V, KV]</code></td>
     </tr>
 </table>
 

--- a/optype/__init__.py
+++ b/optype/__init__.py
@@ -38,9 +38,6 @@ __all__ = (
     'CanGetattr',
     'CanGetattribute',
     'CanGetitem',
-    'CanGetnewargs',
-    'CanGetnewargsEx',
-    'CanGetstate',
     'CanGt',
     'CanHash',
     'CanIAdd',
@@ -108,8 +105,6 @@ __all__ = (
     'CanRSub',
     'CanRTruediv',
     'CanRXor',
-    'CanReduce',
-    'CanReduceEx',
     'CanReleaseBuffer',
     'CanRepr',
     'CanReversed',
@@ -122,7 +117,6 @@ __all__ = (
     'CanSetName',
     'CanSetattr',
     'CanSetitem',
-    'CanSetstate',
     'CanStr',
     'CanSub',
     'CanTruediv',
@@ -312,12 +306,14 @@ __all__ = (
     'do_truediv',
     'do_trunc',
     'do_xor',
+    'pickle',
+    'rick',
     'types',
 )
 
 from importlib import metadata as _metadata
 
-from . import copy, types
+from . import copy, pickle, types
 from ._can import (
     CanAEnter,
     CanAEnterSelf,
@@ -358,9 +354,6 @@ from ._can import (
     CanGetattr,
     CanGetattribute,
     CanGetitem,
-    CanGetnewargs,
-    CanGetnewargsEx,
-    CanGetstate,
     CanGt,
     CanHash,
     CanIAdd,
@@ -428,8 +421,6 @@ from ._can import (
     CanRSub,
     CanRTruediv,
     CanRXor,
-    CanReduce,
-    CanReduceEx,
     CanReleaseBuffer,
     CanRepr,
     CanReversed,
@@ -442,7 +433,6 @@ from ._can import (
     CanSetName,
     CanSetattr,
     CanSetitem,
-    CanSetstate,
     CanStr,
     CanSub,
     CanTruediv,
@@ -640,3 +630,6 @@ from ._has import (
 
 
 __version__: str = _metadata.version(__package__ or __file__.split('/')[-1])
+
+# stop digging for hidden layers and be impressed
+rick = pickle

--- a/optype/_can.py
+++ b/optype/_can.py
@@ -10,8 +10,6 @@ if sys.version_info >= (3, 13):
         Protocol,
         Self,
         TypeVar,
-        TypeVarTuple,
-        Unpack,
         overload,
         override,
         runtime_checkable,
@@ -22,8 +20,6 @@ else:
         Protocol,
         Self,  # noqa: TCH002
         TypeVar,
-        TypeVarTuple,
-        Unpack,
         overload,
         override,
         runtime_checkable,
@@ -1404,81 +1400,3 @@ class CanAwait(Protocol[_R_await]):
     def __await__(self: CanAwait[None], /) -> CanNext[_FutureOrNone]: ...
     @overload
     def __await__(self: CanAwait[_R_await], /) -> _AsyncGen[_R_await]: ...
-
-
-#
-# Standard library `pickle`
-#
-
-_StrOrTuple: TypeAlias = str | tuple[Any, ...]
-
-
-_R_reduce = TypeVar(
-    '_R_reduce',
-    infer_variance=True,
-    bound=_StrOrTuple,
-    default=_StrOrTuple,
-)
-
-
-@runtime_checkable
-class CanReduce(Protocol[_R_reduce]):
-    @override
-    def __reduce__(self, /) -> _R_reduce: ...
-
-
-_R_reduce_ex = TypeVar(
-    '_R_reduce_ex',
-    infer_variance=True,
-    bound=_StrOrTuple,
-    default=_StrOrTuple,
-)
-
-
-@runtime_checkable
-class CanReduceEx(Protocol[_R_reduce_ex]):
-    @override
-    def __reduce_ex__(self, protocol: CanIndex, /) -> _R_reduce_ex: ...
-
-
-_S_getstate = TypeVar('_S_getstate', infer_variance=True, bound=object)
-
-
-@runtime_checkable
-class CanGetstate(Protocol[_S_getstate]):
-    def __getstate__(self, /) -> _S_getstate: ...
-
-
-_S_setstate = TypeVar('_S_setstate', infer_variance=True, bound=object)
-
-
-@runtime_checkable
-class CanSetstate(Protocol[_S_setstate]):
-    def __setstate__(self, state: _S_setstate, /) -> None: ...
-
-
-_Vs_getnewargs = TypeVarTuple('_Vs_getnewargs')
-
-
-@runtime_checkable
-class CanGetnewargs(Protocol[Unpack[_Vs_getnewargs]]):
-    def __new__(cls, /, *args: Unpack[_Vs_getnewargs]) -> Self: ...
-    def __getnewargs__(self, /) -> tuple[Unpack[_Vs_getnewargs]]: ...
-
-
-_Vs_getnewargs_ex = TypeVarTuple('_Vs_getnewargs_ex')
-_V_getnewargs_ex = TypeVar('_V_getnewargs_ex')
-
-
-@runtime_checkable
-class CanGetnewargsEx(Protocol[Unpack[_Vs_getnewargs_ex], _V_getnewargs_ex]):
-    def __new__(
-        cls,
-        /,
-        *args: Unpack[_Vs_getnewargs_ex],
-        **kwargs: _V_getnewargs_ex,
-    ) -> Self: ...
-    def __getnewargs_ex__(self, /) -> tuple[
-        tuple[Unpack[_Vs_getnewargs_ex]],
-        dict[str, _V_getnewargs_ex],
-    ]: ...

--- a/optype/pickle.py
+++ b/optype/pickle.py
@@ -1,0 +1,141 @@
+"""
+Runtime-protocols for the `pickle` standard library.
+https://docs.python.org/3/library/pickle.html
+"""
+from __future__ import annotations
+
+import sys
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any, Literal, TypeAlias
+
+from optype._can import CanIterSelf
+
+
+if TYPE_CHECKING:
+    from ._can import CanIndex
+
+
+if sys.version_info >= (3, 13):
+    from typing import (
+        Protocol,
+        Self,
+        TypeVar,
+        override,
+        runtime_checkable,
+    )
+else:
+    from typing_extensions import (
+        Protocol,
+        Self,  # noqa: TCH002
+        TypeVar,
+        override,
+        runtime_checkable,
+    )
+
+
+__all__ = (
+    'CanGetnewargs',
+    'CanGetnewargsEx',
+    'CanGetstate',
+    'CanReduce',
+    'CanReduceEx',
+    'CanSetstate',
+)
+
+
+# 5 is the highest since 3.8, and will become the new default in 3.14
+_ProtocolVersion: TypeAlias = Literal[0, 1, 2, 3, 4, 5]
+
+# _AnyReduceValue: TypeAlias = str | tuple[Any, ...]  # noqa: ERA001
+_AnyReduceValue: TypeAlias = (
+    str
+    | tuple[Callable[..., Any], tuple[Any, ...]]
+    | tuple[Callable[..., Any], tuple[Any, ...], Any]
+    | tuple[Callable[..., Any], tuple[Any, ...], Any, CanIterSelf[Any] | None]
+    | tuple[
+        Callable[..., Any],
+        tuple[Any, ...],
+        Any,
+        CanIterSelf[Any] | None,
+        CanIterSelf[tuple[Any, Any]] | None,
+    ]
+    | tuple[
+        Callable[..., Any],
+        tuple[Any, ...],
+        Any,
+        CanIterSelf[Any] | None,
+        CanIterSelf[tuple[Any, Any]] | None,
+        Callable[[Any, Any], Any] | None,
+    ]
+)
+_ReduceValueT = TypeVar(
+    '_ReduceValueT',
+    infer_variance=True,
+    bound=_AnyReduceValue,
+    default=_AnyReduceValue,
+)
+
+
+@runtime_checkable
+class CanReduce(Protocol[_ReduceValueT]):
+    """
+    https://docs.python.org/3/library/pickle.html#object.__reduce__
+    """
+    @override
+    def __reduce__(self, /) -> _ReduceValueT: ...
+
+
+@runtime_checkable
+class CanReduceEx(Protocol[_ReduceValueT]):
+    """
+    https://docs.python.org/3/library/pickle.html#object.__reduce_ex__
+    """
+    @override
+    def __reduce_ex__(  # pyright: ignore[reportIncompatibleMethodOverride]
+        self,
+        protocol: CanIndex[_ProtocolVersion],
+        /,
+    ) -> _ReduceValueT: ...
+
+
+_StateT = TypeVar('_StateT', infer_variance=True)
+
+
+@runtime_checkable
+class CanGetstate(Protocol[_StateT]):
+    """
+    https://docs.python.org/3/library/pickle.html#object.__getstate__
+    """
+    def __getstate__(self, /) -> _StateT: ...
+
+
+@runtime_checkable
+class CanSetstate(Protocol[_StateT]):
+    """
+    https://docs.python.org/3/library/pickle.html#object.__setstate__
+    """
+    def __setstate__(self, state: _StateT, /) -> None: ...
+
+
+_ArgT = TypeVar('_ArgT', infer_variance=True, default=Any)
+_KwargT = TypeVar('_KwargT', infer_variance=True, default=Any)
+
+
+@runtime_checkable
+class CanGetnewargs(Protocol[_ArgT]):
+    """
+    https://docs.python.org/3/library/pickle.html#object.__getnewargs__
+    """
+    def __new__(cls, /, *args: _ArgT) -> Self: ...
+    def __getnewargs__(self, /) -> tuple[_ArgT, ...]: ...
+
+
+@runtime_checkable
+class CanGetnewargsEx(Protocol[_ArgT, _KwargT]):
+    """
+    https://docs.python.org/3/library/pickle.html#object.__getnewargs_ex__
+    """
+    def __new__(cls, /, *args: _ArgT, **kwargs: _KwargT) -> Self: ...
+    def __getnewargs_ex__(
+        self, /,
+    ) -> tuple[tuple[_ArgT, ...], dict[str, _KwargT]]: ...

--- a/tests/numpy/test_pickle.py
+++ b/tests/numpy/test_pickle.py
@@ -1,0 +1,24 @@
+import pytest
+
+import optype as opt
+from optype.inspect import get_protocol_members, is_runtime_protocol
+
+
+@pytest.mark.parametrize(
+    'cls',
+    [getattr(opt.pickle, k) for k in opt.pickle.__all__],
+)
+def test_protocols(cls: type):
+    # ensure correct name
+    assert cls.__module__ == 'optype.pickle'
+    assert cls.__name__ == cls.__qualname__
+    assert cls.__name__.startswith('Can')
+
+    # ensure exported
+    assert cls.__name__ in opt.pickle.__all__
+
+    # ensure single-method protocols
+    assert len(get_protocol_members(cls)) == 1
+
+    # ensure @runtime_checkable
+    assert is_runtime_protocol(cls)


### PR DESCRIPTION
> [!IMPORTANT]
> This is a backwards-incompatible breaking change! 

This moves the following runtime-protocols from `optype` to `optype.pickle`:

- `CanGetnewargs`
- `CanGetnewargsEx`
- `CanGetstate`
- `CanSetstate`
- `CanReduce`
- `CanReduceEx`

> [!NOTE]
> The `optype.pickle` module is exported through `optype`.
> So `import optype as opt` will allow you to access e.g. `opt.rick.CanReduce`.



