### PR TITLE
`ToJustInt` scalar- and array-likes in `optype.numpy`

### DIFF
--- a/README.md
+++ b/README.md
@@ -2540,9 +2540,12 @@ matrix-likes, and cuboid-likes, and the `To{}` aliases for "bare" scalar types.
     <th align="center"><code>N</code>-d array-like</th>
 </tr>
 <tr>
-    <th align="center"><code>builtins</code></th>
-    <th align="center"><code>numpy</code></th>
-    <th align="center" colspan="4"><code>optype.numpy</code></th>
+    <th align="left">
+        <code>builtins</code> /<br>
+        <a href="#optypetyping"><code>optype.typing</code></a>
+    </th>
+    <th align="left"><code>numpy</code></th>
+    <th align="left" colspan="4"><code>optype.numpy</code></th>
 </tr>
 <tr><td colspan="5"></td></tr>
 <tr>
@@ -2551,6 +2554,18 @@ matrix-likes, and cuboid-likes, and the `To{}` aliases for "bare" scalar types.
     <td align="left"><code>ToBool</code></td>
     <td align="left"><code>ToBool{1,2,3}D</code></td>
     <td align="left"><code>ToBoolND</code></td>
+</tr>
+<tr><td colspan="6"></td></tr>
+<tr>
+    <td align="left">
+        <a href="#just-types"><code>JustInt</code><a>
+    </td>
+    <td align="left">
+        <code>integer</code>
+    </td>
+    <td align="left"><code>ToJustInt</code></td>
+    <td align="left"><code>ToJustInt{1,2,3}D</code></td>
+    <td align="left"><code>ToJustIntND</code></td>
 </tr>
 <tr><td colspan="6"></td></tr>
 <tr>

--- a/optype/numpy/_to.py
+++ b/optype/numpy/_to.py
@@ -1,10 +1,11 @@
-from __future__ import annotations
-
+# mypy: disable-error-code="no-any-explicit"
 import sys
 from collections.abc import Sequence as Seq
-from typing import TypeAlias, TypeVar
+from typing import Literal, TypeAlias, TypeVar
 
 import numpy as np
+
+import optype.typing as opt
 
 from ._array import CanArrayND
 from ._scalar import floating, integer, number
@@ -18,78 +19,81 @@ else:
 
 
 __all__ = [
-    "ToArray1D",
-    "ToArray2D",
-    "ToArray3D",
-    "ToArrayND",
-    "ToBool",
-    "ToBool1D",
-    "ToBool2D",
-    "ToBool3D",
-    "ToBoolND",
-    "ToComplex",
-    "ToComplex1D",
-    "ToComplex2D",
-    "ToComplex3D",
-    "ToComplexND",
-    "ToFloat",
-    "ToFloat1D",
-    "ToFloat2D",
-    "ToFloat3D",
-    "ToFloatND",
-    "ToInt",
-    "ToInt1D",
-    "ToInt2D",
-    "ToInt3D",
-    "ToIntND",
+    "ToArray1D", "ToArray2D", "ToArray3D", "ToArrayND",
+    "ToBool", "ToBool1D", "ToBool2D", "ToBool3D", "ToBoolND",
+    "ToComplex", "ToComplex1D", "ToComplex2D", "ToComplex3D", "ToComplexND",
+    "ToFloat", "ToFloat1D", "ToFloat2D", "ToFloat3D", "ToFloatND",
+    "ToInt", "ToInt1D", "ToInt2D", "ToInt3D", "ToIntND",
+    "ToJustInt", "ToJustInt1D", "ToJustInt2D", "ToJustInt3D", "ToJustIntND",
     "ToScalar",
-]
+]  # fmt: skip
 
-T = TypeVar("T")
 ST = TypeVar("ST", bound=np.generic)
+T = TypeVar("T")
 
