### PR TITLE
`optype.inspect` A collection of functions for typing inspection at runtime

### DIFF
--- a/optype/__init__.py
+++ b/optype/__init__.py
@@ -310,12 +310,13 @@ __all__ = (
     'pickle',
     'rick',
     'string',
+    'types',
     'typing',
 )
 
 from importlib import metadata as _metadata
 
-from . import copy, dataclasses, inspect, pickle, string, typing
+from . import copy, dataclasses, inspect, pickle, string, types, typing
 from ._can import (
     CanAEnter,
     CanAEnterSelf,

--- a/optype/_types_impl.py
+++ b/optype/_types_impl.py
@@ -1,0 +1,7 @@
+import typing as tp
+
+
+__all__ = ('LiteralType',)
+
+
+LiteralType = type(tp.Literal[None])

--- a/optype/_types_impl.py
+++ b/optype/_types_impl.py
@@ -1,7 +1,23 @@
-import typing as tp
+from typing import Annotated, Generic, Literal, TypeVar
 
 
-__all__ = ('LiteralType',)
+__all__ = 'AnnotatedAlias', 'GenericType', 'LiteralAlias', 'UnionAlias'
 
 
-LiteralType = type(tp.Literal[None])
+_T = TypeVar('_T')
+class _C(Generic[_T]):  ...  # noqa: E302
+
+
+# typing._GenericAlias
+# NOTE: this is not the same as`types.GenericAlias`!
+GenericType = type(_C[None])
+
+# typing._AnnotatedAlias
+AnnotatedAlias = type(Annotated[None, None])
+
+# typing._LiteralGenericAlias
+LiteralAlias = type(Literal[None])
+
+# typing._UnionGenericAlias
+# NOTE: this is not the same as `types.UnionType`!
+UnionAlias = type(Literal[None] | None)

--- a/optype/_types_impl.pyi
+++ b/optype/_types_impl.pyi
@@ -1,5 +1,76 @@
+import sys
 import types as _types
+from collections.abc import Iterator
+from typing import (
+    Any,
+    Generic,
+    Literal,
+    ParamSpec,
+    TypeAlias,
+    _SpecialForm,  # pyright: ignore[reportPrivateUsage]
+    final,
+    type_check_only,
+)
 
-__all__ = ('LiteralType',)
+from typing_extensions import Self, TypeVar, TypeVarTuple, override
 
-LiteralType: _types.GenericAlias
+__all__ = 'AnnotatedAlias', 'GenericType', 'LiteralAlias', 'UnionAlias'
+
+_TypeOrigin: TypeAlias = (
+    type | _types.GenericAlias | GenericType
+)
+_TypeParam: TypeAlias = TypeVar | TypeVarTuple | ParamSpec
+
+# represents `typing._GenericAlias`
+# NOTE: This is different from `typing.GenericAlias`!
+class GenericType:
+    @property
+    def __origin__(self) -> _TypeOrigin: ...
+    @property
+    def __args__(self) -> tuple[Any, ...]: ...
+    @property
+    def __parameters__(self) -> tuple[_TypeParam, ...]: ...
+
+    def __init__(self, origin: _TypeOrigin, args: Any) -> None: ...
+    def __or__(self, rhs: Any, /) -> UnionAlias: ...
+    def __ror__(self, lhs: Any, /) -> UnionAlias: ...
+    def __getitem__(self, args: Any, /) -> GenericType: ...
+    def copy_with(self, params: Any, /) -> GenericType: ...
+
+    if sys.version_info >= (3, 11):
+        def __iter__(self, /) -> Iterator[UnpackAlias[Self]]: ...
+
+    def __call__(self, *args: Any, **kwargs: Any) -> _SpecialForm | object: ...
+    def __mro_entries__(self, bases: tuple[type, ...]) -> tuple[type, ...]: ...
+    def __instancecheck__(self, obj: object, /) -> bool: ...
+
+@final
+class AnnotatedAlias(GenericType): ...
+@final
+class LiteralAlias(GenericType): ...
+@final
+class UnionAlias(GenericType): ...
+
+_Ts_co = TypeVar(
+    '_Ts_co', covariant=True, bound=tuple[Any, ...] | TypeVarTuple,
+)
+
+@type_check_only
+class UnpackAlias(GenericType, Generic[_Ts_co]):
+    @property
+    def __typing_unpacked_tuple_args__(self) -> tuple[Any, ...] | None: ...
+    @property
+    def __typing_is_unpacked_typevartuple__(self) -> Literal[False, True]: ...
+
+    @property
+    @override
+    def __origin__(self) -> type[_SpecialForm]: ...
+    @property
+    @override
+    def __args__(self) -> tuple[_Ts_co]: ...
+    @property
+    @override
+    def __parameters__(self) -> tuple[()] | tuple[TypeVarTuple]: ...
+
+    @override
+    def __init__(self, origin: _SpecialForm, args: tuple[_Ts_co]) -> None: ...

--- a/optype/_types_impl.pyi
+++ b/optype/_types_impl.pyi
@@ -1,0 +1,5 @@
+import types as _types
+
+__all__ = ('LiteralType',)
+
+LiteralType: _types.GenericAlias

--- a/optype/inspect.py
+++ b/optype/inspect.py
@@ -167,22 +167,6 @@ def is_final(
     return False
 
 
-def is_runtime_protocol(cls: type, /) -> bool:
-    """
-    Check if `cls` is a `typing[_extensions].Protocol` that's decorated with
-    `typing[_extensions].runtime_checkable`.
-    """
-    return is_protocol(cls) and getattr(cls, '_is_runtime_protocol', False)
-
-
-def is_union_type(tp: Any, /) -> TypeIs[UnionType | UnionAlias]:
-    return isinstance(tp, UnionType | UnionAlias)
-
-
-def is_generic_alias(tp: Any, /) -> TypeIs[GenericType | GenericAlias]:
-    return isinstance(tp, GenericType | GenericAlias)
-
-
 def _get_alias(tp: Any, /) -> Any:
     seen: set[TypeAliasType] = set()
     for _ in range(sys.getrecursionlimit()):
@@ -199,6 +183,34 @@ def _get_alias(tp: Any, /) -> Any:
         return tp
 
     raise RecursionError
+
+
+def is_runtime_protocol(type_expr: Any, /) -> bool:
+    """
+    Check if `type_expr` is a `typing[_extensions].Protocol` that's decorated
+    with `typing[_extensions].runtime_checkable`.
+    """
+    if isinstance(type_expr, AnnotatedAlias | TypeAliasType):
+        type_expr = _get_alias(type_expr)
+    return (
+        getattr(type_expr, '_is_runtime_protocol', False)
+        and is_protocol(type_expr)
+    )
+
+
+def is_union_type(type_expr: Any, /) -> TypeIs[UnionType | UnionAlias]:
+    if isinstance(type_expr, AnnotatedAlias | TypeAliasType):
+        type_expr = _get_alias(type_expr)
+    return isinstance(type_expr, UnionType | UnionAlias)
+
+
+def is_generic_alias(type_expr: Any, /) -> TypeIs[GenericType | GenericAlias]:
+    if isinstance(type_expr, AnnotatedAlias | TypeAliasType):
+        type_expr = _get_alias(type_expr)
+    return (
+        isinstance(type_expr, GenericType | GenericAlias)
+        and not isinstance(type_expr, UnionType | UnionAlias)
+    )
 
 
 def get_args(tp: Any, /) -> tuple[Any, ...]:

--- a/optype/types.py
+++ b/optype/types.py
@@ -1,0 +1,26 @@
+# noqa: A005
+from __future__ import annotations
+
+import sys
+from typing import ClassVar, Literal
+
+
+if sys.version_info >= (3, 13):
+    from typing import Protocol, runtime_checkable
+else:
+    from typing_extensions import Protocol, runtime_checkable
+
+
+__all__ = ('FinalType',)
+
+
+@runtime_checkable
+class FinalType(Protocol):
+    """
+    A runtime-protocol that represents a type or method that's decorated with
+    `@typing.final` or `@typing_extensions.final`.
+
+    Note that the name `HasFinal` isn't used, because `__final__` is
+    undocumented, and therefore not a part of the public API.
+    """
+    __final__: ClassVar[Literal[True]]

--- a/optype/types.py
+++ b/optype/types.py
@@ -14,13 +14,16 @@ else:
         runtime_checkable,
     )
 
-from ._types_impl import LiteralType
+from ._types_impl import AnnotatedAlias, GenericType, LiteralAlias, UnionAlias
 
 
 __all__ = (
-    'LiteralType',
+    'AnnotatedAlias',
+    'GenericType',
+    'LiteralAlias',
     'ProtocolType',
     'RuntimeProtocolType',
+    'UnionAlias',
     'WrappedFinalType',
 )
 

--- a/optype/types.py
+++ b/optype/types.py
@@ -2,20 +2,31 @@
 from __future__ import annotations
 
 import sys
-from typing import ClassVar, Literal
+from typing import Literal
 
 
 if sys.version_info >= (3, 13):
-    from typing import Protocol, runtime_checkable
+    from typing import LiteralString, Protocol, runtime_checkable
 else:
-    from typing_extensions import Protocol, runtime_checkable
+    from typing_extensions import (
+        LiteralString,  # noqa: TCH002
+        Protocol,
+        runtime_checkable,
+    )
+
+from ._types_impl import LiteralType
 
 
-__all__ = ('FinalType',)
+__all__ = (
+    'LiteralType',
+    'ProtocolType',
+    'RuntimeProtocolType',
+    'WrappedFinalType',
+)
 
 
 @runtime_checkable
-class FinalType(Protocol):
+class WrappedFinalType(Protocol):
     """
     A runtime-protocol that represents a type or method that's decorated with
     `@typing.final` or `@typing_extensions.final`.
@@ -23,4 +34,20 @@ class FinalType(Protocol):
     Note that the name `HasFinal` isn't used, because `__final__` is
     undocumented, and therefore not a part of the public API.
     """
-    __final__: ClassVar[Literal[True]]
+    __final__: Literal[True]
+
+
+@runtime_checkable
+class ProtocolType(Protocol):
+    _is_protocol: Literal[True]
+
+    if sys.version_info >= (3, 12, 0):
+        __protocol_attrs__: set[LiteralString]
+
+
+@runtime_checkable
+class RuntimeProtocolType(ProtocolType, Protocol):
+    _is_runtime_protocol: Literal[True]
+
+    if sys.version_info >= (3, 12, 2):
+        __non_callable_proto_members__: set[LiteralString]

--- a/poetry.lock
+++ b/poetry.lock
@@ -668,5 +668,5 @@ numpy = ["numpy"]
 
 [metadata]
 lock-version = "2.0"
-python-versions = "^3.10"
-content-hash = "f5019da828e8a468c7eb769977aae62c107b73b2e86baf310a368ccb8bcd09e5"
+python-versions = "^3.10.1"
+content-hash = "d20d17e2a14553773d4f0d23c77a390c3e1302863069b5e60191eb2a259c5eeb"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,6 +96,7 @@ addopts = [
     "--doctest-modules",
     "--strict-config",
     "--strict-markers",
+    "--showlocals",
 ]
 doctest_optionflags = [
     "NORMALIZE_WHITESPACE",
@@ -143,7 +144,6 @@ select = [
     "YTT",      # flake8-2020
     "ANN",      # flake8-annotations
     "ASYNC",    # flake8-async
-    "ASYNC1",     # flake8-trio
     "BLE",      # flake8-blind-except
     "B",        # flake8-bugbear
     "A",        # flake8-builtins
@@ -151,11 +151,11 @@ select = [
     "C4",       # flake8-comprehensions
     "DTZ",      # flake8-datetimez
     "T10",      # flake8-debugger
-    "EM",       # flake8-errmsg
     "EXE",      # flake8-executable
     "FA",       # flake8-future-annotations
     "ISC",      # flake8-implicit-str-concat
     "ICN",      # flake8-import-conventions
+    "LOG",      # flake8-logging
     "G",        # flake8-logging-format
     "INP",      # flake8-no-pep420
     "PIE",      # flake8-pie
@@ -178,11 +178,11 @@ select = [
     "PL",       # pylint
     "TRY",      # tryceratops
     "FLY",      # flynt
-    "NPY",      # numpy
+    "NPY",      # NumPy
+    "FAST",     # FastAPI
     "AIR",      # airflow
     "PERF",     # perflint,
     "FURB",     # refurb
-    "LOG",      # flake8-logging
     "RUF",      # ruff
 ]
 ignore = [
@@ -197,6 +197,8 @@ ignore = [
     "PLR0904",  # too-many-public-methods
     # refurb
     "FURB118",  # reimplemented-operator
+    # tryceratops
+    "TRY003",   # raise-vanilla-args
 ]
 
 [tool.ruff.lint.per-file-ignores]
@@ -244,6 +246,13 @@ allow-dunder-method-names = [
     "__qualname__", # attr like `__name__`
     "__replace__",  # method used by `copy.replace` in Python 3.13+
     "__self__",     # attr of a bound method
+
+    "__value__",
+    "__origin__",
+    "__args__",
+    "__parameters__",
+    "__typing_unpacked_tuple_args__",
+    "__typing_is_unpacked_typevartuple__",
 
     # numpy array special methods
     "__array__",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,8 +30,7 @@ documentation = "https://github.com/jorenham/optype?tab=readme-ov-file#optype"
 numpy = ["numpy"]
 
 [tool.poetry.dependencies]
-# bump to ^3.11 after 2025-04-04
-# bump to ^3.12 after 2026-04-24
+# bump to `^3.11` after 2025-04-04, and to `^3.12` after 2026-04-24
 python = "^3.10.1"
 typing-extensions = {version = ">=4.7", python = "<3.13"}
 
@@ -80,14 +79,11 @@ pythonPlatform = "All"
 typeCheckingMode = "all"
 defineConstant = {"_NP_V2" = true, "byteorder" = "little"}
 
-reportAny = false
-reportUnusedCallResult = false
-# because of `sys.version_info()` conditionals
-reportUnreachable = false
-# already handled by ruff F401
-reportUnusedImport = false
-# already handled by ruff F841
-reportUnusedVariable = false
+reportAny = false  # blame typeshed
+reportUnusedCallResult = false  # https://github.com/microsoft/pyright/issues/8650
+reportUnreachable = false  # nothing wrong with `if sys.version_info() >= ...`
+reportUnusedImport = false  # dupe of F401
+reportUnusedVariable = false  # dupe of F841
 
 
 [tool.pytest.ini_options]
@@ -112,13 +108,13 @@ xfail_strict = true
 
 [tool.repo-review]
 ignore = [
-    "PY004",    # README.md >> docs/
-    "PC110",    # optype's style >> (black | ruff-format)
-    "PC140",    # (based)pyright >> mypy (by several orders of magnitude)
-    "PC170",    # no .rst
-    "PC180",    # no .css or .js
-    "MY",       # (based)pyright >> mypy (by several orders of magnitude)
-    "RTD",      # README.md >> rtd
+    "PY004",    # no `docs/` (maybe later)
+    "PC110",    # no auto-format (all formatters are bad for readability atm)
+    "PC140",    # no mypy
+    "PC170",    # no sphinx
+    "PC180",    # no css or js
+    "MY",       # no mypy
+    "RTD",      # no readthedocs
 ]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ numpy = ["numpy"]
 [tool.poetry.dependencies]
 # bump to ^3.11 after 2025-04-04
 # bump to ^3.12 after 2026-04-24
-python = "^3.10"
+python = "^3.10.1"
 typing-extensions = {version = ">=4.7", python = "<3.13"}
 
 # https://scientific-python.org/specs/spec-0000/

--- a/tests/test_inspect.py
+++ b/tests/test_inspect.py
@@ -162,7 +162,23 @@ def test_get_protocol_members():
     assert opt.inspect.get_protocol_members(CanNew) == {'__new__'}
 
 
-# TODO: test `get_protocols`
+def test_get_protocols():
+    import collections.abc  # noqa: PLC0415
+    import types  # noqa: PLC0415
+
+    assert not opt.inspect.get_protocols(collections.abc)
+    assert not opt.inspect.get_protocols(types)
+    # ... hence optype
+
+    protocols_tp = opt.inspect.get_protocols(tp)
+    assert protocols_tp
+    assert opt.inspect.get_protocols(tp, private=True) >= protocols_tp
+
+    protocols_tpx = opt.inspect.get_protocols(tpx)
+    assert protocols_tpx
+    assert opt.inspect.get_protocols(tpx, private=True) >= protocols_tpx
+
+    assert protocols_tp <= protocols_tpx
 
 
 def test_type_is_final():

--- a/tests/test_inspect.py
+++ b/tests/test_inspect.py
@@ -1,7 +1,153 @@
+# ruff: noqa: ANN205, ANN206
+from __future__ import annotations
+
+import sys
+import typing as tp
+
+
+if sys.version_info >= (3, 12):
+    from typing import TypeAliasType
+else:
+    from typing_extensions import TypeAliasType
+
+from inspect import getattr_static
+
+import typing_extensions as tpx
+
 import optype as opt
 
 
-def test_iterable():
+FalsyBool = tp.Literal[False]
+FalsyInt: tp.TypeAlias = tp.Annotated[tp.Literal[0], (int, False)]
+FalsyIntCo: tp.TypeAlias = FalsyBool | FalsyInt
+# this is equivalent to `type FalsyStr = ...` on `python>=3.12`
+FalsyStr = TypeAliasType('FalsyStr', tp.Literal['', b''])
+Falsy = TypeAliasType('Falsy', tp.Literal[None, FalsyIntCo] | FalsyStr)
+
+
+class PTyp(tp.Protocol): ...
+
+
+class PExt(tpx.Protocol): ...
+
+
+@tp.runtime_checkable
+class RuntimePTyp(tp.Protocol): ...
+
+
+@tpx.runtime_checkable
+class RuntimePExt(tpx.Protocol): ...
+
+
+@tp.final
+class FinalPTyp(tp.Protocol): ...
+
+
+@tpx.final
+class FinalPExt(tpx.Protocol): ...
+
+
+class FinalMembers:
+    @property
+    def p(self): pass
+    @property
+    @tp.final
+    def p_final_typ(self): pass
+    @tpx.final
+    def p_final_ext(self): pass
+
+    def f(self): pass
+    @tp.final
+    def f_final_typ(self): pass
+    @tpx.final
+    def f_final_ext(self): pass
+
+    @classmethod
+    def cf(cls): pass
+    @classmethod
+    @tp.final
+    def cf_final1_typ(cls): pass
+    @classmethod
+    @tpx.final
+    def cf_final1_ext(cls): pass
+    @tp.final
+    @classmethod
+    def cf_final2_typ(cls): pass
+    @tpx.final
+    @classmethod
+    def cf_final2_ext(cls): pass
+
+    @staticmethod
+    def sf(): pass
+    @staticmethod
+    @tp.final
+    def sf_final1_typ(): pass
+    @staticmethod
+    @tpx.final
+    def sf_final1_ext(): pass
+    @tp.final
+    @staticmethod
+    def sf_final2_typ(): pass
+    @tpx.final
+    @staticmethod
+    def sf_final2_ext(): pass
+
+
+def test_get_args():
+    assert opt.inspect.get_args(FalsyBool) == (False,)
+    assert opt.inspect.get_args(FalsyInt) == (0,)
+    assert opt.inspect.get_args(FalsyIntCo) == (False, 0)
+    assert opt.inspect.get_args(FalsyStr) == ('', b'')
+    assert opt.inspect.get_args(Falsy) == (None, False, 0, '', b'')
+
+
+# TODO: test `get_protocol_members`
+# TODO: test `get_protocols`
+
+
+def test_type_is_final():
+    assert not opt.inspect.is_final(opt.CanAdd)
+    assert opt.inspect.is_final(opt.DoesAdd)
+
+    assert not opt.inspect.is_final(PTyp)
+    assert not opt.inspect.is_final(PExt)
+    assert not opt.inspect.is_final(RuntimePTyp)
+    assert opt.inspect.is_final(FinalPTyp)
+    assert opt.inspect.is_final(FinalPExt)
+
+
+def test_property_is_final():
+    assert not opt.inspect.is_final(FinalMembers.p)
+    assert opt.inspect.is_final(FinalMembers.p_final_typ)
+    assert opt.inspect.is_final(FinalMembers.p_final_ext)
+
+
+def test_method_is_final():
+    assert not opt.inspect.is_final(FinalMembers.f)
+    assert opt.inspect.is_final(FinalMembers.f_final_typ)
+    assert opt.inspect.is_final(FinalMembers.f_final_ext)
+
+
+def test_classmethod_is_final():
+    assert not opt.inspect.is_final(FinalMembers.cf)
+    assert opt.inspect.is_final(getattr_static(FinalMembers, 'cf_final1_typ'))
+    assert opt.inspect.is_final(getattr_static(FinalMembers, 'cf_final1_ext'))
+    assert opt.inspect.is_final(getattr_static(FinalMembers, 'cf_final2_typ'))
+    assert opt.inspect.is_final(getattr_static(FinalMembers, 'cf_final2_ext'))
+
+
+def test_staticmethod_is_final():
+    assert not opt.inspect.is_final(FinalMembers.sf)
+    assert opt.inspect.is_final(getattr_static(FinalMembers, 'sf_final1_typ'))
+    assert opt.inspect.is_final(getattr_static(FinalMembers, 'sf_final1_ext'))
+    assert opt.inspect.is_final(getattr_static(FinalMembers, 'sf_final2_typ'))
+    assert opt.inspect.is_final(getattr_static(FinalMembers, 'sf_final2_ext'))
+
+
+# TODO: test `is_generic_alias`
+
+
+def test_is_iterable():
     assert opt.inspect.is_iterable([])
     assert opt.inspect.is_iterable(())
     assert opt.inspect.is_iterable('')
@@ -10,7 +156,16 @@ def test_iterable():
     assert opt.inspect.is_iterable(i for i in range(2))
 
 
-# TODO: tests for is_runtime_protocol
-# TODO: tests for get_args
-# TODO: tests for get_protocol_members
-# TODO: tests for get_protocols
+def test_is_runtime_protocol():
+    assert opt.inspect.is_runtime_protocol(opt.CanAdd)
+    assert not opt.inspect.is_runtime_protocol(opt.DoesAdd)
+
+    assert not opt.inspect.is_runtime_protocol(PTyp)
+    assert not opt.inspect.is_runtime_protocol(PExt)
+    assert opt.inspect.is_runtime_protocol(RuntimePTyp)
+    assert opt.inspect.is_runtime_protocol(RuntimePExt)
+    assert not opt.inspect.is_runtime_protocol(FinalPTyp)
+    assert not opt.inspect.is_runtime_protocol(FinalPTyp)
+
+
+# TODO: test `is_union_type`

--- a/tests/test_inspect.py
+++ b/tests/test_inspect.py
@@ -49,6 +49,13 @@ class CanNew(tpx.Protocol[_Pss, _T_co]):
     def __new__(cls, *args: _Pss.args, **kwargs: _Pss.kwargs) -> _T_co: ...
 
 
+class ProtoOverload(tpx.Protocol):
+    @tpx.overload
+    def method(self) -> int: ...
+    @tpx.overload
+    def method(self, x: tp.Any, /) -> str: ...
+
+
 class Proto(tp.Protocol): ...
 
 
@@ -162,6 +169,8 @@ def test_get_protocol_members():
 
     assert opt.inspect.get_protocol_members(CanInit) == {'__init__'}
     assert opt.inspect.get_protocol_members(CanNew) == {'__new__'}
+
+    assert opt.inspect.get_protocol_members(ProtoOverload) == {'method'}
 
 
 def test_get_protocols():

--- a/tests/test_inspect.py
+++ b/tests/test_inspect.py
@@ -253,4 +253,13 @@ def test_is_runtime_protocol():
     assert not opt.inspect.is_runtime_protocol(FinalPTyp)
 
 
-# TODO: test `is_union_type`
+@pytest.mark.parametrize('origin', [int, tp.Literal[True], PTyp, PExt])
+def test_is_union_type(origin: tp.Any):
+    assert opt.inspect.is_union_type(origin | None)
+    Alias = TypeAliasType('Alias', origin | None)  # noqa: N806
+    assert opt.inspect.is_union_type(Alias)
+    assert opt.inspect.is_union_type(tp.Annotated[origin | None, None])
+    assert opt.inspect.is_union_type(tp.Annotated[origin, None] | None)
+
+    assert not opt.inspect.is_union_type(origin)
+    assert not opt.inspect.is_union_type(origin | origin)

--- a/tests/test_inspect.py
+++ b/tests/test_inspect.py
@@ -123,7 +123,7 @@ def test_get_args_literals():
     assert opt.inspect.get_args(Falsy) == (None, False, 0, '', b'')
 
 
-@pytest.mark.parametrize('origin', [tuple, GenericTP, GenericTPX])
+@pytest.mark.parametrize('origin', [type, list, tuple, GenericTP, GenericTPX])
 def test_get_args_generic(origin: tp.Any):
     assert opt.inspect.get_args(origin[FalsyBool]) == (FalsyBool,)
     assert opt.inspect.get_args(origin[FalsyInt]) == (FalsyInt,)
@@ -220,7 +220,16 @@ def test_staticmethod_is_final():
     assert opt.inspect.is_final(getattr_static(FinalMembers, 'sf_final2_ext'))
 
 
-# TODO: test `is_generic_alias`
+@pytest.mark.parametrize('origin', [type, list, tuple, GenericTP, GenericTPX])
+def test_is_generic_alias(origin: tp.Any):
+    assert not opt.inspect.is_generic_alias(origin)
+
+    assert opt.inspect.is_generic_alias(origin[None])
+    Alias = TypeAliasType('Alias', origin[None])  # noqa: N806
+    assert opt.inspect.is_generic_alias(Alias)
+    assert opt.inspect.is_generic_alias(tp.Annotated[origin[None], None])
+
+    assert not opt.inspect.is_generic_alias(origin[None] | None)
 
 
 def test_is_iterable():

--- a/tests/test_pickle.py
+++ b/tests/test_pickle.py
@@ -18,7 +18,7 @@ def test_protocols(cls: type):
     assert cls.__name__ in opt.pickle.__all__
 
     # ensure single-method protocols
-    assert len(get_protocol_members(cls)) == 1
+    assert len(get_protocol_members(cls) - {'__new__'}) == 1
 
     # ensure @runtime_checkable
     assert is_runtime_protocol(cls)


### PR DESCRIPTION
This module exists since optype 0.5, but *was* undocumented, untested, and (therefore) buggy.
Several new functions were also added.