### PR TITLE
`onp.To*Strict{1,2,3}D`: array-like aliases with strict shape-type

### DIFF
--- a/README.md
+++ b/README.md
@@ -2554,7 +2554,7 @@ matrix-likes, and cuboid-likes, and the `To{}` aliases for "bare" scalar types.
     <th align="center" colspan="2">scalar types</th>
     <th align="center">scalar-like</th>
     <th align="center"><code>{1,2,3}</code>-d array-like</th>
-    <th align="center"><code>N</code>-d array-like</th>
+    <th align="center"><code>*</code>-d array-like</th>
 </tr>
 <tr>
     <th align="left">
@@ -2562,14 +2562,14 @@ matrix-likes, and cuboid-likes, and the `To{}` aliases for "bare" scalar types.
         <a href="#optypetyping"><code>optype.typing</code></a>
     </th>
     <th align="left"><code>numpy</code></th>
-    <th align="left" colspan="4"><code>optype.numpy</code></th>
+    <th align="center" colspan="4"><code>optype.numpy</code></th>
 </tr>
 <tr><td colspan="5"></td></tr>
 <tr>
     <td align="left"><code>bool</code></td>
     <td align="left"><code>bool_</code></td>
     <td align="left"><code>ToBool</code></td>
-    <td align="left"><code>ToBool{1,2,3}D</code></td>
+    <td align="left"><code>ToBool[strict]{1,2,3}D</code></td>
     <td align="left"><code>ToBoolND</code></td>
 </tr>
 <tr><td colspan="6"></td></tr>
@@ -2581,7 +2581,7 @@ matrix-likes, and cuboid-likes, and the `To{}` aliases for "bare" scalar types.
         <code>integer</code>
     </td>
     <td align="left"><code>ToJustInt</code></td>
-    <td align="left"><code>ToJustInt{1,2,3}D</code></td>
+    <td align="left"><code>ToJustInt[strict]{1,2,3}D</code></td>
     <td align="left"><code>ToJustIntND</code></td>
 </tr>
 <tr><td colspan="6"></td></tr>
@@ -2592,7 +2592,7 @@ matrix-likes, and cuboid-likes, and the `To{}` aliases for "bare" scalar types.
         <code>| bool_</code>
     </td>
     <td align="left"><code>ToInt</code></td>
-    <td align="left"><code>ToInt{1,2,3}D</code></td>
+    <td align="left"><code>ToInt[strict]{1,2,3}D</code></td>
     <td align="left"><code>ToIntND</code></td>
 </tr>
 <tr><td colspan="6"></td></tr>
@@ -2607,7 +2607,7 @@ matrix-likes, and cuboid-likes, and the `To{}` aliases for "bare" scalar types.
         <code>| bool_</code>
     </td>
     <td align="left"><code>ToFloat</code></td>
-    <td align="left"><code>ToFloat{1,2,3}D</code></td>
+    <td align="left"><code>ToFloat[strict]{1,2,3}D</code></td>
     <td align="left"><code>ToFloatND</code></td>
 </tr>
 <tr><td colspan="6"></td></tr>
@@ -2622,7 +2622,7 @@ matrix-likes, and cuboid-likes, and the `To{}` aliases for "bare" scalar types.
         <code>| bool_</code>
     </td>
     <td align="left"><code>ToComplex</code></td>
-    <td align="left"><code>ToComplex{1,2,3}D</code></td>
+    <td align="left"><code>ToComplex[strict]{1,2,3}D</code></td>
     <td align="left"><code>ToComplexND</code></td>
 </tr>
 <tr><td colspan="6"></td></tr>
@@ -2636,10 +2636,19 @@ matrix-likes, and cuboid-likes, and the `To{}` aliases for "bare" scalar types.
     </td>
     <td align="left"><code>generic</code></td>
     <td align="left"><code>ToScalar</code></td>
-    <td align="left"><code>ToArray{1,2,3}D</code></td>
+    <td align="left"><code>ToArray[strict]{1,2,3}D</code></td>
     <td align="left"><code>ToArrayND</code></td>
 </tr>
 </table>
+
+> [!NOTE]
+> The `To*Strict{1,2,3}D` aliases were added in `optype 0.7.3`.
+>
+> These array-likes with *strict shape-type* require the shape-typed input to be
+> shape-typed.
+> This means that e.g. `ToFloat1D` and `ToFloat2D` are disjoint (non-overlapping),
+> and makes them suitable to overload array-likes of a particular dtype for different
+> numbers of dimensions.
 
 Source code: [`optype/numpy/_to.py`][CODE-NP-TO]
 

