### PR TITLE
workaround a PEP 696 bug in `typing_extensions.Protocol`  affecting `CanSequence`

### DIFF
--- a/optype/_core/_can.py
+++ b/optype/_core/_can.py
@@ -2,13 +2,12 @@
 from __future__ import annotations
 
 import sys
-from typing import TYPE_CHECKING, Literal, TypeAlias
+from typing import TYPE_CHECKING, Literal, Protocol, TypeAlias
 
 
 if sys.version_info >= (3, 13):
     from typing import (
         ParamSpec,
-        Protocol,
         Self,
         TypeVar,
         overload,
@@ -18,7 +17,6 @@ if sys.version_info >= (3, 13):
 else:
     from typing_extensions import (
         ParamSpec,
-        Protocol,
         Self,
         TypeVar,
         overload,
@@ -447,8 +445,8 @@ _IndexT_contra = TypeVar("_IndexT_contra", bound=CanIndex | slice, contravariant
 @set_module("optype")
 @runtime_checkable
 class CanSequence(
-    CanLen[_IntT_co],
     CanGetitem[_IndexT_contra, _V_co],
+    CanLen[_IntT_co],
     Protocol[_IndexT_contra, _V_co, _IntT_co],
 ):
     """

--- a/optype/_core/_does.py
+++ b/optype/_core/_does.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
 
 import sys
-from typing import TYPE_CHECKING, Literal, TypeAlias
+from typing import TYPE_CHECKING, Literal, Protocol, TypeAlias
 
 
 if sys.version_info >= (3, 13):
-    from typing import ParamSpec, Protocol, TypeVar, overload
+    from typing import ParamSpec, TypeVar, overload
 else:
-    from typing_extensions import ParamSpec, Protocol, TypeVar, overload
+    from typing_extensions import ParamSpec, TypeVar, overload
 
 if TYPE_CHECKING:
     from collections.abc import Callable

--- a/optype/_core/_has.py
+++ b/optype/_core/_has.py
@@ -1,14 +1,13 @@
 from __future__ import annotations
 
 import sys
-from typing import TYPE_CHECKING, ClassVar
+from typing import TYPE_CHECKING, ClassVar, Protocol
 
 
 if sys.version_info >= (3, 13):
     from typing import (
         LiteralString,
         ParamSpec,
-        Protocol,
         Self,
         TypeVar,
         TypeVarTuple,
@@ -20,7 +19,6 @@ else:
     from typing_extensions import (
         LiteralString,
         ParamSpec,
-        Protocol,
         Self,
         TypeVar,
         TypeVarTuple,

--- a/optype/_core/_utils.py
+++ b/optype/_core/_utils.py
@@ -1,17 +1,16 @@
 from __future__ import annotations
 
 import sys
-from typing import TYPE_CHECKING
-
-
-if TYPE_CHECKING:
-    from types import ModuleType
+from typing import TYPE_CHECKING, Protocol
 
 
 if sys.version_info >= (3, 13):
-    from typing import LiteralString, Protocol, TypeVar, is_protocol
+    from typing import LiteralString, TypeVar, is_protocol
 else:
-    from typing_extensions import LiteralString, Protocol, TypeVar, is_protocol
+    from typing_extensions import LiteralString, TypeVar, is_protocol
+
+if TYPE_CHECKING:
+    from types import ModuleType
 
 
 __all__ = "get_callables", "set_module"

--- a/optype/copy.py
+++ b/optype/copy.py
@@ -6,12 +6,13 @@ https://docs.python.org/3/library/copy.html
 from __future__ import annotations
 
 import sys
+from typing import Protocol
 
 
 if sys.version_info >= (3, 13):
-    from typing import Protocol, Self, TypeVar, override, runtime_checkable
+    from typing import Self, TypeVar, override, runtime_checkable
 else:
-    from typing_extensions import Protocol, Self, TypeVar, override, runtime_checkable
+    from typing_extensions import Self, TypeVar, override, runtime_checkable
 
 
 __all__ = (
@@ -20,9 +21,14 @@ __all__ = (
     "CanReplace", "CanReplaceSelf",
 )  # fmt: skip
 
+
+def __dir__() -> tuple[str, ...]:
+    return __all__
+
+
 _T_co = TypeVar("_T_co", covariant=True)
-_V_contra = TypeVar("_V_contra", contravariant=True)
-_AnyV_contra = TypeVar("_AnyV_contra", contravariant=True, default=object)
+_VT_contra = TypeVar("_VT_contra", contravariant=True)
+_VT0_contra = TypeVar("_VT0_contra", contravariant=True, default=object)
 
 
 @runtime_checkable
@@ -56,21 +62,21 @@ class CanDeepcopySelf(CanDeepcopy["CanDeepcopySelf"], Protocol):
 
 
 @runtime_checkable
-class CanReplace(Protocol[_V_contra, _T_co]):
+class CanReplace(Protocol[_VT_contra, _T_co]):
     """
     Anything that can be used as `copy.replace(_: CanReplace[-V, +T]) -> T` (since
     Python 3.13+).
     """
 
-    def __replace__(self, /, **changes: _V_contra) -> _T_co: ...
+    def __replace__(self, /, **changes: _VT_contra) -> _T_co: ...
 
 
 @runtime_checkable
 class CanReplaceSelf(
-    CanReplace[_AnyV_contra, "CanReplaceSelf[_AnyV_contra]"],
-    Protocol[_AnyV_contra],
+    CanReplace[_VT0_contra, "CanReplaceSelf[_VT0_contra]"],
+    Protocol[_VT0_contra],
 ):
     """Runtime-checkable alias `CanReplaceSelf[-V = object] = CanReplace[V, Self]`."""
 
     @override
-    def __replace__(self, /, **changes: _AnyV_contra) -> Self: ...
+    def __replace__(self, /, **changes: _VT0_contra) -> Self: ...

--- a/optype/dataclasses.py
+++ b/optype/dataclasses.py
@@ -6,7 +6,13 @@ https://docs.python.org/3/library/dataclasses.html
 from __future__ import annotations
 
 import sys
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Protocol
+
+
+if sys.version_info >= (3, 13):
+    from typing import TypeVar, runtime_checkable
+else:
+    from typing_extensions import TypeVar, runtime_checkable
 
 
 if TYPE_CHECKING:
@@ -14,13 +20,11 @@ if TYPE_CHECKING:
     from collections.abc import Mapping
 
 
-if sys.version_info >= (3, 13):
-    from typing import Protocol, TypeVar, runtime_checkable
-else:
-    from typing_extensions import Protocol, TypeVar, runtime_checkable
-
-
 __all__ = ("HasDataclassFields",)
+
+
+def __dir__() -> tuple[str, ...]:
+    return __all__
 
 
 _FieldsT = TypeVar(

--- a/optype/dlpack.py
+++ b/optype/dlpack.py
@@ -7,17 +7,21 @@ from __future__ import annotations
 
 import enum
 import sys
-from typing import Any, runtime_checkable
+from typing import Any, Protocol
 
 
 if sys.version_info >= (3, 13):
     from types import CapsuleType
-    from typing import Protocol, TypeVar
+    from typing import TypeVar, runtime_checkable
 else:
-    from typing_extensions import CapsuleType, Protocol, TypeVar
+    from typing_extensions import CapsuleType, TypeVar, runtime_checkable
 
 
-__all__ = ["CanDLPack", "CanDLPackDevice"]
+__all__ = "CanDLPack", "CanDLPackDevice"
+
+
+def __dir__() -> tuple[str, ...]:
+    return __all__
 
 
 class DLDeviceType(enum.IntEnum):

--- a/optype/inspect.py
+++ b/optype/inspect.py
@@ -43,6 +43,10 @@ __all__ = (
 )
 
 
+def __dir__() -> tuple[str, ...]:
+    return __all__
+
+
 def is_iterable(obj: object, /) -> TypeIs[AnyIterable]:
     """
     Check whether the object can be iterated over, i.e. if it can be used in

--- a/optype/inspect.py
+++ b/optype/inspect.py
@@ -8,15 +8,16 @@ from typing import TYPE_CHECKING, Any, Literal, cast, get_args as _get_args
 
 
 if sys.version_info >= (3, 13):
-    from typing import TypeAliasType, TypeIs, is_protocol, overload
+    from typing import TypeAliasType, TypeIs, _get_protocol_attrs, is_protocol, overload
 else:
-    from typing_extensions import TypeAliasType, is_protocol, overload
+    from typing_extensions import (  # type: ignore[attr-defined]
+        TypeAliasType,
+        TypeIs,
+        _get_protocol_attrs,  # noqa: PLC2701  # pyright: ignore[reportAttributeAccessIssue, reportUnknownVariableType]
+        is_protocol,
+        overload,
+    )
 
-    try:
-        from typing_extensions import TypeIs
-    except ImportError:
-        # fallback for `typing_extensions<4.10`
-        from typing import TypeGuard as TypeIs  # type: ignore[assignment]
 
 if TYPE_CHECKING:
     from collections.abc import Callable as CanCall
@@ -279,6 +280,9 @@ def get_protocol_members(cls: type, /) -> frozenset[str]:
     # won't be as broken. I have little hope though...
     if hasattr(cls, "__protocol_attrs__"):
         members |= cast(set[str], cls.__protocol_attrs__)
+    else:
+        # python <3.11
+        members |= cast(set[str], _get_protocol_attrs(cls))
 
     # sometimes __protocol_attrs__ hallicunates some non-existing dunders.
     # the `getattr_static` avoids potential descriptor magic

--- a/optype/json.py
+++ b/optype/json.py
@@ -15,7 +15,13 @@ if sys.version_info >= (3, 13):
 else:
     from typing_extensions import TypeVar
 
+
 __all__ = "AnyArray", "AnyObject", "AnyValue", "Array", "Object", "_Value"
+
+
+def __dir__() -> tuple[str, ...]:
+    return __all__
+
 
 _Primitive: TypeAlias = None | bool | int | float | str
 

--- a/optype/pickle.py
+++ b/optype/pickle.py
@@ -7,15 +7,15 @@ from __future__ import annotations
 
 import sys
 from collections.abc import Callable
-from typing import Concatenate, Literal, TypeAlias
-
-from ._core._can import CanIndex, CanIterSelf
+from typing import Concatenate, Literal, Protocol, TypeAlias
 
 
 if sys.version_info >= (3, 13):
-    from typing import Protocol, Self, TypeVar, override, runtime_checkable
+    from typing import Self, TypeVar, override, runtime_checkable
 else:
-    from typing_extensions import Protocol, Self, TypeVar, override, runtime_checkable
+    from typing_extensions import Self, TypeVar, override, runtime_checkable
+
+from ._core._can import CanIndex, CanIterSelf
 
 
 __all__ = (
@@ -26,6 +26,10 @@ __all__ = (
     "CanReduceEx",
     "CanSetstate",
 )
+
+
+def __dir__() -> tuple[str, ...]:
+    return __all__
 
 
 # 5 is the highest since 3.8, and will become the new default in 3.14

--- a/optype/types/_typeforms.pyi
+++ b/optype/types/_typeforms.pyi
@@ -3,19 +3,19 @@ import types as _types
 from collections.abc import Iterator
 from typing import (
     Generic,
-    ParamSpec,
     TypeAlias,
     _SpecialForm,  # pyright: ignore[reportPrivateUsage]
-    final,
     type_check_only,
 )
 
 from typing_extensions import (
+    ParamSpec,
     Self,
     TypeAliasType,
     TypeVar,
     TypeVarTuple,
     Unpack,
+    final,
     override,
 )
 

--- a/optype/typing.py
+++ b/optype/typing.py
@@ -4,13 +4,18 @@ import enum
 import sys
 from typing import Literal, NoReturn, TypeAlias
 
-from typing_extensions import LiteralString
-
 
 if sys.version_info >= (3, 13):
-    from typing import Never, TypeVar, TypedDict, Unpack, final
+    from typing import LiteralString, Never, TypeVar, TypedDict, Unpack, final
 else:
-    from typing_extensions import Never, TypeVar, TypedDict, Unpack, final
+    from typing_extensions import (
+        LiteralString,
+        Never,
+        TypeVar,
+        TypedDict,
+        Unpack,
+        final,
+    )
 
 from ._core import _can as _c
 
@@ -31,6 +36,10 @@ __all__ = (
     "LiteralBool",
     "LiteralByte",
 )
+
+
+def __dir__() -> tuple[str, ...]:
+    return __all__
 
 
 # Anything that can *always* be converted to an `int` / `float` / `complex`

--- a/uv.lock
+++ b/uv.lock
@@ -665,11 +665,11 @@ cli = [
 
 [[package]]
 name = "tomli"
-version = "2.0.2"
+version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/35/b9/de2a5c0144d7d75a57ff355c0c24054f965b2dc3036456ae03a51ea6264b/tomli-2.0.2.tar.gz", hash = "sha256:d46d457a85337051c36524bc5349dd91b1877838e2979ac5ced3e710ed8a60ed", size = 16096 }
+sdist = { url = "https://files.pythonhosted.org/packages/1e/e4/1b6cbcc82d8832dd0ce34767d5c560df8a3547ad8cbc427f34601415930a/tomli-2.1.0.tar.gz", hash = "sha256:3f646cae2aec94e17d04973e4249548320197cfabdf130015d023de4b74d8ab8", size = 16622 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cf/db/ce8eda256fa131af12e0a76d481711abe4681b6923c27efb9a255c9e4594/tomli-2.0.2-py3-none-any.whl", hash = "sha256:2ebe24485c53d303f690b0ec092806a085f07af5a5aa1464f3931eec36caaa38", size = 13237 },
+    { url = "https://files.pythonhosted.org/packages/de/f7/4da0ffe1892122c9ea096c57f64c2753ae5dd3ce85488802d11b0992cc6d/tomli-2.1.0-py3-none-any.whl", hash = "sha256:a5c57c3d1c56f5ccdf89f6523458f60ef716e210fc47c4cfb188c5ba473e0391", size = 13750 },
 ]
 
 [[package]]


### PR DESCRIPTION
This fixes (at least) the following issue:

```pycon
>>> op.CanSequence[int, float]
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/joren/.pyenv/versions/3.12.7/lib/python3.12/typing.py", line 398, in inner
    return func(*args, **kwds)
           ^^^^^^^^^^^^^^^^^^^
  File "/home/joren/.pyenv/versions/3.12.7/lib/python3.12/typing.py", line 1110, in _generic_class_getitem
    _check_generic(cls, params, len(cls.__parameters__))
  File "/home/joren/.pyenv/versions/3.12.7/lib/python3.12/site-packages/typing_extensions.py", line 2947, in _check_generic
    raise TypeError(f"Too {'many' if alen > elen else 'few'} arguments"
TypeError: Too few arguments for <class 'optype.CanSequence'>; actual 2, expected at least 2
```