-
-_To1D: TypeAlias = CanArrayND[ST] | Seq[ST | T]
-_To2D: TypeAlias = CanArrayND[ST] | Seq[CanArrayND[ST]] | Seq[Seq[ST | T]]
-_To3D: TypeAlias = (
-    CanArrayND[ST]
-    | Seq[CanArrayND[ST]]
-    | Seq[Seq[CanArrayND[ST]]]
-    | Seq[Seq[Seq[ST | T]]]
+_To1D = TypeAliasType(
+    "_To1D",
+    CanArrayND[ST] | Seq[ST | T],
+    type_params=(ST, T),
+)
+_To2D = TypeAliasType(
+    "_To2D",
+    CanArrayND[ST] | Seq[CanArrayND[ST]] | Seq[Seq[ST | T]],
+    type_params=(ST, T),
+)
+_To3D = TypeAliasType(
+    "_To3D",
+    (
+        CanArrayND[ST]
+        | Seq[CanArrayND[ST]]
+        | Seq[Seq[CanArrayND[ST]]]
+        | Seq[Seq[Seq[ST | T]]]
+    ),
+    type_params=(ST, T),
 )
 # recursive sequence type cannot be used due to a mypy bug:
 # https://github.com/python/mypy/issues/18184
 _ToND: TypeAlias = CanArrayND[ST] | SequenceND[T | ST] | SequenceND[CanArrayND[ST]]
 
-ToScalar: TypeAlias = complex | bytes | str | np.generic
-ToArray1D: TypeAlias = _To1D[np.generic, complex | bytes | str]
-ToArray2D: TypeAlias = _To2D[np.generic, complex | bytes | str]
-ToArray3D: TypeAlias = _To3D[np.generic, complex | bytes | str]
-ToArrayND: TypeAlias = _ToND[np.generic, complex | bytes | str]
+_PyBool: TypeAlias = bool | Literal[0, 1]  # 0 and 1 are sometimes used as bool values
+_PyScalar: TypeAlias = complex | bytes | str  # `complex` somehow includes `float | int`
 
-ToBool: TypeAlias = bool | np.bool_
-ToBool1D: TypeAlias = _To1D[np.bool_, bool]
-ToBool2D: TypeAlias = _To2D[np.bool_, bool]
-ToBool3D: TypeAlias = _To3D[np.bool_, bool]
-ToBoolND: TypeAlias = _ToND[np.bool_, bool]
+_Int = TypeAliasType("_Int", integer | np.bool_)
+_Float = TypeAliasType("_Float", floating | integer | np.bool_)
+_Complex = TypeAliasType("_Complex", number | np.bool_)
 
-integer_co = TypeAliasType("integer_co", integer | np.bool_)  # type: ignore[no-any-explicit]
-ToInt: TypeAlias = int | integer_co
-ToInt1D: TypeAlias = _To1D[integer_co, int]
-ToInt2D: TypeAlias = _To2D[integer_co, int]
-ToInt3D: TypeAlias = _To3D[integer_co, int]
-ToIntND: TypeAlias = _ToND[integer_co, int]
+ToScalar: TypeAlias = np.generic | _PyScalar
+ToArray1D: TypeAlias = _To1D[np.generic, _PyScalar]
+ToArray2D: TypeAlias = _To2D[np.generic, _PyScalar]
+ToArray3D: TypeAlias = _To3D[np.generic, _PyScalar]
+ToArrayND: TypeAlias = _ToND[np.generic, _PyScalar]
 
-floating_co = TypeAliasType("floating_co", floating | integer | np.bool_)  # type: ignore[no-any-explicit]
-ToFloat: TypeAlias = float | floating_co
-ToFloat1D: TypeAlias = _To1D[floating_co, float]
-ToFloat2D: TypeAlias = _To2D[floating_co, float]
-ToFloat3D: TypeAlias = _To3D[floating_co, float]
-ToFloatND: TypeAlias = _ToND[floating_co, float]
+ToBool: TypeAlias = np.bool_ | _PyBool
+ToBool1D: TypeAlias = _To1D[np.bool_, _PyBool]
+ToBool2D: TypeAlias = _To2D[np.bool_, _PyBool]
+ToBool3D: TypeAlias = _To3D[np.bool_, _PyBool]
+ToBoolND: TypeAlias = _ToND[np.bool_, _PyBool]
 
-complexfloating_co = TypeAliasType("complexfloating_co", number | np.bool_)  # type: ignore[no-any-explicit]
-ToComplex: TypeAlias = complex | complexfloating_co
-ToComplex1D: TypeAlias = _To1D[complexfloating_co, complex]
-ToComplex2D: TypeAlias = _To2D[complexfloating_co, complex]
-ToComplex3D: TypeAlias = _To3D[complexfloating_co, complex]
-ToComplexND: TypeAlias = _ToND[complexfloating_co, complex]
+ToJustInt: TypeAlias = integer | opt.JustInt
+ToJustInt1D: TypeAlias = _To1D[integer, opt.JustInt]
+ToJustInt2D: TypeAlias = _To2D[integer, opt.JustInt]
+ToJustInt3D: TypeAlias = _To3D[integer, opt.JustInt]
+ToJustIntND: TypeAlias = _ToND[integer, opt.JustInt]
+
+ToInt: TypeAlias = _Int | int
+ToInt1D: TypeAlias = _To1D[_Int, int]
+ToInt2D: TypeAlias = _To2D[_Int, int]
+ToInt3D: TypeAlias = _To3D[_Int, int]
+ToIntND: TypeAlias = _ToND[_Int, int]
+
+ToFloat: TypeAlias = _Float | float
+ToFloat1D: TypeAlias = _To1D[_Float, float]
+ToFloat2D: TypeAlias = _To2D[_Float, float]
+ToFloat3D: TypeAlias = _To3D[_Float, float]
+ToFloatND: TypeAlias = _ToND[_Float, float]
+
+ToComplex: TypeAlias = _Complex | complex
+ToComplex1D: TypeAlias = _To1D[_Complex, complex]
+ToComplex2D: TypeAlias = _To2D[_Complex, complex]
+ToComplex3D: TypeAlias = _To3D[_Complex, complex]
+ToComplexND: TypeAlias = _ToND[_Complex, complex]

--- a/tests/numpy/test_to.pyi
+++ b/tests/numpy/test_to.pyi
@@ -23,6 +23,9 @@ arr_c: onp.ArrayND[np.clongdouble] | list[list[list[complex | np.clongdouble]]]
 sb0: onp.ToBool = True
 sb1: onp.ToBool = np.True_
 
+sj0: onp.ToJustInt = 42
+sj1: onp.ToJustInt = np.int_(42)
+
 si0: onp.ToInt = 42
 si1: onp.ToInt = np.int_(42)
 
@@ -34,63 +37,83 @@ sc1: onp.ToComplex = np.clongdouble(42.0 + 1j)
 
 # vectors
 vb: onp.ToBool1D = vec_b
+vj: onp.ToJustInt1D = vec_i
 vi: onp.ToInt1D = vec_i
 vf: onp.ToFloat1D = vec_f
 vc: onp.ToComplex1D = vec_c
 
 vsb: onp.ToBool1D = True  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+vsj: onp.ToJustInt1D = 42  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
 vsi: onp.ToInt1D = 42  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
 vsf: onp.ToFloat1D = 42.0  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
 vsc: onp.ToComplex1D = 42 + 1j  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
 
 vub: onp.ToBool1D = "illegal"  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+vuj: onp.ToJustInt1D = "illegal"  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
 vui: onp.ToInt1D = "illegal"  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
 vuf: onp.ToFloat1D = "illegal"  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
 vuc: onp.ToComplex1D = "illegal"  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
 
 # matrices
 mb: onp.ToBool2D = mat_b
+mj: onp.ToJustInt2D = mat_i
 mi: onp.ToInt2D = mat_i
 mf: onp.ToFloat2D = mat_f
 mc: onp.ToComplex2D = mat_c
 
 mvb: onp.ToBool2D = vec_b  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+mvj: onp.ToJustInt2D = vec_i  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
 mvi: onp.ToInt2D = vec_i  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
 mvf: onp.ToFloat2D = vec_f  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
 mvc: onp.ToComplex2D = vec_c  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
 
 msb: onp.ToBool2D = True  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+msj: onp.ToJustInt2D = 42  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
 msi: onp.ToInt2D = 42  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
 msf: onp.ToFloat2D = 42.0  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
 msc: onp.ToComplex2D = 42 + 0j  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
 
 mub: onp.ToBool2D = "illegal"  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+muj: onp.ToJustInt2D = "illegal"  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
 mui: onp.ToInt2D = "illegal"  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
 muf: onp.ToFloat2D = "illegal"  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
 muc: onp.ToComplex2D = "illegal"  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
 
 # tensors
 tb: onp.ToBoolND = arr_b
+tj: onp.ToJustIntND = arr_i
 ti: onp.ToIntND = arr_i
 tf: onp.ToFloatND = arr_f
 tc: onp.ToComplexND = arr_c
 
-tmb: onp.ToBoolND = mat_b
-tmi: onp.ToIntND = mat_i
-tmf: onp.ToFloatND = mat_f
-tmc: onp.ToComplexND = mat_c
+ttbj: onp.ToJustIntND = tb  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+ttbi: onp.ToIntND = tb
+ttbf: onp.ToFloatND = tb
+ttif: onp.ToFloatND = ti
+ttbc: onp.ToComplexND = tb
+ttic: onp.ToComplexND = ti
+ttfc: onp.ToComplexND = tf
 
-tvb: onp.ToBoolND = vec_b
-tvi: onp.ToIntND = vec_i
-tvf: onp.ToFloatND = vec_f
-tvc: onp.ToComplexND = vec_c
+tmb: onp.ToBoolND = mb
+tmj: onp.ToJustIntND = mj
+tmi: onp.ToIntND = mi
+tmf: onp.ToFloatND = mf
+tmc: onp.ToComplexND = mc
+
+tvb: onp.ToBoolND = vb
+tvj: onp.ToJustIntND = vj
+tvi: onp.ToIntND = vi
+tvf: onp.ToFloatND = vf
+tvc: onp.ToComplexND = vc
 
 tsb: onp.ToBoolND = True  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+tsj: onp.ToJustIntND = 42  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
 tsi: onp.ToIntND = 42  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
 tsf: onp.ToFloatND = 42.0  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
 tsc: onp.ToComplexND = 42 + 0j  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
 
 tub: onp.ToBoolND = "illegal"  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+tuj: onp.ToJustIntND = "illegal"  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
 tui: onp.ToIntND = "illegal"  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
 tuf: onp.ToFloatND = "illegal"  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
 tuc: onp.ToComplexND = "illegal"  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]


### PR DESCRIPTION
unlike the `ToInt*` ones, the `ToJustInt*` types reject scalars/arrays of `builtins.bool` and `np.bool_`