--- a/optype/numpy/_to.py
+++ b/optype/numpy/_to.py
@@ -7,7 +7,7 @@ import numpy as np
 
 import optype.typing as opt
 
-from ._array import CanArrayND
+from ._array import CanArray1D, CanArray2D, CanArray3D, CanArrayND
 from ._scalar import floating, integer, number
 from ._sequence_nd import SequenceND
 
@@ -19,12 +19,53 @@ else:
 
 
 __all__ = [
-    "ToArray1D", "ToArray2D", "ToArray3D", "ToArrayND",
-    "ToBool", "ToBool1D", "ToBool2D", "ToBool3D", "ToBoolND",
-    "ToComplex", "ToComplex1D", "ToComplex2D", "ToComplex3D", "ToComplexND",
-    "ToFloat", "ToFloat1D", "ToFloat2D", "ToFloat3D", "ToFloatND",
-    "ToInt", "ToInt1D", "ToInt2D", "ToInt3D", "ToIntND",
-    "ToJustInt", "ToJustInt1D", "ToJustInt2D", "ToJustInt3D", "ToJustIntND",
+    "ToArray1D",
+    "ToArray2D",
+    "ToArray3D",
+    "ToArrayND",
+    "ToArrayStrict1D",
+    "ToArrayStrict2D",
+    "ToArrayStrict3D",
+    "ToBool",
+    "ToBool1D",
+    "ToBool2D",
+    "ToBool3D",
+    "ToBoolND",
+    "ToBoolStrict1D",
+    "ToBoolStrict2D",
+    "ToBoolStrict3D",
+    "ToComplex",
+    "ToComplex1D",
+    "ToComplex2D",
+    "ToComplex3D",
+    "ToComplexND",
+    "ToComplexStrict1D",
+    "ToComplexStrict2D",
+    "ToComplexStrict3D",
+    "ToFloat",
+    "ToFloat1D",
+    "ToFloat2D",
+    "ToFloat3D",
+    "ToFloatND",
+    "ToFloatStrict1D",
+    "ToFloatStrict2D",
+    "ToFloatStrict3D",
+    "ToInt",
+    "ToInt1D",
+    "ToInt2D",
+    "ToInt3D",
+    "ToIntND",
+    "ToIntStrict1D",
+    "ToIntStrict2D",
+    "ToIntStrict3D",
+    "ToJustInt",
+    "ToJustInt1D",
+    "ToJustInt2D",
+    "ToJustInt3D",
+    "ToJustIntND",
+    "ToJustIntStrict1D",
+    "ToJustIntStrict2D",
+    "ToJustIntStrict3D",
     "ToScalar",
 ]  # fmt: skip
 
@@ -36,11 +77,23 @@ _To1D = TypeAliasType(
     CanArrayND[ST] | Seq[ST | T],
     type_params=(ST, T),
 )
+_ToStrict1D = TypeAliasType(
+    "_ToStrict1D",
+    CanArray1D[ST] | Seq[ST | T],
+    type_params=(ST, T),
+)
+
 _To2D = TypeAliasType(
     "_To2D",
     CanArrayND[ST] | Seq[CanArrayND[ST]] | Seq[Seq[ST | T]],
     type_params=(ST, T),
 )
