### PR TITLE
Move `optype.HasDataclassFields` to  the new `optype.dataclasses` namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,7 @@ The reference docs are structured as follows:
     - [Descriptors](#descriptors)
     - [Buffer types](#buffer-types)
 - [`optype.copy`](#optypecopy)
+- [`optype.dataclasses`](#optypedataclasses)
 - [`optype.pickle`](#optypepickle)
 - [`optype.types`](#optypetypes)
     - [`Slice`](#slice)
@@ -238,8 +239,6 @@ The reference docs are structured as follows:
     - [`AnyInt` / `AnyFloat` / `AnyComplex`](#anyint--anyfloat--anycomplex)
     - [`LiteralBool`](#literalbool)
     - [`LiteralByte`](#literalbyte)
-- [Standard libs](#standard-libs)
-    - [`dataclasses`](#dataclasses)
 - [NumPy](#numpy)
     - [Arrays](#arrays)
         - [`Array`](#array)
@@ -1589,6 +1588,15 @@ type CanReplaceSelf[V] = CanReplace[V, CanReplaceSelf[V]]
 
 [CP]: https://docs.python.org/3/library/copy.html
 
+### `optype.dataclasses`
+
+For the [`dataclasses`][DC] standard library, `optype.dataclasses` provides the
+`HasDataclassFields[V: Mapping[str, Field]]` interface.
+It can conveniently be used to check whether a type or instance is a
+dataclass, i.e. `isinstance(obj, HasDataclassFields)`.
+
+[DC]: https://docs.python.org/3/library/dataclasses.html
+
 ### `optype.pickle`
 
 For the [`pickle`][PK] standard library, `optype.pickle` provides the following
@@ -1689,17 +1697,6 @@ The analogue of `typing.LiteralString`, but for `int` values that make up
 a `bytes` or `bytearray` instance, i.e. `x: int` s.t. `0 <= x < 256`.
 `LiteralByte` is defined as the `typing.Literal` of the the integers in
 `range(256)`.
-
-### Standard libs
-
-#### `dataclasses`
-
-For the [`dataclasses`][DC] standard library, `optype` provides the
-`HasDataclassFields[V: Mapping[str, Field]]` interface.
-It can conveniently be used to check whether a type or instance is a
-dataclass, i.e. `isinstance(obj, optype.HasDataclassFields)`.
-
-[DC]: https://docs.python.org/3/library/dataclasses.html
 
 ### NumPy
 

--- a/optype/__init__.py
+++ b/optype/__init__.py
@@ -209,7 +209,6 @@ __all__ = (
     'HasAnnotations',
     'HasClass',
     'HasCode',
-    'HasDataclassFields',
     'HasDict',
     'HasDoc',
     'HasFunc',
@@ -224,6 +223,7 @@ __all__ = (
     'HasWrapped',
     '__version__',
     'copy',
+    'dataclasses',
     'do_abs',
     'do_add',
     'do_aiter',
@@ -313,7 +313,7 @@ __all__ = (
 
 from importlib import metadata as _metadata
 
-from . import copy, pickle, types
+from . import copy, dataclasses, pickle, types
 from ._can import (
     CanAEnter,
     CanAEnterSelf,
@@ -613,7 +613,6 @@ from ._has import (
     HasAnnotations,
     HasClass,
     HasCode,
-    HasDataclassFields,
     HasDict,
     HasDoc,
     HasFunc,

--- a/optype/_has.py
+++ b/optype/_has.py
@@ -34,7 +34,6 @@ import optype._can as _c
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Mapping
-    from dataclasses import Field as _Field
     from types import CodeType, ModuleType
 
 
@@ -232,20 +231,3 @@ class HasSelf(Protocol[_V_self]):
 @runtime_checkable
 class HasCode(Protocol):
     __code__: CodeType
-
-
-# Module `dataclasses`
-# https://docs.python.org/3/library/dataclasses.html
-
-_V_dataclass_fields = TypeVar(
-    '_V_dataclass_fields',
-    infer_variance=True,
-    bound='Mapping[str, _Field[Any]]',
-    default=dict[str, '_Field[Any]'],
-)
-
-
-@runtime_checkable
-class HasDataclassFields(Protocol[_V_dataclass_fields]):
-    """Can be used to check whether a type or instance is a dataclass."""
-    __dataclass_fields__: _V_dataclass_fields

--- a/optype/dataclasses.py
+++ b/optype/dataclasses.py
@@ -1,0 +1,44 @@
+"""
+Runtime-protocols for the `dataclasses` standard library.
+https://docs.python.org/3/library/dataclasses.html
+"""
+from __future__ import annotations
+
+import sys
+from typing import TYPE_CHECKING, Any
+
+
+if TYPE_CHECKING:
+    import dataclasses
+    from collections.abc import Mapping
+
+
+if sys.version_info >= (3, 13):
+    from typing import (
+        Protocol,
+        TypeVar,
+        runtime_checkable,
+    )
+else:
+    from typing_extensions import (
+        Protocol,
+        TypeVar,
+        runtime_checkable,
+    )
+
+
+__all__ = ('HasDataclassFields',)
+
+
+_FieldsT = TypeVar(
+    '_FieldsT',
+    infer_variance=True,
+    bound='Mapping[str, dataclasses.Field[Any]]',
+    default=dict[str, 'dataclasses.Field[Any]'],
+)
+
+
+@runtime_checkable
+class HasDataclassFields(Protocol[_FieldsT]):
+    """Can be used to check whether a type or instance is a dataclass."""
+    __dataclass_fields__: _FieldsT


### PR DESCRIPTION
> [!IMPORTANT]
> This is a backwards-incompatible breaking change! 

This moves the following runtime-protocols from `optype` to `optype.dataclasses`:

- `HasDataclassFields`

> [!NOTE]
> The `optype.dataclasses` module is exported through `optype`.
> So `import optype as opt` will allow you to access e.g. `opt.dataclasses.HasDataclassFields`.
