### PR TITLE
Complete mypy support, with `strict=true`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: markdownlint
+        uses: DavidAnson/markdownlint-cli2-action@v16
+        with:
+          config: ".markdownlint.yaml"
+          globs: "**/*.md"
+
       - name: install poetry
         run: pipx install poetry
 
@@ -42,13 +48,9 @@ jobs:
 
       - name: basedpyright --verifytypes
         run: poetry run basedpyright --ignoreexternal --verifytypes optype
-        # continue-on-error: true
 
-      - name: markdownlint
-        uses: DavidAnson/markdownlint-cli2-action@v16
-        with:
-          config: ".markdownlint.yaml"
-          globs: "**/*.md"
+      - name: mypy
+        run: poetry run mypy .
 
       - uses: scientific-python/repo-review@v0.11.0
         with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -69,8 +69,7 @@ repos:
         name: basedpyright
         entry: poetry run basedpyright
         language: system
-        types: [file]
-        files: '\.py(i?)$'
+        types_or: [python, pyi]
 
       - id: basedpyright-verifytypes
         name: basedpyright --verifytypes
@@ -78,3 +77,9 @@ repos:
         language: system
         always_run: true
         pass_filenames: false
+
+      - id: mypy
+        name: mypy
+        entry: poetry run mypy
+        language: system
+        types_or: [python, pyi]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -69,8 +69,8 @@ repos:
         name: basedpyright
         entry: poetry run basedpyright
         language: system
-        # always_run: true
-        # pass_filenames: false
+        types: [file]
+        files: '\.py(i?)$'
 
       - id: basedpyright-verifytypes
         name: basedpyright --verifytypes

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,6 +9,7 @@ ci:
     - ruff
     - basedpyright
     - basedpyright-verifytypes
+    - mypy
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/README.md
+++ b/README.md
@@ -2297,7 +2297,7 @@ The shape aliases are roughly defined as:
 
 ```python
 type AtLeast0D[
-    *N: int = ...,
+    Ds: int = int,
 ]
 ```
 