+_ToStrict2D = TypeAliasType(
+    "_ToStrict2D",
+    CanArray2D[ST] | Seq[CanArray1D[ST]] | Seq[Seq[ST | T]],
+    type_params=(ST, T),
+)
+
 _To3D = TypeAliasType(
     "_To3D",
     (
@@ -51,12 +104,23 @@ _To3D = TypeAliasType(
     ),
     type_params=(ST, T),
 )
+_ToStrict3D = TypeAliasType(
+    "_ToStrict3D",
+    (
+        CanArray3D[ST]
+        | Seq[CanArray2D[ST]]
+        | Seq[Seq[CanArray1D[ST]]]
+        | Seq[Seq[Seq[ST | T]]]
+    ),
+    type_params=(ST, T),
+)
+
 # recursive sequence type cannot be used due to a mypy bug:
 # https://github.com/python/mypy/issues/18184
 _ToND: TypeAlias = CanArrayND[ST] | SequenceND[T | ST] | SequenceND[CanArrayND[ST]]
 
 _PyBool: TypeAlias = bool | Literal[0, 1]  # 0 and 1 are sometimes used as bool values
-_PyScalar: TypeAlias = complex | bytes | str  # `complex` somehow includes `float | int`
+_PyScalar: TypeAlias = complex | bytes | str  # `complex` equivs `complex | float | int`
 
 _Int = TypeAliasType("_Int", integer | np.bool_)
 _Float = TypeAliasType("_Float", floating | integer | np.bool_)
@@ -64,36 +128,54 @@ _Complex = TypeAliasType("_Complex", number | np.bool_)
 
 ToScalar: TypeAlias = np.generic | _PyScalar
 ToArray1D: TypeAlias = _To1D[np.generic, _PyScalar]
+ToArrayStrict1D: TypeAlias = _ToStrict1D[np.generic, _PyScalar]
 ToArray2D: TypeAlias = _To2D[np.generic, _PyScalar]
+ToArrayStrict2D: TypeAlias = _ToStrict2D[np.generic, _PyScalar]
 ToArray3D: TypeAlias = _To3D[np.generic, _PyScalar]
+ToArrayStrict3D: TypeAlias = _ToStrict3D[np.generic, _PyScalar]
 ToArrayND: TypeAlias = _ToND[np.generic, _PyScalar]
 
 ToBool: TypeAlias = np.bool_ | _PyBool
 ToBool1D: TypeAlias = _To1D[np.bool_, _PyBool]
+ToBoolStrict1D: TypeAlias = _ToStrict1D[np.bool_, _PyBool]
 ToBool2D: TypeAlias = _To2D[np.bool_, _PyBool]
+ToBoolStrict2D: TypeAlias = _ToStrict2D[np.bool_, _PyBool]
 ToBool3D: TypeAlias = _To3D[np.bool_, _PyBool]
+ToBoolStrict3D: TypeAlias = _ToStrict3D[np.bool_, _PyBool]
 ToBoolND: TypeAlias = _ToND[np.bool_, _PyBool]
 
 ToJustInt: TypeAlias = integer | opt.JustInt
 ToJustInt1D: TypeAlias = _To1D[integer, opt.JustInt]
+ToJustIntStrict1D: TypeAlias = _ToStrict1D[integer, opt.JustInt]
 ToJustInt2D: TypeAlias = _To2D[integer, opt.JustInt]
+ToJustIntStrict2D: TypeAlias = _ToStrict2D[integer, opt.JustInt]
 ToJustInt3D: TypeAlias = _To3D[integer, opt.JustInt]
+ToJustIntStrict3D: TypeAlias = _ToStrict3D[integer, opt.JustInt]
 ToJustIntND: TypeAlias = _ToND[integer, opt.JustInt]
 
 ToInt: TypeAlias = _Int | int
 ToInt1D: TypeAlias = _To1D[_Int, int]
+ToIntStrict1D: TypeAlias = _ToStrict1D[_Int, int]
 ToInt2D: TypeAlias = _To2D[_Int, int]
+ToIntStrict2D: TypeAlias = _ToStrict2D[_Int, int]
 ToInt3D: TypeAlias = _To3D[_Int, int]
+ToIntStrict3D: TypeAlias = _ToStrict3D[_Int, int]
 ToIntND: TypeAlias = _ToND[_Int, int]
 
 ToFloat: TypeAlias = _Float | float
 ToFloat1D: TypeAlias = _To1D[_Float, float]
+ToFloatStrict1D: TypeAlias = _ToStrict1D[_Float, float]
 ToFloat2D: TypeAlias = _To2D[_Float, float]
+ToFloatStrict2D: TypeAlias = _ToStrict2D[_Float, float]
 ToFloat3D: TypeAlias = _To3D[_Float, float]
+ToFloatStrict3D: TypeAlias = _ToStrict3D[_Float, float]
 ToFloatND: TypeAlias = _ToND[_Float, float]
 
 ToComplex: TypeAlias = _Complex | complex
 ToComplex1D: TypeAlias = _To1D[_Complex, complex]
+ToComplexStrict1D: TypeAlias = _ToStrict1D[_Complex, complex]
 ToComplex2D: TypeAlias = _To2D[_Complex, complex]
+ToComplexStrict2D: TypeAlias = _ToStrict2D[_Complex, complex]
 ToComplex3D: TypeAlias = _To3D[_Complex, complex]
+ToComplexStrict3D: TypeAlias = _ToStrict3D[_Complex, complex]
 ToComplexND: TypeAlias = _ToND[_Complex, complex]


### PR DESCRIPTION
This adds the following type aliases to `optype.numpy`

- `ToBoolStrict{1,2,3}D`
- `ToIntStrict{1,2,3}D`
- `ToFloatStrict{1,2,3}D`
- `ToComplexStrict{1,2,3}D`
- `ToArrayStrict{1,2,3}D`

These are completely disjoint (i.e. non-overlapping), which makes them suitable for defining shape-type specific overloads on array-like input.