### PR TITLE
improve readability of `optype.numpy` type aliases and protocols

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,8 @@ jobs:
 
       - name: basedpyright --verifytypes
         run: uv run basedpyright --ignoreexternal --verifytypes optype
+        # https://github.com/microsoft/pyright/issues/9446
+        continue-on-error: true
 
   test:
     timeout-minutes: 5

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ ci:
     - ruff-format
     - basedmypy
     - basedpyright
-    - basedpyright-verifytypes
+    # - basedpyright-verifytypes
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
@@ -79,9 +79,10 @@ repos:
         language: system
         types_or: [python, pyi]
 
-      - id: basedpyright-verifytypes
-        name: basedpyright --verifytypes
-        entry: uv run basedpyright --ignoreexternal --verifytypes optype
-        language: system
-        always_run: true
-        pass_filenames: false
+      # https://github.com/microsoft/pyright/issues/9446
+      # - id: basedpyright-verifytypes
+      #   name: basedpyright --verifytypes
+      #   entry: uv run basedpyright --ignoreexternal --verifytypes optype
+      #   language: system
+      #   always_run: true
+      #   pass_filenames: false

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,7 @@
   {
+    "[markdown]": {
+      "editor.rulers": [88]
+    },
     "[python]": {
       "editor.defaultFormatter": "charliermarsh.ruff",
       "editor.formatOnPaste": true,

--- a/README.md
+++ b/README.md
@@ -2588,10 +2588,22 @@ the type parameter can be omitted, in which case it's equivalent to
 
 #### `Any*Array` and `Any*DType`
 
-The `Any{Scalar}Array` type aliases describe *everything* that, when passed to
-`numpy.asarray` (or any other `numpy.ndarray` constructor), results in a
-`numpy.ndarray` with specific [dtype][REF-DTYPE], i.e.
-`numpy.dtypes.{Scalar}DType`.
+The `Any{Scalar}Array` type aliases describe array-likes that are coercible to an
+`numpy.ndarray` with specific [dtype][REF-DTYPE].
+
+Unlike `numpy.typing.ArrayLike`, these `optype.numpy` aliases *do not*
+include include scalar types. To illustrate:
+
+```py
+import numpy.typing as npt
+import optype.numpy as onp
+
+v_np: npt.ArrayLike = 3.14  # accepted
+v_op: onp.AnyArray = 3.14  # rejected
+
+sigma1_np: npt.ArrayLike = [[0, 1], [1, 0]]  # accepted
+sigma1_op: onp.AnyArray = [[0, 1], [1, 0]]  # accepted
+```
 
 > [!NOTE]
 > The [`numpy.dtypes` docs][REF-DTYPES] exists since NumPy 1.25, but its

--- a/optype/numpy/__init__.py
+++ b/optype/numpy/__init__.py
@@ -17,3 +17,7 @@ __all__ += _dtype.__all__
 __all__ += _scalar.__all__
 __all__ += _shape.__all__
 __all__ += _ufunc.__all__
+
+
+def __dir__() -> list[str]:
+    return __all__

--- a/optype/numpy/_any_array.py
+++ b/optype/numpy/_any_array.py
@@ -1,3 +1,4 @@
+# mypy: disable-error-code="no-any-explicit"
 from __future__ import annotations
 
 import sys
@@ -10,6 +11,7 @@ import optype.numpy._array as _a
 import optype.numpy._compat as _x
 import optype.numpy._scalar as _sc
 import optype.numpy.ctypeslib as _ct
+from optype._core._utils import set_module
 
 
 if sys.version_info >= (3, 13):
@@ -66,33 +68,34 @@ _T = TypeVar("_T")
 _T_co = TypeVar("_T_co", covariant=True)
 
 
+@set_module("_optype")
 class _PyArrray(Protocol[_T_co]):
     def __len__(self, /) -> int: ...
     def __getitem__(self, i: int, /) -> _T_co | _PyArrray[_T_co]: ...
 
 
-_AnyPyArray: Alias = _T | _PyArrray[_T]
+_PyArrayLike: Alias = _T | _PyArrray[_T]
 _PyChar: Alias = bytes | str
-_PyGeneric: Alias = int | float | complex | _PyChar
+_PyGeneric: Alias = complex | _PyChar
 
 _T_np = TypeVar("_T_np", bound=np.generic)
 _T_ct = TypeVar("_T_ct", bound=_ct.CType)
 _T_py = TypeVar("_T_py", bound=_PyGeneric | o.CanBuffer)
 
-_Any1: Alias = _AnyPyArray[_a.CanArray[tuple[int, ...], np.dtype[_T_np]]]
-_Any2: Alias = _Any1[_T_np] | _AnyPyArray[_T_ct] | _ct.Array[_T_ct]
-_Any3: Alias = _Any2[_T_np, _T_ct] | _AnyPyArray[_T_py]
+_Any1: Alias = _PyArrayLike[_a.CanArray[tuple[int, ...], np.dtype[_T_np]]]
+_Any2: Alias = _Any1[_T_np] | _PyArrayLike[_T_ct] | _ct.Array[_T_ct]
+_Any3: Alias = _Any2[_T_np, _T_ct] | _PyArrayLike[_T_py]
 
 
 AnyArray: Alias = _Any3[np.generic, _ct.Generic, _PyGeneric]
 
-ST_iufc = TypeVar("ST_iufc", bound=_sc.Number, default=_sc.Number)
+ST_iufc = TypeVar("ST_iufc", bound=_sc.number, default=_sc.number)
 # NOTE: `builtins.bool <: int`, so `int` can't be included here
 AnyNumberArray: Alias = _Any2[ST_iufc, _ct.Number]
-AnyIntegerArray: Alias = _Any2[_sc.Integer, _ct.Integer]
-AnyUnsignedIntegerArray: Alias = _Any2[_sc.UnsignedInteger, _ct.UnsignedInteger]
-AnySignedIntegerArray: Alias = _Any2[_sc.SignedInteger, _ct.SignedInteger]
-AnyInexactArray: Alias = _Any2[_sc.Inexact, _ct.Floating]
+AnyIntegerArray: Alias = _Any2[_sc.integer, _ct.Integer]
+AnyUnsignedIntegerArray: Alias = _Any2[_sc.uinteger, _ct.UnsignedInteger]
+AnySignedIntegerArray: Alias = _Any2[_sc.sinteger, _ct.SignedInteger]
+AnyInexactArray: Alias = _Any2[_sc.inexact, _ct.Floating]
 
 AnyBoolArray: Alias = _Any3[_x.Bool, _ct.Bool, bool]
 
@@ -123,14 +126,14 @@ AnyLongArray: Alias = _Any2[_x.Long, _ct.Long]  # no int (numpy<=1)
 AnyLongLongArray: Alias = _Any2[np.longlong, _ct.LongLong]
 
 # NOTE: `int <: float` (type-check only), so it can't be included here
-AnyFloatingArray: Alias = _Any2[_sc.Floating, _ct.Floating]
+AnyFloatingArray: Alias = _Any2[_sc.floating, _ct.Floating]
 AnyFloat16Array: Alias = _Any1[np.float16 | np.half]
 AnyFloat32Array: Alias = _Any2[np.float32 | np.single, _ct.Float32]
 AnyFloat64Array: Alias = _Any2[np.float64 | np.double, _ct.Float64]
 AnyLongDoubleArray: Alias = _Any1[np.longdouble]
 
 # NOTE: `float <: complex` (type-check only), so it can't be included here
-AnyComplexFloatingArray: Alias = _Any1[_sc.ComplexFloating]
+AnyComplexFloatingArray: Alias = _Any1[_sc.cfloating]
 AnyComplex64Array: Alias = _Any1[np.complex64 | np.csingle]
 AnyComplex128Array: Alias = _Any1[np.complex128 | np.cdouble]  # no `complex`
 AnyCLongDoubleArray: Alias = _Any1[np.clongdouble]

--- a/optype/numpy/_any_array.py
+++ b/optype/numpy/_any_array.py
@@ -2,22 +2,23 @@
 from __future__ import annotations
 
 import sys
-from typing import TypeAlias as Alias
+from typing import TYPE_CHECKING, Any, TypeAlias
 
 import numpy as np
 
-import optype as o
-import optype.numpy._array as _a
 import optype.numpy._compat as _x
 import optype.numpy._scalar as _sc
-import optype.numpy.ctypeslib as _ct
+from optype._core._can import CanBuffer
 from optype._core._utils import set_module
 
 
 if sys.version_info >= (3, 13):
-    from typing import Never, Protocol, TypeVar
+    from typing import Never, Protocol, TypeAliasType, TypeVar
 else:
-    from typing_extensions import Never, Protocol, TypeVar
+    from typing_extensions import Never, Protocol, TypeAliasType, TypeVar
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
 
 
 # ruff: noqa: RUF022
@@ -66,96 +67,111 @@ __all__ = [
 
 _T = TypeVar("_T")
 _T_co = TypeVar("_T_co", covariant=True)
+_ST = TypeVar("_ST", bound=np.generic, default=np.generic)
+_ST_co = TypeVar("_ST_co", covariant=True, bound=np.generic)
+_VT = TypeVar("_VT", default=_ST)
 
 
-@set_module("_optype")
-class _PyArrray(Protocol[_T_co]):
+# NOTE: Does not include scalar types
+class _AnyArrayNP(Protocol[_ST_co]):
     def __len__(self, /) -> int: ...
-    def __getitem__(self, i: int, /) -> _T_co | _PyArrray[_T_co]: ...
+    def __array__(self, /) -> np.ndarray[tuple[int, ...], np.dtype[_ST_co]]: ...
 
 
-_PyArrayLike: Alias = _T | _PyArrray[_T]
-_PyChar: Alias = bytes | str
-_PyGeneric: Alias = complex | _PyChar
-
-_T_np = TypeVar("_T_np", bound=np.generic)
-_T_ct = TypeVar("_T_ct", bound=_ct.CType)
-_T_py = TypeVar("_T_py", bound=_PyGeneric | o.CanBuffer)
-
-_Any1: Alias = _PyArrayLike[_a.CanArray[tuple[int, ...], np.dtype[_T_np]]]
-_Any2: Alias = _Any1[_T_np] | _PyArrayLike[_T_ct] | _ct.Array[_T_ct]
-_Any3: Alias = _Any2[_T_np, _T_ct] | _PyArrayLike[_T_py]
+# NOTE: does not include tuple
+class _AnyArrayPY0(Protocol[_T_co]):
+    def __len__(self, /) -> int: ...
+    def __getitem__(self, i: int, /) -> _T_co | _AnyArrayPY0[_T_co]: ...
+    def __reversed__(self, /) -> Iterator[_T_co | _AnyArrayPY0[_T_co]]: ...
+    def index(self, x: Any, /) -> int: ...  # pyright: ignore[reportAny]
 
 
-AnyArray: Alias = _Any3[np.generic, _ct.Generic, _PyGeneric]
+_AnyArrayPY: TypeAlias = tuple[_T, ...] | _AnyArrayPY0[_T]
+_AnyArray = TypeAliasType(
+    "_AnyArray",
+    _AnyArrayNP[_ST] | _AnyArrayPY[_VT] | _AnyArrayPY[_AnyArrayNP[_ST]],
+    type_params=(_ST, _VT),
+)
 
-ST_iufc = TypeVar("ST_iufc", bound=_sc.number, default=_sc.number)
-# NOTE: `builtins.bool <: int`, so `int` can't be included here
-AnyNumberArray: Alias = _Any2[ST_iufc, _ct.Number]
-AnyIntegerArray: Alias = _Any2[_sc.integer, _ct.Integer]
-AnyUnsignedIntegerArray: Alias = _Any2[_sc.uinteger, _ct.UnsignedInteger]
-AnySignedIntegerArray: Alias = _Any2[_sc.sinteger, _ct.SignedInteger]
-AnyInexactArray: Alias = _Any2[_sc.inexact, _ct.Floating]
+AnyArray: TypeAlias = _AnyArray[_ST, object] | CanBuffer
 
-AnyBoolArray: Alias = _Any3[_x.Bool, _ct.Bool, bool]
+_ST_iufc = TypeVar("_ST_iufc", bound=_sc.number, default=_sc.number)
+# TODO: also allow `Just[int] | Just[float] | Just[complex]` values
+AnyNumberArray: TypeAlias = _AnyArray[_ST_iufc]
+# TODO: also allow `Just[int]` values
+AnyIntegerArray: TypeAlias = _AnyArray[_sc.integer]
+# TODO: also allow `Just[int]` values
+AnySignedIntegerArray: TypeAlias = _AnyArray[_sc.sinteger]
+AnyUnsignedIntegerArray: TypeAlias = _AnyArray[_sc.uinteger]
+# TODO: also allow `Just[float] | Just[complex]` values
+AnyInexactArray: TypeAlias = _AnyArray[_sc.inexact]
 
-# NOTE: This requires enabling PEP 688 semantics in your type-checker:
-#   - mypy: see https://github.com/python/mypy/issues/15313
-#   - pyright: set `disableBytesTypePromotions = true` (or `strict = true`)
-AnyUInt8Array: Alias = _Any3[np.uint8, _ct.UInt8, o.CanBuffer]
-AnyUInt16Array: Alias = _Any2[np.uint16, _ct.UInt16]
-AnyUInt32Array: Alias = _Any2[np.uint32, _ct.UInt32]
-AnyUInt64Array: Alias = _Any2[np.uint64, _ct.UInt64]
-AnyUByteArray: Alias = _Any2[np.ubyte, _ct.UByte]
-AnyUShortArray: Alias = _Any2[np.ushort, _ct.UShort]
-AnyUIntCArray: Alias = _Any2[np.uintc, _ct.UIntC]
-AnyUIntPArray: Alias = _Any2[np.uintp, _ct.UIntP]
-AnyULongArray: Alias = _Any2[_x.ULong, _ct.ULong]
-AnyULongLongArray: Alias = _Any2[np.ulonglong, _ct.ULongLong]
+AnyBoolArray: TypeAlias = _AnyArray[_x.Bool, bool | _x.Bool]
 
-AnyInt8Array: Alias = _Any2[np.int8, _ct.Int8]
-AnyInt16Array: Alias = _Any2[np.int16, _ct.Int16]
-AnyInt32Array: Alias = _Any2[np.int32, _ct.Int32]
-AnyInt64Array: Alias = _Any2[np.int64, _ct.Int64]
-AnyByteArray: Alias = _Any2[np.byte, _ct.Byte]
-AnyShortArray: Alias = _Any2[np.short, _ct.Short]
-AnyIntCArray: Alias = _Any2[np.intc, _ct.IntC]
-# NOTE: `builtins.bool <: int`, so `int` can't be included here
-AnyIntPArray: Alias = _Any2[np.intp, _ct.IntP]  # no int (numpy>=2)
-AnyLongArray: Alias = _Any2[_x.Long, _ct.Long]  # no int (numpy<=1)
-AnyLongLongArray: Alias = _Any2[np.longlong, _ct.LongLong]
+AnyUInt8Array: TypeAlias = _AnyArray[np.uint8, np.uint8 | CanBuffer] | CanBuffer
+AnyUByteArray = AnyUInt8Array
+AnyUInt16Array: TypeAlias = _AnyArray[np.uint16]
+AnyUShortArray = AnyUInt16Array
+AnyUInt32Array: TypeAlias = _AnyArray[np.uint32]
+AnyUInt64Array: TypeAlias = _AnyArray[np.uint64]
+AnyUIntCArray: TypeAlias = _AnyArray[np.uintc]
+AnyUIntPArray: TypeAlias = _AnyArray[np.uintp]
+AnyULongArray: TypeAlias = _AnyArray[_x.ULong]
+AnyULongLongArray: TypeAlias = _AnyArray[np.ulonglong]
 
-# NOTE: `int <: float` (type-check only), so it can't be included here
-AnyFloatingArray: Alias = _Any2[_sc.floating, _ct.Floating]
-AnyFloat16Array: Alias = _Any1[np.float16 | np.half]
-AnyFloat32Array: Alias = _Any2[np.float32 | np.single, _ct.Float32]
-AnyFloat64Array: Alias = _Any2[np.float64 | np.double, _ct.Float64]
-AnyLongDoubleArray: Alias = _Any1[np.longdouble]
+AnyInt8Array: TypeAlias = _AnyArray[np.int8]
+AnyByteArray = AnyInt8Array
+AnyInt16Array: TypeAlias = _AnyArray[np.int16]
+AnyShortArray = AnyInt16Array
+AnyInt32Array: TypeAlias = _AnyArray[np.int32]
+AnyInt64Array: TypeAlias = _AnyArray[np.int64]
+AnyIntCArray: TypeAlias = _AnyArray[np.intc]
+# TODO: also allow `Just[int]` values
+AnyIntPArray: TypeAlias = _AnyArray[np.intp]  # no int (numpy>=2)
+AnyLongArray: TypeAlias = _AnyArray[_x.Long]  # no int (numpy<=1)
+AnyLongLongArray: TypeAlias = _AnyArray[np.longlong]
 
-# NOTE: `float <: complex` (type-check only), so it can't be included here
-AnyComplexFloatingArray: Alias = _Any1[_sc.cfloating]
-AnyComplex64Array: Alias = _Any1[np.complex64 | np.csingle]
-AnyComplex128Array: Alias = _Any1[np.complex128 | np.cdouble]  # no `complex`
-AnyCLongDoubleArray: Alias = _Any1[np.clongdouble]
+# TODO: also allow `Just[float]` values
+AnyFloatingArray: TypeAlias = _AnyArray[_sc.floating]
+AnyFloat16Array: TypeAlias = _AnyArray[np.float16]
+AnyFloat32Array: TypeAlias = _AnyArray[np.float32]
+AnyFloat64Array: TypeAlias = _AnyArray[np.float64]
+AnyLongDoubleArray: TypeAlias = _AnyArray[np.longdouble]
 
-AnyCharacterArray: Alias = _Any3[np.character, _ct.Bytes, _PyChar]
-AnyBytesArray: Alias = _Any3[np.bytes_, _ct.Bytes, bytes]
-AnyStrArray: Alias = _Any1[np.str_] | _PyArrray[str]
+# TODO: also allow `Just[complex]` values
+AnyComplexFloatingArray: TypeAlias = _AnyArray[_sc.cfloating]
+AnyComplex64Array: TypeAlias = _AnyArray[np.complex64]
+AnyComplex128Array: TypeAlias = _AnyArray[np.complex128]  # no `complex`
+AnyCLongDoubleArray: TypeAlias = _AnyArray[np.clongdouble]
 
-AnyFlexibleArray: Alias = _Any3[np.flexible, _ct.Flexible, _PyChar]
-AnyVoidArray: Alias = _Any2[np.void, _ct.Void]
+AnyCharacterArray: TypeAlias = _AnyArray[np.character, bytes | str | np.character]
+AnyBytesArray: TypeAlias = _AnyArray[np.bytes_, bytes | np.bytes_]
+AnyStrArray: TypeAlias = _AnyArray[np.str_, str | np.str_]
 
-AnyDateTime64Array: Alias = _Any1[np.datetime64]
-AnyTimeDelta64Array: Alias = _Any1[np.timedelta64]
+AnyFlexibleArray: TypeAlias = _AnyArray[np.flexible, bytes | str | np.flexible]
+AnyVoidArray: TypeAlias = _AnyArray[np.void]
+
+AnyDateTime64Array: TypeAlias = _AnyArray[np.datetime64]
+AnyTimeDelta64Array: TypeAlias = _AnyArray[np.timedelta64]
 # NOTE: `{everything} <: object`, so it can't be included here
-AnyObjectArray: Alias = _Any2[np.object_, _ct.Object]
+AnyObjectArray: TypeAlias = _AnyArray[np.object_]
 
-if _x.NP2 and not _x.NP20:  # `numpy>=2.1`
-    AnyStringArray: Alias = _a.CanArray[  # type: ignore[type-var]
-        tuple[int, ...],
-        np.dtypes.StringDType,  # pyright: ignore[reportInvalidTypeArguments]
-    ]
-elif _x.NP2:  # `numpy>=2,<2.1`
-    AnyStringArray: Alias = _a.CanArray[tuple[int, ...], np.dtype[Never]]
+
+if _x.NP2:
+
+    @set_module("optype.numpy")
+    class AnyStringArray(Protocol):
+        def __len__(self, /) -> int: ...
+
+        if _x.NP2 and not _x.NP20:
+            # `numpy>=2.1`
+            def __array__(
+                self, /
+            ) -> np.ndarray[tuple[int, ...], np.dtypes.StringDType]: ...
+
+        elif _x.NP2:
+            # `numpy>=2,<2.1`
+            def __array__(self, /) -> np.ndarray[tuple[int, ...], np.dtype[Never]]: ...
+
 else:  # `numpy<2`
-    AnyStringArray: Alias = Never
+    AnyStringArray: TypeAlias = Never

--- a/optype/numpy/_any_dtype.py
+++ b/optype/numpy/_any_dtype.py
@@ -1,3 +1,4 @@
+# mypy: disable-error-code="no-any-explicit"
 """
 The allowed `np.dtype` arguments for specific scalar types.
 The names are analogous to those in `numpy.dtypes`.
@@ -204,7 +205,7 @@ _Code_g: Alias = L[_Name_g, _Char_g]
 AnyLongDoubleDType: Alias = _AnyDType[np.longdouble] | _Code_g
 
 _Code_fx: Alias = L[_Code_f2, _Code_f4, _Code_f8, _Code_g]
-AnyFloatingDType: Alias = _AnyDType[_sc.Floating] | _Code_fx
+AnyFloatingDType: Alias = _AnyDType[_sc.floating] | _Code_fx
 
 # complex floating
 
@@ -224,7 +225,7 @@ _Code_G: Alias = L[_Name_G, _Char_G]
 AnyCLongDoubleDType: Alias = _AnyDType[np.clongdouble] | _Code_G
 
 _Code_cx: Alias = L[_Code_c8, _Code_c16, _Code_G]
-AnyComplexFloatingDType: Alias = _AnyDType[_sc.ComplexFloating] | _Code_cx
+AnyComplexFloatingDType: Alias = _AnyDType[_sc.cfloating] | _Code_cx
 
 # temporal
 
@@ -340,7 +341,7 @@ _Code_O: Alias = L[_Name_O, _Char_O]
 AnyObjectDType: Alias = _AnyDType[np.object_] | _Code_O
 
 _Code_fc: Alias = L[_Code_fx, _Code_cx]
-AnyInexactDType: Alias = _AnyDType[_sc.Inexact] | _Code_fc
+AnyInexactDType: Alias = _AnyDType[_sc.inexact] | _Code_fc
 
 _Name_ix: Alias = L[
     "int", "int_", "intp",
@@ -376,19 +377,19 @@ if _x.NP2:
 
     _Char_ux: Alias = L[_Char_ux_common, _Char_u0, _Char_P]
     _Code_ux: Alias = L[_Name_ux, _Char_ux]
-    AnyUnsignedIntegerDType: Alias = _AnyDType[_sc.UnsignedInteger] | _Code_ux
+    AnyUnsignedIntegerDType: Alias = _AnyDType[_sc.uinteger] | _Code_ux
 
     _Char_ix: Alias = L[_Char_ix_common, _Char_i0, _Char_p]
     _Code_ix: Alias = L[_Name_ix, _Char_ix]
-    AnySignedIntegerDType: Alias = _AnyDType[_sc.SignedInteger] | _Code_ix
+    AnySignedIntegerDType: Alias = _AnyDType[_sc.sinteger] | _Code_ix
 
     _Code_ui: Alias = L[_Code_ux, _Code_ix]
-    AnyIntegerDType: Alias = _AnyDType[_sc.Integer] | _Code_ui
+    AnyIntegerDType: Alias = _AnyDType[_sc.integer] | _Code_ui
 
     _Code_uifc: Alias = L[_Code_ui, _Code_fc]
     # NOTE: this doesn't include `int` or `float` or `complex`, since that
     # would autoamtically include `bool`.
-    AnyNumberDType: Alias = _AnyDType[_sc.Number] | _Code_uifc
+    AnyNumberDType: Alias = _AnyDType[_sc.number] | _Code_uifc
 
     # NOTE: `np.dtypes.StringDType` didn't exist in the stubs prior to 2.1 (so
     # I (@jorenham) added them, see https://github.com/numpy/numpy/pull/27008).
@@ -424,17 +425,17 @@ else:
 
     _Char_ux: Alias = L[_Char_ux_common, _Char_u0]
     _Code_ux: Alias = L[_Name_ux, _Char_ux]
-    AnyUnsignedIntegerDType: Alias = _AnyDType[_sc.UnsignedInteger] | _Code_ux
+    AnyUnsignedIntegerDType: Alias = _AnyDType[_sc.uinteger] | _Code_ux
 
     _Char_ix: Alias = L[_Char_ix_common, _Char_i0]
     _Code_ix: Alias = L[_Name_ix, _Char_ix]
-    AnySignedIntegerDType: Alias = _AnyDType[_sc.SignedInteger] | _Code_ix
+    AnySignedIntegerDType: Alias = _AnyDType[_sc.sinteger] | _Code_ix
 
     _Code_ui: Alias = L[_Code_ux, _Code_ix]
-    AnyIntegerDType: Alias = _AnyDType[_sc.Integer] | _Code_ui
+    AnyIntegerDType: Alias = _AnyDType[_sc.integer] | _Code_ui
 
     _Code_uifc: Alias = L[_Code_ui, _Code_fc]
-    AnyNumberDType: Alias = _AnyDType[_sc.Number] | _Code_uifc
+    AnyNumberDType: Alias = _AnyDType[_sc.number] | _Code_uifc
 
     AnyStringDType: Alias = Never
 

--- a/optype/numpy/_array.py
+++ b/optype/numpy/_array.py
@@ -1,18 +1,27 @@
 from __future__ import annotations
 
 import sys
-from typing import TYPE_CHECKING, TypeAlias
+from typing import TYPE_CHECKING
 
 import numpy as np
 
 import optype.numpy._compat as _x
-from optype.numpy._dtype import DType
+from optype._core._utils import set_module
+
+from ._dtype import DType
+from ._shape import AtLeast0D
 
 
 if sys.version_info >= (3, 13):
-    from typing import Protocol, Self, TypeVar, runtime_checkable
+    from typing import Protocol, Self, TypeAliasType, TypeVar, runtime_checkable
 else:
-    from typing_extensions import Protocol, Self, TypeVar, runtime_checkable
+    from typing_extensions import (
+        Protocol,
+        Self,
+        TypeAliasType,
+        TypeVar,
+        runtime_checkable,
+    )
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
@@ -28,33 +37,40 @@ __all__ = [
 ]
 
 
-_AnyShape: TypeAlias = tuple[int, ...]
+_ND = TypeVar("_ND", bound=AtLeast0D)
+_ND0_co = TypeVar("_ND0_co", covariant=True, bound=AtLeast0D, default=AtLeast0D)
+_ND0 = TypeVar("_ND0", bound=AtLeast0D, default=AtLeast0D)
+_ST = TypeVar("_ST", bound=np.generic, default=np.generic)
+_DT = TypeVar("_DT", bound=DType)
+_DT_co = TypeVar("_DT_co", bound=DType, covariant=True, default=DType)
 
-# NumPy array with optional type params for shape and generic dtype.
-_ShapeT = TypeVar("_ShapeT", bound=_AnyShape)
-_ScalarT = TypeVar("_ScalarT", bound=np.generic, default=np.generic)
-Array: TypeAlias = np.ndarray[_ShapeT, np.dtype[_ScalarT]]
+
+Array = TypeAliasType("Array", np.ndarray[_ND, np.dtype[_ST]], type_params=(_ND, _ST))
+"""
+```py
+type Array[
+    ND: (int, ...) = AtLeast0D,
+    ST: np.generic = np.generic,
+] = np.ndarray[ND, ST]
+```
+"""
 
 
-_ShapeT0 = TypeVar("_ShapeT0", bound=_AnyShape, default=_AnyShape)
-_ShapeT_co = TypeVar("_ShapeT_co", covariant=True, bound=_AnyShape, default=_AnyShape)
-
-_DTypeT = TypeVar("_DTypeT", bound=DType)
-_DTypeT_co = TypeVar("_DTypeT_co", bound=DType, covariant=True, default=DType)
+###########################
 
 if _x.NP2 and not _x.NP20:
     # numpy >= 2.1: shape is covariant
     @runtime_checkable
-    class CanArray(Protocol[_ShapeT_co, _DTypeT_co]):
-        def __array__(self, /) -> np.ndarray[_ShapeT_co, _DTypeT_co]: ...
+    @set_module("optype.numpy")
+    class CanArray(Protocol[_ND0_co, _DT_co]):
+        def __array__(self, /) -> np.ndarray[_ND0_co, _DT_co]: ...
 
 else:
     # numpy < 2.1: shape is invariant
     @runtime_checkable
-    class CanArray(Protocol[_ShapeT0, _DTypeT_co]):
-        def __array__(self, /) -> np.ndarray[_ShapeT0, _DTypeT_co]: ...
-
-###########################
+    @set_module("optype.numpy")
+    class CanArray(Protocol[_ND0, _DT_co]):
+        def __array__(self, /) -> np.ndarray[_ND0, _DT_co]: ...
 
 
 # this is almost always a `ndarray`, but setting a `bound` might break in some
@@ -63,30 +79,32 @@ _T_contra = TypeVar("_T_contra", contravariant=True, default=object)
 
 
 @runtime_checkable
+@set_module("optype.numpy")
 class CanArrayFinalize(Protocol[_T_contra]):
     def __array_finalize__(self, obj: _T_contra, /) -> None: ...
 
 
 @runtime_checkable
+@set_module("optype.numpy")
 class CanArrayWrap(Protocol):
     if _x.NP2:
 
         def __array_wrap__(
             self,
-            array: np.ndarray[_ShapeT, _DTypeT],
+            array: np.ndarray[_ND, _DT],
             context: tuple[np.ufunc, tuple[object, ...], int] | None = ...,
             return_scalar: bool = ...,
             /,
-        ) -> np.ndarray[_ShapeT, _DTypeT] | Self: ...
+        ) -> np.ndarray[_ND, _DT] | Self: ...
 
     else:
 
         def __array_wrap__(
             self,
-            array: np.ndarray[_ShapeT, _DTypeT],
+            array: np.ndarray[_ND, _DT],
             context: tuple[np.ufunc, tuple[object, ...], int] | None = ...,
             /,
-        ) -> np.ndarray[_ShapeT, _DTypeT] | Self: ...
+        ) -> np.ndarray[_ND, _DT] | Self: ...
 
 
 _ArrayInterfaceT_co = TypeVar(
@@ -98,12 +116,14 @@ _ArrayInterfaceT_co = TypeVar(
 
 
 @runtime_checkable
+@set_module("optype.numpy")
 class HasArrayInterface(Protocol[_ArrayInterfaceT_co]):
     @property
     def __array_interface__(self, /) -> _ArrayInterfaceT_co: ...
 
 
 @runtime_checkable
+@set_module("optype.numpy")
 class HasArrayPriority(Protocol):
     @property
     def __array_priority__(self, /) -> float: ...

--- a/optype/numpy/_dtype.py
+++ b/optype/numpy/_dtype.py
@@ -3,6 +3,8 @@ from typing import TypeAlias
 
 import numpy as np
 
+from optype._core._utils import set_module
+
 
 if sys.version_info >= (3, 13):
     from typing import Protocol, TypeVar, runtime_checkable
@@ -22,6 +24,7 @@ _DT_co = TypeVar("_DT_co", bound=DType, covariant=True, default=DType)
 
 
 @runtime_checkable
+@set_module("optype.numpy")
 class HasDType(Protocol[_DT_co]):
     """HasDType[DT: np.dtype[Any] = Any]
 

--- a/optype/numpy/_scalar.py
+++ b/optype/numpy/_scalar.py
@@ -1,10 +1,14 @@
+# mypy: disable-error-code="no-any-explicit"
 from __future__ import annotations
 
 import sys
-from typing import TYPE_CHECKING, Literal, TypeAlias
+from typing import TYPE_CHECKING, Any, Literal, TypeAlias
 
 import numpy as np
 import numpy.typing as npt
+from typing_extensions import TypeAliasType
+
+from optype._core._utils import set_module
 
 
 if sys.version_info >= (3, 13):
@@ -37,6 +41,7 @@ _Array0D: TypeAlias = np.ndarray[tuple[()], _DT]
 
 
 @runtime_checkable
+@set_module("optype.numpy")
 class Scalar(Protocol[_PT_co, _NB_co]):
     """
     A lightweight `numpy.generic` interface that's actually generic, and
@@ -99,19 +104,17 @@ class Scalar(Protocol[_PT_co, _NB_co]):
     def __array__(self, dtype: _DT, /) -> _Array0D[_DT]: ...
 
 
-_N_re = TypeVar("_N_re", bound=npt.NBitBase, default=npt.NBitBase)
-_N_im = TypeVar("_N_im", bound=npt.NBitBase, default=_N_re)
+# `NBitBase` invariant and doesn't actually do anything, so the default should be `Any`
+_N = TypeVar("_N", bound=npt.NBitBase, default=Any)
 
-Generic: TypeAlias = np.generic
-Number: TypeAlias = np.number[_N_re]
+generic = np.generic
+flexible = np.flexible
+character = np.character
 
-Integer: TypeAlias = np.integer[_N_re]
-UnsignedInteger: TypeAlias = np.unsignedinteger[_N_re]
-SignedInteger: TypeAlias = np.signedinteger[_N_re]
-
-Inexact: TypeAlias = np.inexact[_N_re]
-Floating: TypeAlias = np.floating[_N_re]
-ComplexFloating: TypeAlias = np.complexfloating[_N_re, _N_im]
-
-Flexible: TypeAlias = np.flexible
-Character: TypeAlias = np.character
+number = TypeAliasType("number", np.number[_N], type_params=(_N,))
+integer = TypeAliasType("integer", np.integer[_N], type_params=(_N,))
+uinteger = TypeAliasType("uinteger", np.unsignedinteger[_N], type_params=(_N,))
+sinteger = TypeAliasType("sinteger", np.signedinteger[_N], type_params=(_N,))
+inexact = TypeAliasType("inexact", np.inexact[_N], type_params=(_N,))
+floating = TypeAliasType("floating", np.floating[_N], type_params=(_N,))
+cfloating = TypeAliasType("cfloating", np.complexfloating[_N, _N], type_params=(_N,))

--- a/optype/numpy/_shape.py
+++ b/optype/numpy/_shape.py
@@ -3,9 +3,9 @@ from typing import TypeAlias
 
 
 if sys.version_info >= (3, 13):
-    from typing import TypeVar, Unpack
+    from typing import TypeAliasType, TypeVar, Unpack
 else:
-    from typing_extensions import TypeVar, Unpack
+    from typing_extensions import TypeAliasType, TypeVar, Unpack
 
 
 __all__ = [
@@ -27,32 +27,44 @@ AtLeast0D: TypeAlias = tuple[_Ns, ...]
 AtMost0D: TypeAlias = tuple[()]
 """Shape with `ndim <= 0`, i.e. *just* the empty tuple `()`."""
 
-
 # 1D (vector)
-
-AtLeast1D: TypeAlias = tuple[_N0, Unpack[tuple[_Ns, ...]]]
+AtLeast1D = TypeAliasType(
+    "AtLeast1D",
+    tuple[_N0, Unpack[tuple[_Ns, ...]]],
+    type_params=(_N0, _Ns),
+)
 """Shape with `ndim >= 1`, i.e. like `(N0: int = int, *AtLeast0D[Ns?])`."""
-AtMost1D: TypeAlias = tuple[_N0] | AtMost0D
+AtMost1D = TypeAliasType("AtMost1D", tuple[_N0] | tuple[()], type_params=(_N0,))
 """Shape with `ndim <= 1`, i.e. like `(N0: int = int, *AtMost0D) `."""
 
 
 # 2D (matrix)
 
-AtLeast2D: TypeAlias = tuple[_N0, _N1, Unpack[tuple[_Ns, ...]]]
-"""
-Shape with `ndim >= 2`, i.e. like `(N0: int = int, *AtLeast1D[N1?, Ns?])`.
-"""
-AtMost2D: TypeAlias = tuple[_N0, _N1] | AtMost1D[_N0]
+AtLeast2D = TypeAliasType(
+    "AtLeast2D",
+    tuple[_N0, _N1, Unpack[tuple[_Ns, ...]]],
+    type_params=(_N0, _N1, _Ns),
+)
+"""Shape with `ndim >= 2`, i.e. like `(N0: int = int, *AtLeast1D[N1?, Ns?])`."""
+AtMost2D = TypeAliasType(
+    "AtMost2D",
+    tuple[_N0, _N1] | tuple[_N0] | tuple[()],
+    type_params=(_N0, _N1),
+)
 """Shape with `ndim <= 2`, i.e. like `(N0: int = int, *AtMost1D[N1])`."""
 
 
 # 3D (cuboid / tensor)
 
-AtLeast3D: TypeAlias = tuple[_N0, _N1, _N2, Unpack[tuple[_Ns, ...]]]
-"""
-Shape with `ndim >= 3`, i.e. like `(N0: int = int, *AtLeast2D[N1?, N2?, Ns?])`.
-"""
-AtMost3D: TypeAlias = tuple[_N0, _N1, _N2] | AtMost2D[_N0, _N1]
-"""
-Shape with `ndim <= 3`, i.e. like `(N0: int = int, *AtMost2D[N1, N2])`.
-"""
+AtLeast3D = TypeAliasType(
+    "AtLeast3D",
+    tuple[_N0, _N1, _N2, Unpack[tuple[_Ns, ...]]],
+    type_params=(_N0, _N1, _N2, _Ns),
+)
+"""Shape with `ndim >= 3`, i.e. like `(N0: int = int, *AtLeast2D[N1?, N2?, Ns?])`."""
+AtMost3D = TypeAliasType(
+    "AtMost3D",
+    tuple[_N0, _N1, _N2] | tuple[_N0, _N1] | tuple[_N0] | tuple[()],
+    type_params=(_N0, _N1, _N2),
+)
+"""Shape with `ndim <= 3`, i.e. like `(N0: int = int, *AtMost2D[N1, N2])`."""

--- a/optype/numpy/ctypeslib.py
+++ b/optype/numpy/ctypeslib.py
@@ -111,6 +111,10 @@ __all__ = [
 ]  # fmt: skip
 
 
+def __dir__() -> list[str]:
+    return __all__
+
+
 SIZE_BYTE: Final = cast(Literal[1], ct.sizeof(ct.c_byte))
 SIZE_SHORT: Final = cast(Literal[2], ct.sizeof(ct.c_short))
 SIZE_INTC: Final = cast(Literal[4], ct.sizeof(ct.c_int))
@@ -136,8 +140,8 @@ assert SIZE_LONGDOUBLE in {8, 12, 16}, (
 
 
 CT = TypeVar("CT", bound=CType)
-Array: TypeAlias = ct.Array[CT] | ct.Array["Array[CT]"]
-
+_Array: TypeAlias = ct.Array[CT] | ct.Array["_Array[CT]"]
+Array = TypeAliasType("Array", _Array[CT], type_params=(CT,))
 
 # `c_(u)byte` is an alias for `c_(u)int8`
 _UnsignedInteger: TypeAlias = (

--- a/tests/numpy/test_any_array.py
+++ b/tests/numpy/test_any_array.py
@@ -119,7 +119,7 @@ def test_any_array() -> None:
 
 @pytest.mark.parametrize("sctype", UNSIGNED_INTEGER)
 def test_any_unsigned_integer_array(
-    sctype: type[_sc.UnsignedInteger | _ct.UnsignedInteger],
+    sctype: type[_sc.uinteger | _ct.UnsignedInteger],
 ) -> None:
     v = sctype(42)
     x = np.array(v)
@@ -129,7 +129,7 @@ def test_any_unsigned_integer_array(
 
 @pytest.mark.parametrize("sctype", SIGNED_INTEGER)
 def test_any_signed_integer_array(
-    sctype: type[_sc.SignedInteger | _ct.SignedInteger],
+    sctype: type[_sc.sinteger | _ct.SignedInteger],
 ) -> None:
     v = sctype(42)
     x = np.array(v)
@@ -139,7 +139,7 @@ def test_any_signed_integer_array(
 
 @pytest.mark.parametrize("sctype", INTEGER)
 def test_any_integer_array(
-    sctype: type[_sc.Integer | _ct.Integer],
+    sctype: type[_sc.integer | _ct.Integer],
 ) -> None:
     v = sctype(42)
     x = np.array(v)
@@ -149,7 +149,7 @@ def test_any_integer_array(
 
 @pytest.mark.parametrize("sctype", FLOATING)
 def test_any_floating_array(
-    sctype: type[_sc.Floating | _ct.Floating],
+    sctype: type[_sc.floating | _ct.Floating],
 ) -> None:
     v = sctype(42)
     x = np.array(v)
@@ -159,7 +159,7 @@ def test_any_floating_array(
 
 @pytest.mark.parametrize("sctype", COMPLEX_FLOATING)
 def test_any_complex_floating_array(
-    sctype: type[_sc.ComplexFloating],
+    sctype: type[_sc.cfloating],
 ) -> None:
     v = sctype(42 + 42j)
     x = np.array(v)

--- a/tests/numpy/test_any_array.py
+++ b/tests/numpy/test_any_array.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import ctypes as ct
 import datetime as dt
+from collections import deque
 from typing import TYPE_CHECKING, Final
 
 import numpy as np
@@ -66,25 +67,28 @@ def test_any_array() -> None:
     type_ct = ct.c_int16
     v = 42
 
-    # Python scalar
-
-    v_py: onp.AnyArray = v
-    assert np.shape(v) == ()
-
-    # C scalar
-
-    v_ct: onp.AnyArray = type_ct(42)
+    v_empty_list: onp.AnyArray = []
+    v_empty_tuple: onp.AnyArray = ()
+    v_empty_deque: onp.AnyArray = deque(())
+    v_empty_bytearray: onp.AnyArray = bytearray(b"")
+    v_empty_memoryview: onp.AnyArray = memoryview(b"")
+    # rejection
+    v_bool: onp.AnyArray = False  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+    v_int: onp.AnyArray = 0  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+    v_float: onp.AnyArray = 0.0  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+    v_complex: onp.AnyArray = 0j  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+    v_empty_set: onp.AnyArray = set()  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+    v_dict: onp.AnyArray = {}  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
 
     # NumPy scalar
 
     v_np = type_np(v)
-    v_np_any: onp.AnyArray = v_np
-    assert int(v) == v_py
+    v_np_any: onp.AnyArray = [v_np]
     assert np.shape(v_np) == ()
 
     # 0d
 
-    x0_np = np.array(v_py)
+    x0_np = np.array(v)
     x0_np_any: onp.AnyArray = x0_np
     assert np.shape(x0_np) == ()
 
@@ -173,7 +177,7 @@ def test_any_datetime64_array(
 ) -> None:
     v: dt.datetime | np.datetime64
     v = sctype.now() if issubclass(sctype, dt.datetime) else sctype()
-    x = np.datetime64(v)
+    x = np.array(np.datetime64(v))
     x_any: onp.AnyDateTime64Array = x
     assert np.issubdtype(x.dtype, np.datetime64)
 
@@ -183,7 +187,7 @@ def test_any_timedelta64_array(
     sctype: type[np.timedelta64 | dt.timedelta],
 ) -> None:
     v = sctype()
-    x = np.timedelta64(v)
+    x = np.array(np.timedelta64(v))
     x_any: onp.AnyTimeDelta64Array = x
     assert np.issubdtype(x.dtype, np.timedelta64)
 

--- a/tests/numpy/test_scalar.py
+++ b/tests/numpy/test_scalar.py
@@ -46,7 +46,7 @@ def test_from_bool() -> None:
     "sctype",
     [np.int8, np.uint8, np.int16, np.uint16, np.int32, np.uint32, np.int64, np.uint64],
 )
-def test_from_integer(sctype: type[_sc.Integer]) -> None:
+def test_from_integer(sctype: type[_sc.integer]) -> None:
     x_py = 42
     x_np = sctype(x_py)
 
@@ -64,7 +64,7 @@ def test_from_integer(sctype: type[_sc.Integer]) -> None:
 
 
 @pytest.mark.parametrize("sctype", [np.float16, np.float32, np.float64])
-def test_from_floating(sctype: type[_sc.Floating]) -> None:
+def test_from_floating(sctype: type[_sc.floating]) -> None:
     x_py = -1 / 12
     x_np = sctype(x_py)
 
@@ -82,7 +82,7 @@ def test_from_floating(sctype: type[_sc.Floating]) -> None:
 
 
 @pytest.mark.parametrize("sctype", [np.complex64, np.complex128])
-def test_from_complex(sctype: type[_sc.ComplexFloating]) -> None:
+def test_from_complex(sctype: type[_sc.cfloating]) -> None:
     x_py = 3 - 4j
     x_np = sctype(x_py)
 


### PR DESCRIPTION
- BREAKING: `Any*Array` aliases no longer accept bare scalars
- BREAKING: no longer allow include `ctypes.Array` in `Any*Array`, as `npt.ArrayLike` also doesn't allow this
- use `TypeAliasType` instead of `TypeAlias` for large unions
- stripped the private submodule name from `__module__` of the `Protocol`s