@@ -2305,7 +2305,7 @@ type AtLeast0D[
 <td>
 
 ```python
-tuple[*N]
+tuple[Ds, ...]
 ```
 
 </td>
@@ -2330,8 +2330,8 @@ tuple[()]
 
 ```python
 type AtLeast1D[
-    N0: int = int,
-    *N: int = ...,
+    D0: int = int,
+    Ds: int = int,
 ]
 ```
 
@@ -2339,7 +2339,10 @@ type AtLeast1D[
 <td>
 
 ```python
-tuple[N0, *N]
+tuple[
+    D0,
+    *tuple[Ds, ...],
+]
 ```
 
 </td>
@@ -2347,7 +2350,7 @@ tuple[N0, *N]
 
 ```python
 type AtMost1D[
-    N0: int = int,
+    D0: int = int,
 ]
 ```
 
@@ -2355,7 +2358,7 @@ type AtMost1D[
 <td>
 
 ```python
-tuple[N0] | AtMost0D
+tuple[D0] | AtMost0D
 ```
 
 </td>
@@ -2366,9 +2369,9 @@ tuple[N0] | AtMost0D
 
 ```python
 type AtLeast2D[
-    N0: int = int,
-    N1: int = int,
-    *N: int = ...,
+    D0: int = int,
+    D1: int = int,
+    Ds: int = int,
 ]
 ```
 
@@ -2376,7 +2379,11 @@ type AtLeast2D[
 <td>
 
 ```python
-tuple[N0, N1, *N]
+tuple[
+    D0,
+    D1,
+    *tuple[Ds, ...],
+]
 ```
 
 </td>
@@ -2384,8 +2391,8 @@ tuple[N0, N1, *N]
 
 ```python
 type AtMost2D[
-    N0: int = int,
-    N1: int = int,
+    D0: int = int,
+    D1: int = int,
 ]
 ```
 
@@ -2394,8 +2401,8 @@ type AtMost2D[
 
 ```python
 (
-    tuple[N0, N1]
-    | AtMost1D[N0]
+    tuple[D0, D1]
+    | AtMost1D[D0]
 )
 ```
 
@@ -2407,10 +2414,10 @@ type AtMost2D[
 
 ```python
 type AtLeast3D[
-    N0: int = int,
-    N1: int = int,
-    N2: int = int,
-    *N: int = ...,
+    D0: int = int,
+    D1: int = int,
+    D2: int = int,
+    Ds: int = int,
 ]
 ```
 
@@ -2418,7 +2425,12 @@ type AtLeast3D[
 <td>
 
 ```python
-tuple[N0, N1, N2, *N]
+tuple[
+    D0,
+    D1,
+    D2,
+    *tuple[Ds, ...],
+]
 ```
 
 </td>
@@ -2426,9 +2438,9 @@ tuple[N0, N1, N2, *N]
 
 ```python
 type AtMost3D[
-    N0: int = int,
-    N1: int = int,
-    N2: int = int,
+    D0: int = int,
+    D1: int = int,
+    D2: int = int,
 ]
 ```
 
@@ -2437,8 +2449,8 @@ type AtMost3D[
 
 ```python
 (
-    tuple[N0, N1, N2]
-    | AtMost2D[N0, N1]
+    tuple[D0, D1, D2]
+    | AtMost2D[D0, D1]
 )
 ```
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,12 @@
     </a>
     <a href="https://detachhead.github.io/basedpyright">
         <img
+            alt="optype - mypy"
+            src="https://www.mypy-lang.org/static/mypy_badge.svg"
+        />
+    </a>
+    <a href="https://detachhead.github.io/basedpyright">
+        <img
             alt="optype - basedpyright"
             src="https://img.shields.io/badge/basedpyright-checked-42b983"
         />

--- a/examples/functor.py
+++ b/examples/functor.py
@@ -111,43 +111,7 @@ class Functor(Generic[_T_co]):
         """
         return self.map2(opt.do_le, x)
 
-    @override
-    def __eq__(  # pyright: ignore[reportIncompatibleMethodOverride]
-        self: Functor[opt.CanEq[_X, _Y]],
-        x: Functor[_X],
-        /,
-    ) -> Functor[_Y]:
-        """
-        >>> Functor(object()) == Functor(object())
-        Functor(False)
-        >>> Functor(0) == Functor(0)
-        Functor(True)
-        >>> Functor(0) == 0
-        False
-        """
-        return self.map2(opt.do_eq, x)
-
-    @override
-    def __ne__(  # pyright: ignore[reportIncompatibleMethodOverride]
-        self: Functor[opt.CanNe[_X, _Y]],
-        x: Functor[_X],
-        /,
-    ) -> Functor[_Y]:
-        """
-        >>> Functor(object()) != Functor(object())
-        Functor(True)
-        >>> Functor(0) != Functor(0)
-        Functor(False)
-        >>> Functor(0) != 0
-        True
-        """
-        return self.map2(opt.do_ne, x)
-
-    def __gt__(
-        self: Functor[opt.CanGt[_X, _Y]],
-        x: Functor[_X],
-        /,
-    ) -> Functor[_Y]:
+    def __gt__(self, x: Functor[opt.CanLt[_T_co, _Y]], /) -> Functor[_Y]:
         """
         >>> Functor({0, 1}) > Functor({0})
         Functor(True)
@@ -156,11 +120,7 @@ class Functor(Generic[_T_co]):
         """
         return self.map2(opt.do_gt, x)
 
-    def __ge__(
-        self: Functor[opt.CanGe[_X, _Y]],
-        x: Functor[_X],
-        /,
-    ) -> Functor[_Y]:
+    def __ge__(self, x: Functor[opt.CanLe[_T_co, _Y]], /) -> Functor[_Y]:
         """
         >>> Functor({0, 1}) >= Functor({0})
         Functor(True)
@@ -317,96 +277,3 @@ class Functor(Generic[_T_co]):
         Functor(7)
         """
         return self.map2(opt.do_or, x)
-
-    # binary reflected infix ops
-
-    def __radd__(
-        self: Functor[opt.CanRAdd[_X, _Y]],
-        x: Functor[_X],
-        /,
-    ) -> Functor[_Y]:
-        return self.map2(opt.do_radd, x)
-
-    def __rsub__(
-        self: Functor[opt.CanRSub[_X, _Y]],
-        x: Functor[_X],
-        /,
-    ) -> Functor[_Y]:
-        return self.map2(opt.do_rsub, x)
-
-    def __rmul__(
-        self: Functor[opt.CanRMul[_X, _Y]],
-        x: Functor[_X],
-        /,
-    ) -> Functor[_Y]:
-        return self.map2(opt.do_rmul, x)
-
-    def __rmatmul__(
-        self: Functor[opt.CanRMatmul[_X, _Y]],
-        x: Functor[_X],
-        /,
-    ) -> Functor[_Y]:
-        return self.map2(opt.do_rmatmul, x)
-
-    def __rtruediv__(
-        self: Functor[opt.CanRTruediv[_X, _Y]],
-        x: Functor[_X],
-        /,
-    ) -> Functor[_Y]:
-        return self.map2(opt.do_rtruediv, x)
-
-    def __rfloordiv__(
-        self: Functor[opt.CanRFloordiv[_X, _Y]],
-        x: Functor[_X],
-        /,
-    ) -> Functor[_Y]:
-        return self.map2(opt.do_rfloordiv, x)
-
-    def __rmod__(
-        self: Functor[opt.CanRMod[_X, _Y]],
-        x: Functor[_X],
-        /,
-    ) -> Functor[_Y]:
-        return self.map2(opt.do_rmod, x)
-
-    def __rpow__(
-        self: Functor[opt.CanRPow[_X, _Y]],
-        x: Functor[_X],
-        /,
-    ) -> Functor[_Y]:
-        return self.map2(opt.do_rpow, x)
-
-    def __rlshift__(
-        self: Functor[opt.CanRLshift[_X, _Y]],
-        x: Functor[_X],
-        /,
-    ) -> Functor[_Y]:
-        return self.map2(opt.do_rlshift, x)
-
-    def __rrshift__(
-        self: Functor[opt.CanRRshift[_X, _Y]],
-        x: Functor[_X],
-        /,
-    ) -> Functor[_Y]:
-        return self.map2(opt.do_rrshift, x)
-
-    def __rand__(
-        self: Functor[opt.CanRAnd[_X, _Y]],
-        x: Functor[_X],
-        /,
-    ) -> Functor[_Y]:
-        return self.map2(opt.do_rand, x)
-
-    def __rxor__(
-        self: Functor[opt.CanRXor[_X, _Y]],
-        x: Functor[_X],
-        /,
-    ) -> Functor[_Y]:
-        return self.map2(opt.do_rxor, x)
-
-    def __ror__(
-        self: Functor[opt.CanROr[_X, _Y]],
-        x: Functor[_X],
-        /,
-    ) -> Functor[_Y]:
-        return self.map2(opt.do_ror, x)

--- a/examples/twice.py
+++ b/examples/twice.py
@@ -1,16 +1,14 @@
 # %%
 import sys
 from typing import (
-    Generic,
     Literal,
     TypeAlias,
     TypeVar,
-    final,
 )
 if sys.version_info >= (3, 12):
-    from typing import TypeVarTuple, Unpack, assert_type
+    from typing import assert_type
 else:
-    from typing_extensions import TypeVarTuple, Unpack, assert_type
+    from typing_extensions import assert_type
 
 import optype as opt
 
@@ -27,24 +25,6 @@ assert_type(twice(True), int)
 assert_type(twice(1 / 137), float)
 assert_type(twice(str(-1 / 12)), str)
 assert_type(twice([object()]), list[object])
-
-
-# %%
-Ts = TypeVarTuple('Ts')
-
-
-@final
-class RMulArgs(Generic[Unpack[Ts]]):
-    def __init__(self, *args: Unpack[Ts]) -> None:
-        self.args = args
-
-    def __rmul__(self, y: Two, /) -> 'RMulArgs[Unpack[Ts], Unpack[Ts]]':
-        if y != 2:
-            return NotImplemented
-        return RMulArgs(*self.args, *self.args)
-
-
-assert_type(twice(RMulArgs(42, True)), RMulArgs[int, bool, int, bool])
 
 
 # %%

--- a/optype/_has.py
+++ b/optype/_has.py
@@ -135,7 +135,7 @@ _AnnotationsT_co = TypeVar(
 @set_module('optype')
 @runtime_checkable
 class HasAnnotations(Protocol[_AnnotationsT_co]):  # pyright: ignore[reportInvalidTypeVarUse]
-    __annotations__: _AnnotationsT_co  # type: ignore[override]  # pyright: ignore[reportIncompatibleVariableOverride]
+    __annotations__: _AnnotationsT_co  # pyright: ignore[reportIncompatibleVariableOverride]
 
 
 # should be one of `(TypeVar, TypeVarTuple, ParamSpec)`

--- a/optype/inspect.py
+++ b/optype/inspect.py
@@ -22,7 +22,7 @@ if sys.version_info >= (3, 13):
 else:
     from typing_extensions import TypeAliasType, is_protocol, overload
     try:
-        from typing_extensions import TypeIs  # type: ignore[attr-defined]
+        from typing_extensions import TypeIs
     except ImportError:
         # fallback for `typing_extensions<4.10`
         from typing import TypeGuard as TypeIs  # type: ignore[assignment]

--- a/optype/numpy/_scalar.py
+++ b/optype/numpy/_scalar.py
@@ -27,7 +27,7 @@ else:
     )
     # `CapsuleType` requires `typing_extensions>=4.12`
     try:
-        from typing_extensions import CapsuleType  # type: ignore[attr-defined]
+        from typing_extensions import CapsuleType
     except ImportError:
         from typing import Any as CapsuleType  # type: ignore[assignment]
 

--- a/optype/numpy/_shape.py
+++ b/optype/numpy/_shape.py
@@ -3,9 +3,9 @@ from typing import TypeAlias
 
 
 if sys.version_info >= (3, 13):
-    from typing import TypeVar, TypeVarTuple, Unpack
+    from typing import TypeVar, Unpack
 else:
-    from typing_extensions import TypeVar, TypeVarTuple, Unpack
+    from typing_extensions import TypeVar, Unpack
 
 
 __all__ = [
@@ -14,50 +14,45 @@ __all__ = [
 ]  # fmt: skip
 
 
+_N0 = TypeVar('_N0', bound=int, default=int)
+_N1 = TypeVar('_N1', bound=int, default=int)
+_N2 = TypeVar('_N2', bound=int, default=int)
+_Ns = TypeVar('_Ns', bound=int, default=int)
+
+
 # 0D (scalar)
 
-_Ns_0D = TypeVarTuple('_Ns_0D', default=Unpack[tuple[int, ...]])
-AtLeast0D: TypeAlias = tuple[Unpack[_Ns_0D]]
-"""Shapes with `ndim >= 0`, i.e. like `tuple[*(Ns=int)]`."""
+AtLeast0D: TypeAlias = tuple[_Ns, ...]
+"""Shape with `ndim >= 0`, i.e. like `(Ns: int = int, ...)`."""
 AtMost0D: TypeAlias = tuple[()]
-"""Shapes with `ndim <= 0`, i.e. *just* the empty tuple `()`."""
+"""Shape with `ndim <= 0`, i.e. *just* the empty tuple `()`."""
 
 
 # 1D (vector)
 
-_N0_1D = TypeVar('_N0_1D', bound=int, default=int)
-_Ns_1D = TypeVarTuple('_Ns_1D', default=Unpack[tuple[int, ...]])
-AtLeast1D: TypeAlias = tuple[_N0_1D, Unpack[_Ns_1D]]
-"""Shapes with `ndim >= 1`, i.e. like `tuple[N0=int, *(Ns=int)]`."""
-AtMost1D: TypeAlias = tuple[_N0_1D] | AtMost0D
-"""Shapes with `ndim <= 1`, i.e. like `(N0: int = int, *AtMost0D) `."""
+AtLeast1D: TypeAlias = tuple[_N0, Unpack[tuple[_Ns, ...]]]
+"""Shape with `ndim >= 1`, i.e. like `(N0: int = int, *AtLeast0D[Ns?])`."""
+AtMost1D: TypeAlias = tuple[_N0] | AtMost0D
+"""Shape with `ndim <= 1`, i.e. like `(N0: int = int, *AtMost0D) `."""
 
 
 # 2D (matrix)
 
-_N0_2D = TypeVar('_N0_2D', bound=int, default=int)
-_N1_2D = TypeVar('_N1_2D', bound=int, default=int)
-_Ns_2D = TypeVarTuple('_Ns_2D', default=Unpack[tuple[int, ...]])
-AtLeast2D: TypeAlias = tuple[_N0_2D, _N1_2D, Unpack[_Ns_2D]]
-"""Shapes with `ndim >= 2`, i.e. like `tuple[N0=int, N1=N0, *(Ns=int)]`."""
-AtMost2D: TypeAlias = tuple[_N0_2D, _N1_2D] | AtMost1D[_N0_2D]
+AtLeast2D: TypeAlias = tuple[_N0, _N1, Unpack[tuple[_Ns, ...]]]
 """
-Shapes with `ndim <= 2`, i.e. like `(N0: int = int, *AtMost1D[N1: int = int])`.
+Shape with `ndim >= 2`, i.e. like `(N0: int = int, *AtLeast1D[N1?, Ns?])`.
 """
+AtMost2D: TypeAlias = tuple[_N0, _N1] | AtMost1D[_N0]
+"""Shape with `ndim <= 2`, i.e. like `(N0: int = int, *AtMost1D[N1])`."""
 
 
-# 3D
+# 3D (cuboid / tensor)
 
-_N0_3D = TypeVar('_N0_3D', bound=int, default=int)
-_N1_3D = TypeVar('_N1_3D', bound=int, default=int)
-_N2_3D = TypeVar('_N2_3D', bound=int, default=int)
-_Ns_3D = TypeVarTuple('_Ns_3D', default=Unpack[tuple[int, ...]])
-AtLeast3D: TypeAlias = tuple[_N0_3D, _N1_3D, _N2_3D, Unpack[_Ns_3D]]
+AtLeast3D: TypeAlias = tuple[_N0, _N1, _N2, Unpack[tuple[_Ns, ...]]]
 """
-Shapes with `ndim >= 3`, i.e. like `tuple[N0=int, N1=int, N2=int, *(Ns=int)]`
+Shape with `ndim >= 3`, i.e. like `(N0: int = int, *AtLeast2D[N1?, N2?, Ns?])`.
 """
-AtMost3D: TypeAlias = tuple[_N0_3D, _N1_3D, _N2_3D] | AtMost2D[_N0_3D, _N1_3D]
+AtMost3D: TypeAlias = tuple[_N0, _N1, _N2] | AtMost2D[_N0, _N1]
 """
-Shapes with `ndim <= 3`, i.e. like
-`(N0: int = int, *AtMost2D[N1: int = int, N2: int = int])`.
+Shape with `ndim <= 3`, i.e. like `(N0: int = int, *AtMost2D[N1, N2])`.
 """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,9 +93,18 @@ python_version = "3.10"
 always_true = "NP2,NP20"
 # always_true = "NP2"
 # always_false = "NP20"
-modules = ["optype"]
-exclude = ["^.venv/.*", "^examples/.*", "^tests/.*"]
-allow_redefinition = true
+modules = ["optype", "tests"]
+exclude = [
+    "^.venv/.*",
+    "^examples/.*",  # TODO
+]
+strict = true
+allow_redefinition = true  # needed for python/numpy compat code
+disallow_untyped_defs = true
+disallow_incomplete_defs = true
+warn_redundant_casts = true
+warn_unused_ignores = true
+show_error_code_links = true
 
 
 [tool.pytest.ini_options]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,10 +94,7 @@ always_true = "NP2,NP20"
 # always_true = "NP2"
 # always_false = "NP20"
 modules = ["optype", "tests"]
-exclude = [
-    "^.venv/.*",
-    "^examples/.*",  # TODO
-]
+exclude = ["^.venv/.*"]
 strict = true
 allow_redefinition = true  # needed for python/numpy compat code
 disallow_untyped_defs = true

--- a/tests/numpy/test_any_array.py
+++ b/tests/numpy/test_any_array.py
@@ -81,37 +81,45 @@ def test_any_array() -> None:
     # scalar
 
     v_py: onp.AnyArray[_0D] = v
-    assert np.shape(v_py) == ()
+    assert np.shape(v) == ()
 
-    v_np: onp.AnyArray[_0D] = type_np(v_py)
-    assert int(v_np) == v_py
+    v_np = type_np(v_py)
+    v_np_any: onp.AnyArray[_0D] = v_np
+    assert int(v) == v_py
     assert np.shape(v_np) == ()
 
     # 0d
 
-    x0_np: onp.AnyArray[_0D] = np.array(v_py)
+    x0_np = np.array(v_py)
+    x0_np_any: onp.AnyArray[_0D] = x0_np
     assert np.shape(x0_np) == ()
 
     # 1d
 
-    x1_py: onp.AnyArray[_1D] = [v_py]
+    x1_py: list[int] = [v]
+    x1_py_any: onp.AnyArray[_1D] = x1_py
     assert np.shape(x1_py) == (1,)
 
-    x1_py_np: onp.AnyArray[_1D] = [x0_np]
+    x1_py_np = [x0_np]
+    x1_py_np_any: onp.AnyArray[_1D] = x1_py_np
     assert np.shape(x1_py_np) == (1,)
 
-    x1_np: onp.AnyArray[_1D] = np.array(x1_py)
+    x1_np = np.array(x1_py)
+    x1_np_any: onp.AnyArray[_1D] = x1_np
     assert np.shape(x1_np) == (1,)
 
     # 2d
 
-    x2_py: onp.AnyArray[_2D] = [x1_py]
+    x2_py = [x1_py]
+    x2_py_any: onp.AnyArray[_2D] = x2_py
     assert np.shape(x2_py) == (1, 1)
 
-    x2_py_np: onp.AnyArray[_2D] = [x1_np]
+    x2_py_np = [x1_np]
+    x2_py_np_any: onp.AnyArray[_2D] = x2_py_np
     assert np.shape(x2_py_np) == (1, 1)
 
-    x2_np: onp.AnyArray[_2D] = np.array(x2_py)
+    x2_np = np.array(x2_py)
+    x2_np_any: onp.AnyArray[_2D] = x2_np
     assert np.shape(x2_np) == (1, 1)
 
 
@@ -120,28 +128,32 @@ def test_any_unsigned_integer_array(
     sctype: type[_sc.AnyUnsignedInteger],
 ) -> None:
     v: _sc.AnyUnsignedInteger = sctype(42)
-    x: onp.AnyUnsignedIntegerArray[_0D] = np.array(v)
+    x = np.array(v)
+    x_any: onp.AnyUnsignedIntegerArray[_0D] = x
     assert np.issubdtype(x.dtype, np.unsignedinteger)
 
 
 @pytest.mark.parametrize('sctype', SIGNED_INTEGER)
 def test_any_signed_integer_array(sctype: type[_sc.AnySignedInteger]) -> None:
     v: _sc.AnySignedInteger = sctype(42)
-    x: onp.AnySignedIntegerArray[_0D] = np.array(v)
+    x = np.array(v)
+    x_any: onp.AnySignedIntegerArray[_0D] = x
     assert np.issubdtype(x.dtype, np.signedinteger)
 
 
 @pytest.mark.parametrize('sctype', INTEGER)
 def test_any_integer_array(sctype: type[_sc.AnyInteger]) -> None:
     v: _sc.AnyInteger = sctype(42)
-    x: onp.AnyIntegerArray[_0D] = np.array(v)
+    x = np.array(v)
+    x_any: onp.AnyIntegerArray[_0D] = x
     assert np.issubdtype(x.dtype, np.integer)
 
 
 @pytest.mark.parametrize('sctype', FLOATING)
 def test_any_floating_array(sctype: type[_sc.AnyFloating]) -> None:
     v: _sc.AnyFloating = sctype(42)
-    x: onp.AnyFloatingArray[_0D] = np.array(v)
+    x = np.array(v)
+    x_any: onp.AnyFloatingArray[_0D] = x
     assert np.issubdtype(x.dtype, np.floating)
 
 
@@ -150,7 +162,8 @@ def test_any_complex_floating_array(
     sctype: type[_sc.AnyComplexFloating],
 ) -> None:
     v: _sc.AnyComplexFloating = sctype(42 + 42j)
-    x: onp.AnyComplexFloatingArray[_0D] = np.array(v)
+    x = np.array(v)
+    x_any: onp.AnyComplexFloatingArray[_0D] = x
     assert np.issubdtype(x.dtype, np.complexfloating)
 
 
@@ -158,61 +171,70 @@ def test_any_complex_floating_array(
 def test_any_datetime64_array(sctype: type[_sc.AnyDateTime64]) -> None:
     v: _sc.AnyDateTime64
     v = sctype.now() if issubclass(sctype, dt.datetime) else sctype()
-    x: onp.AnyDateTime64Array[_0D] = np.datetime64(v)
+    x = np.datetime64(v)
+    x_any: onp.AnyDateTime64Array[_0D] = x
     assert np.issubdtype(x.dtype, np.datetime64)
 
 
 @pytest.mark.parametrize('sctype', TIMEDELTA64)
 def test_any_timedelta64_array(sctype: type[_sc.AnyTimeDelta64]) -> None:
     v: _sc.AnyTimeDelta64 = sctype()
-    x: onp.AnyTimeDelta64Array[_0D] = np.timedelta64(v)
+    x = np.timedelta64(v)
+    x_any: onp.AnyTimeDelta64Array[_0D] = x
     assert np.issubdtype(x.dtype, np.timedelta64)
 
 
 @pytest.mark.parametrize('sctype', STR)
 def test_any_str_array(sctype: type[_sc.AnyStr]) -> None:
     v: _sc.AnyStr = sctype()
-    x: onp.AnyStrArray[_0D] = np.array(v)
+    x = np.array(v)
+    x_any: onp.AnyStrArray[_0D] = x
     assert np.issubdtype(x.dtype, np.str_)
 
 
 @pytest.mark.parametrize('sctype', BYTES)
 def test_any_bytes_array(sctype: type[_sc.AnyBytes]) -> None:
     v: _sc.AnyBytes = sctype()
-    x: onp.AnyBytesArray[_0D] = np.array(v)
+    x = np.array(v)
+    x_any: onp.AnyBytesArray[_0D] = x
     assert np.issubdtype(x.dtype, np.bytes_)
 
 
 @pytest.mark.parametrize('sctype', CHARACTER)
 def test_any_character_array(sctype: type[_sc.AnyCharacter]) -> None:
     v: _sc.AnyCharacter = sctype()
-    x: onp.AnyCharacterArray[_0D] = np.array(v)
+    x = np.array(v)
+    x_any: onp.AnyCharacterArray[_0D] = x
     assert np.issubdtype(x.dtype, np.character)
 
 
 @pytest.mark.parametrize('sctype', VOID)
 def test_any_void_array(sctype: type[_sc.AnyVoid]) -> None:
     v: _sc.AnyVoid = sctype(0)
-    x: onp.AnyVoidArray[_0D] = np.array(v)
+    x = np.array(v)
+    x_any: onp.AnyVoidArray[_0D] = x
     assert np.issubdtype(x.dtype, np.void)
 
 
 @pytest.mark.parametrize('sctype', FLEXIBLE)
 def test_any_flexible_array(sctype: type[_sc.AnyFlexible]) -> None:
     v: _sc.AnyFlexible = sctype(0)
-    x: onp.AnyFlexibleArray[_0D] = np.array(v)
+    x = np.array(v)
+    x_any: onp.AnyFlexibleArray[_0D] = x
     assert np.issubdtype(x.dtype, np.flexible)
 
 
 @pytest.mark.parametrize('sctype', BOOL)
 def test_any_bool_array(sctype: type[_sc.AnyBool]) -> None:
     v: _sc.AnyBool = sctype(True)
-    x: onp.AnyBoolArray[_0D] = np.array(v)
+    x = np.array(v)
+    x_any: onp.AnyBoolArray[_0D] = x
     assert np.issubdtype(x.dtype, np.bool_)
 
 
 @pytest.mark.parametrize('sctype', OBJECT)
 def test_any_object_array(sctype: type[_sc.AnyObject]) -> None:
     v: _sc.AnyObject = sctype()
-    x: onp.AnyObjectArray[_0D] = np.array(v)
+    x = np.array(v)
+    x_any: onp.AnyObjectArray[_0D] = x
     assert np.issubdtype(x.dtype, np.object_)

--- a/tests/numpy/test_any_scalar.py
+++ b/tests/numpy/test_any_scalar.py
@@ -50,7 +50,7 @@ def _get_dtype_info(name: str) -> tuple[
     'name',
     [*_NUMERIC_N, *_NUMERIC_C, *_SIMPLE, *_TEMPORAL, *_FLEXIBLE],
 )
-def test_sctypes(name: str):
+def test_sctypes(name: str) -> None:
     dtype_expect = np.dtype(name.lower())
     sctype_expect = dtype_expect.type
     types, names, chars = _get_dtype_info(name)
@@ -70,7 +70,7 @@ def test_sctypes(name: str):
     'name',
     [*_NUMERIC_N, *_SIMPLE, *_TEMPORAL, *_FLEXIBLE],
 )
-def test_sctype_name(name: str):
+def test_sctype_name(name: str) -> None:
     dtype_expect = np.dtype(name.lower())
     _, names, _ = _get_dtype_info(name)
 
@@ -81,7 +81,7 @@ def test_sctype_name(name: str):
     'name',
     [*_NUMERIC_C, *_SIMPLE, * _TEMPORAL, * _FLEXIBLE],
 )
-def test_sctype_char(name: str):
+def test_sctype_char(name: str) -> None:
     dtype_expect = np.dtype(name.lower())
     _, _, chars = _get_dtype_info(name)
 

--- a/tests/numpy/test_array.py
+++ b/tests/numpy/test_array.py
@@ -13,24 +13,24 @@ _Shape2D: TypeAlias = tuple[int, int]
 
 # Don't wake up, Neo...
 @pytest.mark.filterwarnings('ignore:the matrix .*:PendingDeprecationWarning')
-def test_can_array():
+def test_can_array() -> None:
     sct: type[np.generic] = np.uint8
 
-    scalar: onp.CanArray[_Shape0D, sct] = sct(42)
+    scalar: onp.CanArray[_Shape0D, Any] = sct(42)
     assert isinstance(scalar, onp.CanArray)
     assert not isinstance(42, onp.CanArray)
 
-    arr_0d: onp.CanArray[_Shape0D, sct] = np.array(42, sct)
+    arr_0d: onp.CanArray[_Shape0D, np.uint8] = np.array(42, sct)
     assert isinstance(arr_0d, onp.CanArray)
 
-    arr_1d: onp.CanArray[_Shape1D, sct] = np.array([42], sct)
+    arr_1d: onp.CanArray[_Shape1D, np.uint8] = np.array([42], sct)
     assert isinstance(arr_1d, onp.CanArray)
     assert not isinstance([42], onp.CanArray)
 
-    arr_2d: onp.CanArray[_Shape2D, sct] = np.array([[42]], sct)
+    arr_2d: onp.CanArray[_Shape2D, np.uint8] = np.array([[42]], sct)
     assert isinstance(arr_2d, onp.CanArray)
 
-    mat: onp.CanArray[_Shape2D, sct] = np.asmatrix(42, sct)
+    mat: onp.CanArray[_Shape2D, np.uint8] = np.asmatrix(42, sct)
     assert isinstance(mat, onp.CanArray)
 
 
@@ -40,37 +40,37 @@ _Arr1D: TypeAlias = onp.Array[tuple[int], _T]
 _Arr2D: TypeAlias = onp.Array[tuple[int, int], _T]
 
 
-def test_can_array_function():
+def test_can_array_function() -> None:
     sct: type[np.generic] = np.uint8
 
     assert not isinstance(sct(42), onp.CanArrayFunction)
 
-    arr_0d: onp.CanArrayFunction[Any, _Arr0D[sct]] = np.array(42, sct)
+    arr_0d: onp.CanArrayFunction[Any, _Arr0D[np.uint8]] = np.array(42, sct)
     assert isinstance(arr_0d, onp.CanArrayFunction)
 
-    arr_1d: onp.CanArrayFunction[Any, _Arr1D[sct]] = np.array([42], sct)
+    arr_1d: onp.CanArrayFunction[Any, _Arr1D[np.uint8]] = np.array([42], sct)
     assert isinstance(arr_1d, onp.CanArrayFunction)
 
-    arr_2d: onp.CanArrayFunction[Any, _Arr2D[sct]] = np.array([[42]], sct)
+    arr_2d: onp.CanArrayFunction[Any, _Arr2D[np.uint8]] = np.array([[42]], sct)
     assert isinstance(arr_2d, onp.CanArrayFunction)
 
 
-def test_can_array_finalize():
+def test_can_array_finalize() -> None:
     sct: type[np.generic] = np.uint8
 
-    arr_0d: onp.CanArrayFinalize[_Arr0D[sct]] = np.array(42, sct)
+    arr_0d: onp.CanArrayFinalize[_Arr0D[np.uint8]] = np.array(42, sct)
     assert isinstance(arr_0d, onp.CanArrayFinalize)
     assert not isinstance(42, onp.CanArrayFinalize)
 
-    arr_1d: onp.CanArrayFinalize[_Arr1D[sct]] = np.array([42], sct)
+    arr_1d: onp.CanArrayFinalize[_Arr1D[np.uint8]] = np.array([42], sct)
     assert isinstance(arr_1d, onp.CanArrayFinalize)
     assert not isinstance([42], onp.CanArrayFinalize)
 
-    arr_2d: onp.CanArrayFinalize[_Arr2D[sct]] = np.array([[42]], sct)
+    arr_2d: onp.CanArrayFinalize[_Arr2D[np.uint8]] = np.array([[42]], sct)
     assert isinstance(arr_2d, onp.CanArrayFinalize)
 
 
-def test_can_array_wrap():
+def test_can_array_wrap() -> None:
     sct: type[np.generic] = np.uint8
 
     arr_0d: onp.CanArrayWrap = np.array(42, sct)
@@ -85,7 +85,7 @@ def test_can_array_wrap():
     assert isinstance(arr_2d, onp.CanArrayWrap)
 
 
-def test_has_array_priority():
+def test_has_array_priority() -> None:
     sct: type[np.generic] = np.uint8
 
     scalar: onp.HasArrayPriority = sct(42)
@@ -103,7 +103,7 @@ def test_has_array_priority():
     assert isinstance(arr_2d, onp.HasArrayPriority)
 
 
-def test_has_array_interface():
+def test_has_array_interface() -> None:
     sct: type[np.generic] = np.uint8
 
     scalar: onp.HasArrayInterface[Any] = sct(42)

--- a/tests/numpy/test_scalar.py
+++ b/tests/numpy/test_scalar.py
@@ -16,11 +16,11 @@ else:
 _NP_V2 = np.__version__.startswith('2.')
 
 
-def test_scalar_from_bool():
+def test_from_bool() -> None:
     x_py = True
     x_np = np.True_
 
-    s_py: Scalar[bool] = x_py  # pyright: ignore[reportAssignmentType]
+    s_py: Scalar[bool] = x_py  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
     assert not isinstance(x_py, Scalar)
 
     s_np_any_n: Scalar[Any] = x_np
@@ -29,8 +29,8 @@ def test_scalar_from_bool():
     s_np_n: Scalar[bool] = x_np
     s_np_1: Scalar[bool, Literal[1]] = x_np
 
-    s_np_wrong_n: Scalar[str] = x_np  # pyright: ignore[reportAssignmentType]
-    s_np_wrong_1: Scalar[str, Literal[1]] = x_np  # pyright: ignore[reportAssignmentType]
+    s_np_wrong_n: Scalar[str] = x_np  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+    s_np_wrong_1: Scalar[str, Literal[1]] = x_np  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
 
     assert isinstance(x_np, Scalar)
 
@@ -47,54 +47,54 @@ def test_scalar_from_bool():
         np.int64, np.uint64,
     ],
 )
-def test_scalar_from_integer(sctype: type[np.integer[Any]]):
+def test_from_integer(sctype: type[np.integer[Any]]) -> None:
     x_py = 42
     x_np = sctype(x_py)
 
-    s_py: Scalar[int] = x_py  # pyright: ignore[reportAssignmentType]
+    s_py: Scalar[int] = x_py  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
     assert not isinstance(x_py, Scalar)
 
     s_np: Scalar[int] = x_np
-    s_np_wrong: Scalar[str] = x_np  # pyright: ignore[reportAssignmentType]
-    s_np_wrong_contra: Scalar[bool] = x_np  # pyright: ignore[reportAssignmentType]
+    s_np_wrong: Scalar[str] = x_np  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+    s_np_wrong_contra: Scalar[bool] = x_np  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
     assert isinstance(x_np, Scalar)
 
     y_py = s_np.item()
     assert_type(y_py, int)
-    assert_type(y_py, bool)  # pyright: ignore[reportAssertTypeFailure]
+    assert_type(y_py, bool)  # type: ignore[assert-type]  # pyright: ignore[reportAssertTypeFailure]
 
 
 @pytest.mark.parametrize('sctype', [np.float16, np.float32, np.float64])
-def test_scalar_from_floating(sctype: type[np.floating[Any]]):
+def test_from_floating(sctype: type[np.floating[Any]]) -> None:
     x_py = -1 / 12
     x_np = sctype(x_py)
 
-    s_py: Scalar[float] = x_py  # pyright: ignore[reportAssignmentType]
+    s_py: Scalar[float] = x_py  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
     assert not isinstance(x_py, Scalar)
 
     s_np: Scalar[float] = x_np
-    s_np_wrong: Scalar[str] = x_np  # pyright: ignore[reportAssignmentType]
-    s_np_wrong_contra: Scalar[int] = x_np  # pyright: ignore[reportAssignmentType]
+    s_np_wrong: Scalar[str] = x_np  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+    s_np_wrong_contra: Scalar[int] = x_np  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
     assert isinstance(x_np, Scalar)
 
     y_py = s_np.item()
     assert_type(y_py, float)
-    assert_type(y_py, int)  # pyright: ignore[reportAssertTypeFailure]
+    assert_type(y_py, int)  # type: ignore[assert-type]  # pyright: ignore[reportAssertTypeFailure]
 
 
 @pytest.mark.parametrize('sctype', [np.complex64, np.complex128])
-def test_scalar_from_complex(sctype: type[np.complexfloating[Any, Any]]):
+def test_from_complex(sctype: type[np.complexfloating[Any, Any]]) -> None:
     x_py = 3 - 4j
     x_np = sctype(x_py)
 
-    s_py: Scalar[complex] = x_py  # pyright: ignore[reportAssignmentType]
+    s_py: Scalar[complex] = x_py  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
     assert not isinstance(x_py, Scalar)
 
     s_np: Scalar[complex] = x_np
-    s_np_wrong: Scalar[str] = x_np  # pyright: ignore[reportAssignmentType]
-    s_np_wrong_contra: Scalar[float] = x_np  # pyright: ignore[reportAssignmentType]
+    s_np_wrong: Scalar[str] = x_np  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+    s_np_wrong_contra: Scalar[float] = x_np  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
     assert isinstance(x_np, Scalar)
 
     y_py = s_np.item()
     assert_type(y_py, complex)
-    assert_type(y_py, float)  # pyright: ignore[reportAssertTypeFailure]
+    assert_type(y_py, float)  # type: ignore[assert-type]  # pyright: ignore[reportAssertTypeFailure]

--- a/tests/numpy/test_shape.py
+++ b/tests/numpy/test_shape.py
@@ -11,110 +11,107 @@ if TYPE_CHECKING:
         from typing_extensions import Never
 
 
-Just0: TypeAlias = Literal[0]
-Just1: TypeAlias = Literal[1]
-Just2: TypeAlias = Literal[2]
-Just3: TypeAlias = Literal[3]
-Just4: TypeAlias = Literal[4]
+Neg1: TypeAlias = Literal[-1]
+Pos0: TypeAlias = Literal[0]
+Pos1: TypeAlias = Literal[1]
+Pos2: TypeAlias = Literal[2]
+Pos3: TypeAlias = Literal[3]
+Pos4: TypeAlias = Literal[4]
 
 
-def test_at_least_0d():
-    s: onp.AtLeast0D = ()
+def test_at_least_0d() -> None:
+    s0: onp.AtLeast0D = ()
+    s0_lit: onp.AtLeast0D[Neg1] = ()
 
     # bool <: int, and the variadic type params of a tuple are somehow
     # covariant (even though `TypeVarTuple`'s can only be invariant...)
-    s_bool: onp.AtLeast0D[bool] = (True,)
+    s1_bool: onp.AtLeast0D[bool] = (True,)
 
-    s_int: onp.AtLeast0D = (1,)
-    s_lit: onp.AtLeast0D[Just1] = (1,)
-    s_lit_wrong: onp.AtLeast0D[Just0] = (1,)  # pyright: ignore[reportAssignmentType]
+    s1_int: onp.AtLeast0D = (1,)
+    s1_lit: onp.AtLeast0D[Pos1] = (1,)
+    s1_lit_wrong: onp.AtLeast0D[Pos0] = (1,)  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
 
-    s_int_int: onp.AtLeast0D = 1, 2
-    s_lit_lit: onp.AtLeast0D[Just1, Just2] = 1, 2
-    s_int_missing: onp.AtLeast0D[int] = 1, 2  # pyright: ignore[reportAssignmentType]
-    s_int_extra: onp.AtLeast0D[int, int, int] = 1, 2  # pyright: ignore[reportAssignmentType]
-
-
-def test_at_least_1d():
-    s_int0: onp.AtLeast1D = ()  # pyright: ignore[reportAssignmentType]
-
-    s_1: onp.AtLeast1D = (1,)
-    s_2: onp.AtLeast1D = 1, 2
-
-    s_int1_2: onp.AtLeast1D[int] = 1, 2
-    s_int2: onp.AtLeast1D[int, int] = 1, 2
-
-    s_lit2: onp.AtLeast1D[Just1, Just2] = 1, 2
-    s_lit2_wrong1: onp.AtLeast1D[Just0, Just2] = 1, 2  # pyright: ignore[reportAssignmentType]
-    s_lit2_wrong2: onp.AtLeast1D[Just1, Just0] = 1, 2  # pyright: ignore[reportAssignmentType]
-
-    s_3: onp.AtLeast1D = 1, 2, 3
-    s_int3: onp.AtLeast1D[int, int, int] = 1, 2, 3
-    s_int3_missing: onp.AtLeast1D[int, int] = 1, 2, 3  # pyright: ignore[reportAssignmentType]
-    s_int3_extra: onp.AtLeast1D[int, int, int, int] = 1, 2, 3  # pyright: ignore[reportAssignmentType]
-
-    s_lit3: onp.AtLeast1D[Just1, Just2, Just3] = 1, 2, 3
+    s2: onp.AtLeast0D = 1, 2
+    s2_lit: onp.AtLeast0D[Pos1 | Pos2] = 1, 2
+    s2_int_int: onp.AtLeast0D[int, int] = 1, 2  # type: ignore[type-arg]  # pyright: ignore[reportInvalidTypeForm]
 
 
-def test_at_least_2d():
-    s_0: onp.AtLeast2D = ()  # pyright: ignore[reportAssignmentType]
-    s_1: onp.AtLeast2D = (1,)  # pyright: ignore[reportAssignmentType]
+def test_at_least_1d() -> None:
+    s0: onp.AtLeast1D = ()  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+    s0_lit: onp.AtLeast1D[Pos0] = ()  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+    s0_lit_lit: onp.AtLeast1D[Pos0, Pos1] = ()  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
 
-    s_2: onp.AtLeast2D = 1, 2
-    s_int1_2: onp.AtLeast2D[int] = 1, 2
-    s_int2: onp.AtLeast2D[int, int] = 1, 2
-    s_lit2: onp.AtLeast2D[Just1, Just2] = 1, 2
+    s1: onp.AtLeast1D = (0,)
+    s1_lit: onp.AtLeast1D[Pos0] = (0,)
+    s1_wrong: onp.AtLeast1D[Pos0] = (-1,)  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+    s1_lit_lit: onp.AtLeast1D[Pos0, Pos1] = (0,)
 
-    s_3: onp.AtLeast2D = 1, 2, 3
-    s_int1_3: onp.AtLeast2D[int] = 1, 2, 3
-    s_int2_3: onp.AtLeast2D[int, int] = 1, 2, 3
-    s_int3: onp.AtLeast2D[int, int, int] = 1, 2, 3
+    s2: onp.AtLeast1D = 0, 1
+    s2_lit: onp.AtLeast1D[Pos0] = 0, 1
+    s2_wrong: onp.AtLeast1D[Pos0] = -1, 1  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+    s2_lit_lit: onp.AtLeast1D[Pos0, Neg1] = 0, -1
+    s2_lit_wrong: onp.AtLeast1D[Pos0, Neg1] = 0, 42  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
 
-    s_lit3: onp.AtLeast2D[Just1, Just2, Just3] = 1, 2, 3
-    s_lit3_wrong1: onp.AtLeast2D[Just0, Just2, Just3] = 1, 2, 3  # pyright: ignore[reportAssignmentType]
-    s_lit3_wrong2: onp.AtLeast2D[Just1, Just0, Just3] = 1, 2, 3  # pyright: ignore[reportAssignmentType]
-    s_lit3_wrong3: onp.AtLeast2D[Just1, Just2, Just0] = 1, 2, 3  # pyright: ignore[reportAssignmentType]
-
-
-def test_at_least_3d():
-    s_0: onp.AtLeast3D = ()  # pyright: ignore[reportAssignmentType]
-    s_1: onp.AtLeast3D = (1,)  # pyright: ignore[reportAssignmentType]
-    s_2: onp.AtLeast3D = 1, 2  # pyright: ignore[reportAssignmentType]
-
-    s_3: onp.AtLeast3D = 1, 2, 3
-    s_4: onp.AtLeast3D = 1, 2, 3, 4
-    s_int1_4: onp.AtLeast3D[int] = 1, 2, 3, 4
-    s_int2_4: onp.AtLeast3D[int, int] = 1, 2, 3, 4
-    s_int3_4: onp.AtLeast3D[int, int, int] = 1, 2, 3, 4
-    s_int4: onp.AtLeast3D[int, int, int, int] = 1, 2, 3, 4
-
-    s_lit4: onp.AtLeast3D[Just1, Just2, Just3, Just4] = 1, 2, 3, 4
-    s_lit4_wrong1: onp.AtLeast3D[Just0, Just2, Just3, Just4] = 1, 2, 3, 4  # pyright: ignore[reportAssignmentType]
-    s_lit4_wrong2: onp.AtLeast3D[Just1, Just0, Just3, Just4] = 1, 2, 3, 4  # pyright: ignore[reportAssignmentType]
-    s_lit4_wrong3: onp.AtLeast3D[Just1, Just2, Just0, Just4] = 1, 2, 3, 4  # pyright: ignore[reportAssignmentType]
-    s_lit4_wrong4: onp.AtLeast3D[Just1, Just2, Just3, Just0] = 1, 2, 3, 4  # pyright: ignore[reportAssignmentType]
+    s3_lit_lit: onp.AtLeast1D[Pos0, Neg1] = 0, -1, -1
+    s3_lit_lit_lit: onp.AtLeast1D[Pos0, Neg1, Pos2] = 0, -1, -1  # type: ignore[type-arg]  # pyright: ignore[reportInvalidTypeForm]
 
 
-def test_at_most_0d():
+def test_at_least_2d() -> None:
+    s0: onp.AtLeast2D = ()  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+    s0_lit_lit: onp.AtLeast2D[Pos0, Pos1] = ()  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+
+    s1: onp.AtLeast2D = (0,)  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+    s1_lit_lit: onp.AtLeast2D[Pos0, Neg1] = (0,)  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+
+    s2: onp.AtLeast2D = 0, 1
+    s2_lit: onp.AtLeast2D[Pos0] = 0, 1
+    s2_wrong: onp.AtLeast2D[Pos0] = -1, 1  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+    s2_lit_lit: onp.AtLeast2D[Pos0, Pos1] = 0, 1
+    s2_lit_wrong: onp.AtLeast2D[Pos0, Pos1] = 0, 42  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+    s2_lit_lit_lit: onp.AtLeast2D[Pos0, Pos1, Neg1] = 0, 1
+
+    s3: onp.AtLeast2D = 0, 1, 2
+    s3_lit_lit: onp.AtLeast2D[Pos0, Pos1] = 0, 1, 2
+    s3_lit_lit_lit: onp.AtLeast2D[Pos0, Pos1, Pos2] = 0, 1, 2
+    s3_lit_lit_wrong: onp.AtLeast2D[Pos0, Pos1, Pos2] = 0, 1, 42  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+
+
+def test_at_least_3d() -> None:
+    s0: onp.AtLeast3D = ()  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+    s0_lit_lit_lit: onp.AtLeast3D[Pos0, Pos1, Pos2] = ()  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+
+    s1: onp.AtLeast3D = (0,)  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+    s1_lit_lit_lit: onp.AtLeast3D[Pos0, Pos1, Pos2] = (0,)  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+
+    s2: onp.AtLeast3D = 0, 1  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+    s2_lit_lit_lit: onp.AtLeast3D[Pos0, Pos1, Pos2] = 0, 1  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+
+    s3: onp.AtLeast3D = 0, 1, 2
+    s3_lit_lit_lit: onp.AtLeast3D[Pos0, Pos1, Pos2] = 0, 1, 2
+    s3_lit_lit_lit_lit: onp.AtLeast3D[Pos0, Pos1, Pos2, Pos3] = 0, 1, 2
+    s3_lit_lit_lit_wrong: onp.AtLeast3D[Pos0, Pos1, Pos2] = 0, 1, 42  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+
+
+def test_at_most_0d() -> None:
     s_0: onp.AtMost0D = ()
-    s_1: onp.AtMost0D = (1,)  # pyright: ignore[reportAssignmentType]
+    s_1: onp.AtMost0D = (1,)  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
 
 
-def test_at_most_1d():
+def test_at_most_1d() -> None:
     s_0: onp.AtMost1D = ()
     s_0_int: onp.AtMost1D[int] = ()
     s_0_never: onp.AtMost1D[Never] = ()
 
     s_1: onp.AtMost1D = (1,)
     s_1_int: onp.AtMost1D[int] = (1,)
-    s_1_lit: onp.AtMost1D[Just1] = (1,)
+    s_1_lit: onp.AtMost1D[Pos1] = (1,)
 
-    s_1_never: onp.AtMost1D[Never] = (1,)  # pyright: ignore[reportAssignmentType]
+    s_1_never: onp.AtMost1D[Never] = (1,)  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
 
-    s_2: onp.AtMost1D = 1, 2  # pyright: ignore[reportAssignmentType]
+    s_2: onp.AtMost1D = 1, 2  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
 
 
-def test_at_most_2d():
+def test_at_most_2d() -> None:
     s_0: onp.AtMost2D = ()
     s_0_int: onp.AtMost2D[int] = ()
     s_0_int_int: onp.AtMost2D[int, int] = ()
@@ -122,34 +119,34 @@ def test_at_most_2d():
     s_0_never_never: onp.AtMost2D[Never, Never] = ()
 
     s_1: onp.AtMost2D = (1,)
-    s_1_lit: onp.AtMost2D[Just1] = (1,)
-    s_1_lit_lit: onp.AtMost2D[Just1, Just2] = (1,)
-    s_1_lit_never: onp.AtMost2D[Just1, Never] = (1,)
-    s_1_never: onp.AtMost2D[Never] = (1,)  # pyright: ignore[reportAssignmentType]
-    s_1_never_never: onp.AtMost2D[Never, Never] = (1,)  # pyright: ignore[reportAssignmentType]
+    s_1_lit: onp.AtMost2D[Pos1] = (1,)
+    s_1_lit_lit: onp.AtMost2D[Pos1, Pos2] = (1,)
+    s_1_lit_never: onp.AtMost2D[Pos1, Never] = (1,)
+    s_1_never: onp.AtMost2D[Never] = (1,)  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+    s_1_never_never: onp.AtMost2D[Never, Never] = (1,)  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
 
     s_2: onp.AtMost2D = 1, 2
-    s_2_lit: onp.AtMost2D[Just1] = 1, 2
-    s_2_lit_lit: onp.AtMost2D[Just1, Just2] = 1, 2
-    s_2_lit_never: onp.AtMost2D[Just1, Never] = 1, 2  # pyright: ignore[reportAssignmentType]
-    s_2_never: onp.AtMost2D[Never] = 1, 2  # pyright: ignore[reportAssignmentType]
-    s_2_never_never: onp.AtMost2D[Never, Never] = 1, 2  # pyright: ignore[reportAssignmentType]
+    s_2_lit: onp.AtMost2D[Pos1] = 1, 2
+    s_2_lit_lit: onp.AtMost2D[Pos1, Pos2] = 1, 2
+    s_2_lit_never: onp.AtMost2D[Pos1, Never] = 1, 2  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+    s_2_never: onp.AtMost2D[Never] = 1, 2  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+    s_2_never_never: onp.AtMost2D[Never, Never] = 1, 2  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
 
-    s_3: onp.AtMost2D = 1, 2, 3  # pyright: ignore[reportAssignmentType]
+    s_3: onp.AtMost2D = 1, 2, 3  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
 
 
-def test_at_most_3d():
+def test_at_most_3d() -> None:
     s_0: onp.AtMost3D = ()
     s_1: onp.AtMost3D = (1,)
     s_2: onp.AtMost3D = 1, 2
     s_3: onp.AtMost3D = 1, 2, 3
 
-    s_3_lit: onp.AtMost3D[Just1] = 1, 2, 3
-    s_3_lit_lit: onp.AtMost3D[Just1, Just2] = 1, 2, 3
-    s_3_lit_lit_lit: onp.AtMost3D[Just1, Just2, Just3] = 1, 2, 3
+    s_3_lit: onp.AtMost3D[Pos1] = 1, 2, 3
+    s_3_lit_lit: onp.AtMost3D[Pos1, Pos2] = 1, 2, 3
+    s_3_lit_lit_lit: onp.AtMost3D[Pos1, Pos2, Pos3] = 1, 2, 3
 
-    s_4: onp.AtMost3D = 1, 2, 3, 4  # pyright: ignore[reportAssignmentType]
+    s_4: onp.AtMost3D = 1, 2, 3, 4  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
 
-    s_3_wrong1: onp.AtMost3D[Just0, Just2, Just3] = 1, 2, 3  # pyright: ignore[reportAssignmentType]
-    s_3_wrong2: onp.AtMost3D[Just1, Just0, Just3] = 1, 2, 3  # pyright: ignore[reportAssignmentType]
-    s_3_wrong3: onp.AtMost3D[Just1, Just2, Just0] = 1, 2, 3  # pyright: ignore[reportAssignmentType]
+    s_3_wrong1: onp.AtMost3D[Pos0, Pos2, Pos3] = 1, 2, 3  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+    s_3_wrong2: onp.AtMost3D[Pos1, Pos0, Pos3] = 1, 2, 3  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+    s_3_wrong3: onp.AtMost3D[Pos1, Pos2, Pos0] = 1, 2, 3  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]

--- a/tests/test_can.py
+++ b/tests/test_can.py
@@ -40,7 +40,7 @@ _T_ReIter = TypeVar('_T_ReIter')
 CanReIter: TypeAlias = CanIter[CanIterSelf[_T_ReIter]]
 
 
-def test_iadd():
+def test_iadd() -> None:
     """
     The `builtins.list` type is the only builtin collection that implements
     `__iadd__`.
@@ -50,19 +50,19 @@ def test_iadd():
     x_iadd: CanIAdd[CanReIter[int], list[int]] = some_list
     x_iadd_any_in: CanIAdd[Any, list[int]] = some_list
     x_iadd_any_out: CanIAdd[CanReIter[int], Any] = some_list
-    x_iadd_wrong_in: CanIAdd[str, list[int]] = some_list  # pyright: ignore[reportAssignmentType]
-    x_iadd_wrong_in_val: CanIAdd[CanReIter[str], list[int]] = some_list  # pyright: ignore[reportAssignmentType]
-    x_iadd_wrong_out: CanIAdd[CanReIter[int], list[str]] = some_list  # pyright: ignore[reportAssignmentType]
+    x_iadd_wrong_in: CanIAdd[str, list[int]] = some_list  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+    x_iadd_wrong_in_val: CanIAdd[CanReIter[str], list[int]] = some_list  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+    x_iadd_wrong_out: CanIAdd[CanReIter[int], list[str]] = some_list  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
     assert isinstance(some_list, CanIAdd)
 
     x_iadd_self: CanIAddSelf[CanReIter[int]] = some_list
     x_iadd_self_any: CanIAddSelf[Any] = some_list
-    x_iadd_self_wrong: CanIAddSelf[str] = some_list  # pyright: ignore[reportAssignmentType]
-    x_iadd_self_wrong_val: CanIAddSelf[CanReIter[str]] = some_list  # pyright: ignore[reportAssignmentType]
+    x_iadd_self_wrong: CanIAddSelf[str] = some_list  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+    x_iadd_self_wrong_val: CanIAddSelf[CanReIter[str]] = some_list  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
     assert isinstance(some_list, CanIAddSelf)
 
 
-def test_imul():
+def test_imul() -> None:
     """
     The `builtins.list` type is the only builtin collection that implements
     `__imul__`.
@@ -72,17 +72,17 @@ def test_imul():
     x_imul: CanIMul[int, list[int]] = some_list
     x_imul_any_in: CanIMul[Any, list[int]] = some_list
     x_imul_any_out: CanIMul[int, Any] = some_list
-    x_imul_wrong_in: CanIMul[str, list[int]] = some_list  # pyright: ignore[reportAssignmentType]
-    x_imul_wrong_out: CanIMul[int, list[str]] = some_list  # pyright: ignore[reportAssignmentType]
+    x_imul_wrong_in: CanIMul[str, list[int]] = some_list  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+    x_imul_wrong_out: CanIMul[int, list[str]] = some_list  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
     assert isinstance(some_list, CanIMul)
 
     x_imul_self: CanIMulSelf[int] = some_list
     x_imul_self_any: CanIMulSelf[Any] = some_list
-    x_imul_self_wrong: CanIMulSelf[str] = some_list  # pyright: ignore[reportAssignmentType]
+    x_imul_self_wrong: CanIMulSelf[str] = some_list  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
     assert isinstance(some_list, CanIMulSelf)
 
 
-def test_isub():
+def test_isub() -> None:
     """
     The `builtins.set` type is the only builtin collection that implements
     `__isub__`.
@@ -92,17 +92,17 @@ def test_isub():
     x_isub: CanISub[set[int], set[int]] = some_set
     x_isub_any_in: CanISub[Any, set[int]] = some_set
     x_isub_any_out: CanISub[set[int], Any] = some_set
-    x_isub_wrong_in: CanISub[int, set[int]] = some_set  # pyright: ignore[reportAssignmentType]
-    x_isub_wrong_out: CanISub[set[int], set[str]] = some_set  # pyright: ignore[reportAssignmentType]
+    x_isub_wrong_in: CanISub[int, set[int]] = some_set  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+    x_isub_wrong_out: CanISub[set[int], set[str]] = some_set  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
     assert isinstance(some_set, CanISub)
 
     x_isub_self: CanISubSelf[set[int]] = some_set
     x_isub_self_any: CanISubSelf[Any] = some_set
-    x_isub_self_wrong: CanISubSelf[str] = some_set  # pyright: ignore[reportAssignmentType]
+    x_isub_self_wrong: CanISubSelf[str] = some_set  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
     assert isinstance(some_set, CanISubSelf)
 
 
-def test_iand():
+def test_iand() -> None:
     """
     The `builtins.set` type is the only builtin collection that implements
     `__iand__`.
@@ -118,17 +118,17 @@ def test_iand():
     x_iand: CanIAnd[set[int], set[int]] = some_set
     x_iand_any_in: CanIAnd[Any, set[int]] = some_set
     x_iand_any_out: CanIAnd[set[int], Any] = some_set
-    x_iand_wrong_in: CanIAnd[int, set[int]] = some_set  # pyright: ignore[reportAssignmentType]
-    x_iand_wrong_out: CanIAnd[set[int], set[str]] = some_set  # pyright: ignore[reportAssignmentType]
+    x_iand_wrong_in: CanIAnd[int, set[int]] = some_set  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+    x_iand_wrong_out: CanIAnd[set[int], set[str]] = some_set  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
     assert isinstance(some_set, CanIAnd)
 
     x_iand_self: CanIAndSelf[set[int]] = some_set
     x_iand_self_any: CanIAndSelf[Any] = some_set
-    x_iand_self_wrong: CanIAndSelf[str] = some_set  # pyright: ignore[reportAssignmentType]
+    x_iand_self_wrong: CanIAndSelf[str] = some_set  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
     assert isinstance(some_set, CanIAndSelf)
 
 
-def test_ixor():
+def test_ixor() -> None:
     """
     The `builtins.set` type is the only builtin collection that implements
     `__ixor__`.
@@ -139,17 +139,17 @@ def test_ixor():
     x_ixor: CanIXor[set[bool], set[bool]] = some_set
     x_ixor_any_in: CanIXor[Any, set[bool]] = some_set
     x_ixor_any_out: CanIXor[set[bool], Any] = some_set
-    x_ixor_wrong_in: CanIXor[set[str], set[bool]] = some_set  # pyright: ignore[reportAssignmentType]
-    x_ixor_wrong_out: CanIXor[set[bool], set[str]] = some_set  # pyright: ignore[reportAssignmentType]
+    x_ixor_wrong_in: CanIXor[set[str], set[bool]] = some_set  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+    x_ixor_wrong_out: CanIXor[set[bool], set[str]] = some_set  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
     assert isinstance(some_set, CanIXor)
 
     x_ixor_self: CanIXorSelf[set[bool]] = some_set
     x_ixor_self_any: CanIXorSelf[Any] = some_set
-    x_ixor_self_wrong: CanIXorSelf[set[str]] = some_set  # pyright: ignore[reportAssignmentType]
+    x_ixor_self_wrong: CanIXorSelf[set[str]] = some_set  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
     assert isinstance(some_set, CanIXorSelf)
 
 
-def test_ior():
+def test_ior() -> None:
     """
     Both the `builtins.set` and the `builtins.dict` standard collection types
     implement `__ior__` method.
@@ -159,13 +159,13 @@ def test_ior():
     x_ior: CanIOr[set[float], set[float]] = some_set
     x_ior_any_in: CanIOr[Any, set[float]] = some_set
     x_ior_any_out: CanIOr[set[float], Any] = some_set
-    x_ior_wrong_in: CanIOr[set[complex], set[float]] = some_set  # pyright: ignore[reportAssignmentType]
-    x_ior_wrong_out: CanIOr[set[float], set[int]] = some_set  # pyright: ignore[reportAssignmentType]
+    x_ior_wrong_in: CanIOr[set[complex], set[float]] = some_set  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+    x_ior_wrong_out: CanIOr[set[float], set[int]] = some_set  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
     assert isinstance(some_set, CanIOr)
 
     x_ior_self: CanIOrSelf[set[float]] = some_set
     x_ior_self_any: CanIOrSelf[Any] = some_set
-    x_ior_self_wrong: CanIOrSelf[set[str]] = some_set  # pyright: ignore[reportAssignmentType]
+    x_ior_self_wrong: CanIOrSelf[set[str]] = some_set  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
     assert isinstance(some_set, CanIOrSelf)
 
     some_dict: dict[bytes, int] = {b'answer': 0x2a}
@@ -173,25 +173,25 @@ def test_ior():
     y_ior: CanIOr[dict[bytes, int], dict[bytes, int]] = some_dict
     y_ior_any_in: CanIOr[Any, dict[bytes, int]] = some_dict
     y_ior_any_out: CanIOr[dict[bytes, int], Any] = some_dict
-    y_ior_wrong_in: CanIOr[dict[str, int], dict[bytes, int]] = some_dict  # pyright: ignore[reportAssignmentType]
-    y_ior_wrong_out: CanIOr[dict[bytes, int], dict[str, int]] = some_dict  # pyright: ignore[reportAssignmentType]
+    y_ior_wrong_in: CanIOr[dict[str, int], dict[bytes, int]] = some_dict  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+    y_ior_wrong_out: CanIOr[dict[bytes, int], dict[str, int]] = some_dict  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
 
     assert isinstance(some_dict, CanIOr)
 
     y_ior_self: CanIOrSelf[dict[bytes, int]] = some_dict
     y_ior_self_any: CanIOrSelf[Any] = some_dict
-    y_ior_self_wrong: CanIOrSelf[dict[str, int]] = some_dict  # pyright: ignore[reportAssignmentType]
+    y_ior_self_wrong: CanIOrSelf[dict[str, int]] = some_dict  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
     assert isinstance(some_dict, CanIOrSelf)
 
 
-def test_can_iter_int():
+def test_can_iter_int() -> None:
     # one can *not* iter and int (pun intended)
     value: int = 42 * 1337
 
-    iter_any: CanIter[Any] = value  # pyright: ignore[reportAssignmentType]
-    iter_next_any: CanIter[CanNext[Any]] = value  # pyright: ignore[reportAssignmentType]
-    iter_next_int: CanIter[CanNext[int]] = value  # pyright: ignore[reportAssignmentType]
-    iter_self_int: CanIterSelf[int] = value  # pyright: ignore[reportAssignmentType]
+    iter_any: CanIter[Any] = value  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+    iter_next_any: CanIter[CanNext[Any]] = value  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+    iter_next_int: CanIter[CanNext[int]] = value  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+    iter_self_int: CanIterSelf[int] = value  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
 
     assert not isinstance(value, CanIter)
     assert not isinstance(value, CanNext)
@@ -216,7 +216,7 @@ def test_can_iter_collection_str(
         | set[str]
         | dict[str, Any]
     ),
-):
+) -> None:
     # sanity checks
     assert isinstance(value, Collection)
     assert not isinstance(value, Iterator)
@@ -224,8 +224,8 @@ def test_can_iter_collection_str(
     value_iter_any: CanIter[Any] = value
     value_iter_next_any: CanIter[CanNext[Any]] = value
     value_iter_next: CanIter[CanNext[str]] = value
-    value_iter_next_wrong: CanIter[CanNext[int]] = value  # pyright: ignore[reportAssignmentType]
-    value_iter_self: CanIterSelf[str] = value  # pyright: ignore[reportAssignmentType]
+    value_iter_next_wrong: CanIter[CanNext[int]] = value  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+    value_iter_self: CanIterSelf[str] = value  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
     value_iter_iter_self: CanIter[CanIterSelf[str]] = value
 
     # strings are iterables of strings; making them infinitely nested
@@ -246,7 +246,7 @@ def test_can_iter_collection_str(
     ivalue_iter_any: CanIter[Any] = ivalue
     ivalue_iter_next_any: CanIter[CanNext[Any]] = ivalue
     ivalue_iter_next: CanIter[CanNext[str]] = ivalue
-    ivalue_iter_next_wrong: CanIter[CanNext[int]] = ivalue  # pyright: ignore[reportAssignmentType]
+    ivalue_iter_next_wrong: CanIter[CanNext[int]] = ivalue  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
     ivalue_iter_self_str: CanIterSelf[str] = ivalue
     ivalue_iter_iter_self: CanIter[CanIterSelf[str]] = ivalue
 
@@ -265,9 +265,9 @@ class UnsliceableSequence:
         return int('inf')
 
 
-def test_unsliceable_sequence():
+def test_unsliceable_sequence() -> None:
     seq_int_str: CanSequence[int, str] = UnsliceableSequence()
-    seq_wrong_str: CanSequence[slice, str] = UnsliceableSequence()  # pyright: ignore[reportAssignmentType]
+    seq_wrong_str: CanSequence[slice, str] = UnsliceableSequence()  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
     assert isinstance(UnsliceableSequence, CanSequence)
 
 
@@ -282,14 +282,14 @@ def test_unsliceable_sequence():
 )
 def test_can_sequence_sequence_str(
     x: str | tuple[str, ...] | list[str] | UnsliceableSequence,
-):
+) -> None:
     x_sequence_any_any: CanSequence[Any, Any] = x
     x_sequence_any_str: CanSequence[Any, str] = x
     x_sequence_int_any: CanSequence[int, Any] = x
     x_sequence_int_str: CanSequence[int, str] = x
 
-    x_sequence_wrong1: CanSequence[slice, str] = x  # pyright: ignore[reportAssignmentType]
-    x_sequence_wrong2: CanSequence[int, bytes] = x  # pyright: ignore[reportAssignmentType]
+    x_sequence_wrong1: CanSequence[slice, str] = x  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+    x_sequence_wrong2: CanSequence[int, bytes] = x  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
 
     assert isinstance(x, CanLen)
     assert isinstance(x, CanGetitem)

--- a/tests/test_copy.py
+++ b/tests/test_copy.py
@@ -23,7 +23,7 @@ def get_type_params(cls: type) -> tuple[Any, ...]:
     'cls',
     [getattr(opt.copy, k) for k in opt.copy.__all__ if not k.endswith('Self')],
 )
-def test_protocols(cls: type):
+def test_protocols(cls: type) -> None:
     # ensure correct name
     assert cls.__module__ == 'optype.copy'
     assert cls.__name__ == cls.__qualname__
@@ -48,7 +48,7 @@ def test_protocols(cls: type):
     assert is_runtime_protocol(cls_self)
 
 
-def test_can_copy():
+def test_can_copy() -> None:
     a = Fraction(1, 137)
 
     a_copy: opt.copy.CanCopy[Fraction] = a
@@ -58,7 +58,7 @@ def test_can_copy():
     assert isinstance(a, opt.copy.CanCopySelf)
 
 
-def test_can_deepcopy():
+def test_can_deepcopy() -> None:
     a = Fraction(1, 137)
 
     a_copy: opt.copy.CanDeepcopy[Fraction] = a
@@ -69,7 +69,7 @@ def test_can_deepcopy():
 
 
 @require_py313
-def test_can_replace():
+def test_can_replace() -> None:
     d = date(2024, 10, 1)
 
     # this seemingly redundant `if` statement prevents pyright errors

--- a/tests/test_does.py
+++ b/tests/test_does.py
@@ -9,7 +9,7 @@ else:
     from typing_extensions import assert_type
 
 
-def test_iadd_iadd():
+def test_iadd_iadd() -> None:
     class IntIAdd:
         def __init__(self, x: int, /) -> None:
             self.x = x
@@ -25,7 +25,7 @@ def test_iadd_iadd():
     assert out == 3
 
 
-def test_iadd_add():
+def test_iadd_add() -> None:
     class IntAdd:
         def __init__(self, x: int, /) -> None:
             self.x = x
@@ -40,7 +40,7 @@ def test_iadd_add():
     assert out == 3
 
 
-def test_iadd_radd():
+def test_iadd_radd() -> None:
     class IntRAdd:
         def __init__(self, x: int, /) -> None:
             self.x = x

--- a/tests/test_inspect.py
+++ b/tests/test_inspect.py
@@ -80,48 +80,48 @@ class ProtoFinalX(tpx.Protocol): ...
 
 class FinalMembers:
     @property
-    def p(self): pass
+    def p(self) -> tp.Any: pass
     @property
     @tp.final
-    def p_final(self): pass
+    def p_final(self) -> tp.Any: pass
     @tpx.final
-    def p_final_x(self): pass
+    def p_final_x(self) -> tp.Any: pass
 
-    def f(self): pass
+    def f(self) -> tp.Any: pass
     @tp.final
-    def f_final(self): pass
+    def f_final(self) -> tp.Any: pass
     @tpx.final
-    def f_final_x(self): pass
+    def f_final_x(self) -> tp.Any: pass
 
     @classmethod
-    def cf(cls): pass
+    def cf(cls) -> tp.Any: pass
     @classmethod
     @tp.final
-    def cf_final1(cls): pass
+    def cf_final1(cls) -> tp.Any: pass
     @classmethod
     @tpx.final
-    def cf_final1_x(cls): pass
+    def cf_final1_x(cls) -> tp.Any: pass
     @tp.final
     @classmethod
-    def cf_final2(cls): pass
+    def cf_final2(cls) -> tp.Any: pass
     @tpx.final
     @classmethod
-    def cf_final2_x(cls): pass
+    def cf_final2_x(cls) -> tp.Any: pass
 
     @staticmethod
-    def sf(): pass
+    def sf() -> tp.Any: pass
     @staticmethod
     @tp.final
-    def sf_final1(): pass
+    def sf_final1() -> tp.Any: pass
     @staticmethod
     @tpx.final
-    def sf_final1_x(): pass
+    def sf_final1_x() -> tp.Any: pass
     @tp.final
     @staticmethod
-    def sf_final2(): pass
+    def sf_final2() -> tp.Any: pass
     @tpx.final
     @staticmethod
-    def sf_final2_x(): pass
+    def sf_final2_x() -> tp.Any: pass
 
 
 def test_get_args_literals() -> None:

--- a/tests/test_inspect.py
+++ b/tests/test_inspect.py
@@ -46,7 +46,7 @@ class CanInit(tpx.Protocol[_Pss]):
 
 @tpx.runtime_checkable
 class CanNew(tpx.Protocol[_Pss, _T_co]):
-    def __new__(cls, *args: _Pss.args, **kwargs: _Pss.kwargs) -> _T_co: ...
+    def __new__(cls, *args: _Pss.args, **kwargs: _Pss.kwargs) -> _T_co: ...  # type: ignore[misc]
 
 
 class ProtoOverload(tpx.Protocol):
@@ -124,7 +124,7 @@ class FinalMembers:
     def sf_final2_x(): pass
 
 
-def test_get_args_literals():
+def test_get_args_literals() -> None:
     assert opt.inspect.get_args(FalsyBool) == (False,)
     assert opt.inspect.get_args(FalsyInt) == (0,)
     assert opt.inspect.get_args(FalsyIntCo) == (False, 0)
@@ -133,7 +133,7 @@ def test_get_args_literals():
 
 
 @pytest.mark.parametrize('origin', [type, list, tuple, GenericTP, GenericTPX])
-def test_get_args_generic(origin: tp.Any):
+def test_get_args_generic(origin: tp.Any) -> None:
     assert opt.inspect.get_args(origin[FalsyBool]) == (FalsyBool,)
     assert opt.inspect.get_args(origin[FalsyInt]) == (FalsyInt,)
     assert opt.inspect.get_args(origin[FalsyIntCo]) == (FalsyIntCo,)
@@ -141,7 +141,7 @@ def test_get_args_generic(origin: tp.Any):
     assert opt.inspect.get_args(origin[Falsy]) == (Falsy,)
 
 
-def test_get_protocol_members():
+def test_get_protocol_members() -> None:
     assert opt.inspect.get_protocol_members(opt.CanAdd) == {'__add__'}
     assert opt.inspect.get_protocol_members(opt.CanPow) == {'__pow__'}
     assert opt.inspect.get_protocol_members(opt.CanHash) == {'__hash__'}
@@ -173,7 +173,7 @@ def test_get_protocol_members():
     assert opt.inspect.get_protocol_members(ProtoOverload) == {'method'}
 
 
-def test_get_protocols():
+def test_get_protocols() -> None:
     import collections.abc  # noqa: PLC0415
     import types  # noqa: PLC0415
 
@@ -190,7 +190,7 @@ def test_get_protocols():
     assert opt.inspect.get_protocols(tpx, private=True) >= protocols_tpx
 
 
-def test_type_is_final():
+def test_type_is_final() -> None:
     assert not opt.inspect.is_final(Proto)
     assert not opt.inspect.is_final(ProtoX)
     assert not opt.inspect.is_final(ProtoRuntime)
@@ -199,21 +199,21 @@ def test_type_is_final():
     assert opt.inspect.is_final(ProtoFinalX)
 
 
-def test_property_is_final():
+def test_property_is_final() -> None:
     assert not opt.inspect.is_final(FinalMembers.p)
     if sys.version_info >= (3, 11):
         assert opt.inspect.is_final(FinalMembers.p_final)
     assert opt.inspect.is_final(FinalMembers.p_final_x)
 
 
-def test_method_is_final():
+def test_method_is_final() -> None:
     assert not opt.inspect.is_final(FinalMembers.f)
     if sys.version_info >= (3, 11):
         assert opt.inspect.is_final(FinalMembers.f_final)
     assert opt.inspect.is_final(FinalMembers.f_final_x)
 
 
-def test_classmethod_is_final():
+def test_classmethod_is_final() -> None:
     assert not opt.inspect.is_final(FinalMembers.cf)
     if sys.version_info >= (3, 11):
         assert opt.inspect.is_final(getattr_static(FinalMembers, 'cf_final1'))
@@ -222,7 +222,7 @@ def test_classmethod_is_final():
     assert opt.inspect.is_final(getattr_static(FinalMembers, 'cf_final2_x'))
 
 
-def test_staticmethod_is_final():
+def test_staticmethod_is_final() -> None:
     assert not opt.inspect.is_final(FinalMembers.sf)
     if sys.version_info >= (3, 11):
         assert opt.inspect.is_final(getattr_static(FinalMembers, 'sf_final1'))
@@ -232,7 +232,7 @@ def test_staticmethod_is_final():
 
 
 @pytest.mark.parametrize('origin', [type, list, tuple, GenericTP, GenericTPX])
-def test_is_generic_alias(origin: tp.Any):
+def test_is_generic_alias(origin: tp.Any) -> None:
     assert not opt.inspect.is_generic_alias(origin)
 
     assert opt.inspect.is_generic_alias(origin[None])
@@ -244,7 +244,7 @@ def test_is_generic_alias(origin: tp.Any):
     assert not opt.inspect.is_generic_alias(origin[None] | None)
 
 
-def test_is_iterable():
+def test_is_iterable() -> None:
     assert opt.inspect.is_iterable([])
     assert opt.inspect.is_iterable(())
     assert opt.inspect.is_iterable('')
@@ -253,7 +253,7 @@ def test_is_iterable():
     assert opt.inspect.is_iterable(i for i in range(2))
 
 
-def test_is_runtime_protocol():
+def test_is_runtime_protocol() -> None:
     assert opt.inspect.is_runtime_protocol(opt.CanAdd)
     assert not opt.inspect.is_runtime_protocol(opt.DoesAdd)
 
@@ -266,7 +266,7 @@ def test_is_runtime_protocol():
 
 
 @pytest.mark.parametrize('origin', [int, tp.Literal[True], Proto, ProtoX])
-def test_is_union_type(origin: tp.Any):
+def test_is_union_type(origin: tp.Any) -> None:
     assert opt.inspect.is_union_type(origin | None)
     Alias = TypeAliasType('Alias', origin | None)  # noqa: N806
     assert opt.inspect.is_union_type(Alias)

--- a/tests/test_pickle.py
+++ b/tests/test_pickle.py
@@ -8,7 +8,7 @@ from optype.inspect import get_protocol_members, is_runtime_protocol
     'cls',
     [getattr(opt.pickle, k) for k in opt.pickle.__all__],
 )
-def test_protocols(cls: type):
+def test_protocols(cls: type) -> None:
     # ensure correct name
     assert cls.__module__ == 'optype.pickle'
     assert cls.__name__ == cls.__qualname__

--- a/tests/test_protocols.py
+++ b/tests/test_protocols.py
@@ -53,7 +53,7 @@ def _pascamel_to_snake(
     return snake
 
 
-def test_all_public():
+def test_all_public() -> None:
     """
     Ensure all of protocols from `optype._can`, `optype._has`, and
     `optype._does` are in `optype.__all__`.
@@ -67,31 +67,31 @@ def test_all_public():
 
 
 @pytest.mark.parametrize('cls', get_protocols(optype._can))
-def test_can_runtime_checkable(cls: type):
+def test_can_runtime_checkable(cls: type) -> None:
     """Ensure that all `Can*` protocols are `@runtime_checkable`."""
     assert is_runtime_protocol(cls)
 
 
 @pytest.mark.parametrize('cls', get_protocols(optype._has))
-def test_has_runtime_checkable(cls: type):
+def test_has_runtime_checkable(cls: type) -> None:
     """Ensure that all `Has*` protocols are `@runtime_checkable`."""
     assert is_runtime_protocol(cls)
 
 
 @pytest.mark.parametrize('cls', get_protocols(optype._does))
-def test_does_not_runtime_checkable(cls: type):
+def test_does_not_runtime_checkable(cls: type) -> None:
     """Ensure that all `Does*` protocols are **not** `@runtime_checkable`."""
     assert not is_runtime_protocol(cls)
 
 
-def test_num_does_eq_num_do():
+def test_num_does_eq_num_do() -> None:
     num_does = len(get_protocols(optype._does))
     num_do = len(get_callables(optype._do))
     assert num_does == num_do
 
 
 @pytest.mark.parametrize('cls', get_protocols(optype._does))
-def test_does_has_do(cls: type):
+def test_does_has_do(cls: type) -> None:
     """Ensure that all `Does*` protocols have a corresponding `do_` op."""
     name = cls.__name__.removeprefix('Does')
     assert name != cls.__name__
@@ -106,7 +106,7 @@ def test_does_has_do(cls: type):
     'cls',
     get_protocols(optype._can) | get_protocols(optype._has),
 )
-def test_name_matches_dunder(cls: type):
+def test_name_matches_dunder(cls: type) -> None:
     """
     Ensure that each single-member `Can*` and `Has*` name matches the name of
     its member, and that each multi-member optype does not have more members

--- a/tests/test_string.py
+++ b/tests/test_string.py
@@ -24,7 +24,7 @@ import optype as opt
 def test_optype_eq_stdlib(
     opt_str: tuple[LiteralString, ...],
     std_str: LiteralString,
-):
+) -> None:
     assert opt_str == tuple(std_str)
 
 
@@ -33,7 +33,7 @@ _ArgT_co = TypeVar('_ArgT_co', bound=opt.typing.AnyLiteral, covariant=True)
 
 # a `typing.Literal` stores it's values in `__args__`
 class _HasArgs(Protocol[_ArgT_co]):
-    __args__: Final[tuple[_ArgT_co, ...]]
+    __args__: Final[tuple[_ArgT_co, ...]]  # type: ignore[misc]
 
 
 @pytest.mark.parametrize(
@@ -54,5 +54,5 @@ class _HasArgs(Protocol[_ArgT_co]):
 def test_literal_args_eq_constant(
     const: tuple[LiteralString, ...],
     lit: _HasArgs[LiteralString],
-):
+) -> None:
     assert opt.inspect.get_args(lit) == const

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -55,29 +55,29 @@ class SequenceLike(Generic[_V_co]):
         return self._xs[index]
 
 
-def test_any_int():
+def test_any_int() -> None:
     p_bool: opt.typing.AnyInt = True
     p_int: opt.typing.AnyInt[Literal[2]] = 2
     p_index: opt.typing.AnyInt[Literal[3]] = Index(3)
     p_int_like: opt.typing.AnyInt[Literal[4]] = IntLike(4)
 
-    n_complex: opt.typing.AnyInt = 5j  # pyright: ignore[reportAssignmentType]
-    n_str: opt.typing.AnyInt = '6'  # pyright: ignore[reportAssignmentType]
+    n_complex: opt.typing.AnyInt = 5j  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+    n_str: opt.typing.AnyInt = '6'  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
 
 
-def test_any_float():
+def test_any_float() -> None:
     p_bool: opt.typing.AnyFloat = True
     p_int: opt.typing.AnyFloat = 1
     p_float: opt.typing.AnyFloat = 2.0
     p_index: opt.typing.AnyFloat = Index(3)
     p_float_like: opt.typing.AnyFloat = FloatLike(4.0)
 
-    n_int_like: opt.typing.AnyFloat = IntLike(5)  # pyright: ignore[reportAssignmentType]
-    n_complex: opt.typing.AnyInt = 6j  # pyright: ignore[reportAssignmentType]
-    n_str: opt.typing.AnyInt = '7'  # pyright: ignore[reportAssignmentType]
+    n_int_like: opt.typing.AnyFloat = IntLike(5)  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+    n_complex: opt.typing.AnyInt = 6j  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+    n_str: opt.typing.AnyInt = '7'  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
 
 
-def test_any_complex():
+def test_any_complex() -> None:
     p_bool: opt.typing.AnyComplex = True
     p_int: opt.typing.AnyComplex = 1
     p_float: opt.typing.AnyComplex = 2.0
@@ -86,11 +86,11 @@ def test_any_complex():
     p_float_like: opt.typing.AnyComplex = FloatLike(5.0)
     p_complex_like: opt.typing.AnyComplex = ComplexLike(6.0)
 
-    n_int_like: opt.typing.AnyComplex = IntLike(7)  # pyright: ignore[reportAssignmentType]
-    n_str: opt.typing.AnyComplex = '8'  # pyright: ignore[reportAssignmentType]
+    n_int_like: opt.typing.AnyComplex = IntLike(7)  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+    n_str: opt.typing.AnyComplex = '8'  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
 
 
-def test_any_iterable():
+def test_any_iterable() -> None:
     p_tuple: opt.typing.AnyIterable[bool] = (False,)
     p_list: opt.typing.AnyIterable[int] = [1]
     p_set: opt.typing.AnyIterable[float] = {2.0}
@@ -106,12 +106,12 @@ class ColorChannel(enum.Enum):
     R, G, B = 0, 1, 2
 
 
-def test_any_literal():
+def test_any_literal() -> None:
     p_none: opt.typing.AnyLiteral = None
     p_bool: opt.typing.AnyLiteral = True
     p_int: opt.typing.AnyLiteral = 1
-    n_float: opt.typing.AnyLiteral = 2.0  # pyright: ignore[reportAssignmentType]
-    n_complex: opt.typing.AnyLiteral = 3j  # pyright: ignore[reportAssignmentType]
+    n_float: opt.typing.AnyLiteral = 2.0  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+    n_complex: opt.typing.AnyLiteral = 3j  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
     p_str: opt.typing.AnyLiteral = '4'
     p_bytes: opt.typing.AnyLiteral = b'5'
     p_enum: opt.typing.AnyLiteral = ColorChannel.R
@@ -120,60 +120,62 @@ def test_any_literal():
 # `Empty*` type aliases
 
 
-def test_empty_string():
+def test_empty_string() -> None:
     empty: opt.typing.EmptyString = ''
-    not_empty: opt.typing.EmptyString = '0'  # pyright: ignore[reportAssignmentType]
+    not_empty: opt.typing.EmptyString = '0'  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
 
 
-def test_empty_bytes():
+def test_empty_bytes() -> None:
     empty: opt.typing.EmptyBytes = b''
-    not_empty: opt.typing.EmptyBytes = b'0'  # pyright: ignore[reportAssignmentType]
+    not_empty: opt.typing.EmptyBytes = b'0'  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
 
 
-def test_empty_tuple():
+def test_empty_tuple() -> None:
     empty: opt.typing.EmptyTuple = ()
-    not_empty: opt.typing.EmptyTuple = (0,)  # pyright: ignore[reportAssignmentType]
+    not_empty: opt.typing.EmptyTuple = (0,)  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
 
 
-def test_empty_list():
+def test_empty_list() -> None:
     empty: opt.typing.EmptyList = []
-    not_empty: opt.typing.EmptyList = [0]  # pyright: ignore[reportAssignmentType]
+    not_empty: opt.typing.EmptyList = [0]  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
 
 
-def test_empty_set():
+def test_empty_set() -> None:
     empty: opt.typing.EmptySet = set()
-    not_empty: opt.typing.EmptySet = {0}  # pyright: ignore[reportAssignmentType]
+    not_empty: opt.typing.EmptySet = {0}  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
 
 
-def test_empty_dict():
+def test_empty_dict() -> None:
     empty: opt.typing.EmptyDict = {}
-    not_empty: opt.typing.EmptyDict = {0: 0}  # pyright: ignore[reportAssignmentType]
+    not_empty: opt.typing.EmptyDict = {0: 0}  # type: ignore[assignment,misc]  # pyright: ignore[reportAssignmentType]
 
 
-def test_empty_iterable():
+def test_empty_iterable() -> None:
     empty: opt.typing.EmptyIterable = ()
-    not_empty: opt.typing.EmptyIterable = (0,)  # pyright: ignore[reportAssignmentType]
+    not_empty: opt.typing.EmptyIterable = (0,)  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
 
 
 # `Literal*` type aliases
 
-def test_literal_bool():
+def test_literal_bool() -> None:
     p_true: opt.typing.LiteralBool = False
     p_false: opt.typing.LiteralBool = True
 
-    n_0: opt.typing.LiteralBool = 0  # pyright: ignore[reportAssignmentType]
-    n_none: opt.typing.LiteralBool = None  # pyright: ignore[reportAssignmentType]
+    n_0: opt.typing.LiteralBool = 0  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+    n_none: opt.typing.LiteralBool = None  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
 
-    assert len(opt.typing.LiteralBool.__args__) == 2
+    # mypy doesn't understand `Literal` aliases...
+    assert len(opt.typing.LiteralBool.__args__) == 2  # type: ignore[attr-defined]
 
 
-def test_literal_byte():
+def test_literal_byte() -> None:
     p_0: opt.typing.LiteralByte = 0
     p_255: opt.typing.LiteralByte = 255
 
-    n_256: opt.typing.LiteralByte = 256  # pyright: ignore[reportAssignmentType]
-    n_m1: opt.typing.LiteralByte = -1  # pyright: ignore[reportAssignmentType]
-    n_bool: opt.typing.LiteralByte = False  # pyright: ignore[reportAssignmentType]
-    n_ix0: opt.typing.LiteralByte = Index(0)  # pyright: ignore[reportAssignmentType]
+    n_256: opt.typing.LiteralByte = 256  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+    n_m1: opt.typing.LiteralByte = -1  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+    n_bool: opt.typing.LiteralByte = False  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+    n_ix0: opt.typing.LiteralByte = Index(0)  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
 
-    assert len(opt.typing.LiteralByte.__args__) == 256
+    # mypy doesn't understand `Literal` aliases...
+    assert len(opt.typing.LiteralByte.__args__) == 256  # type: ignore[attr-defined]

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,6 +1,6 @@
 import optype as opt
 
 
-def test_version():
+def test_version() -> None:
     assert opt.__version__
     assert all(map(str.isdigit, opt.__version__.split('.')[:3]))


### PR DESCRIPTION
This also reworked the `optype.numpy` shape aliases, so that both mypy and pyright treat them the same.

Additionally, the examples were simplified; making them more to-the-point, and mypy-valid.