### PR TITLE
0-d numpy array aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -2311,9 +2311,9 @@ type ArrayND[
 </tr>
 </table>
 
-Additionally, there are the three `Array{1,2,3}D[ST: generic]` aliases, which are
-equivalent to `Array` with `tuple[int]`, `tuple[int, int]` and `tuple[int, int, int]` as
-shape-type, respectively.
+Additionally, there are the three `Array{0,1,2,3}D[ST: generic]` aliases, which are
+equivalent to `Array` with `tuple[()]`, `tuple[int]`, `tuple[int, int]` and
+`tuple[int, int, int]` as shape-type, respectively.
 
 [^1]: Since `numpy>=2.2` the `NDArray` alias uses `tuple[int, ...]` as shape-type
     instead of `Any`.

--- a/optype/numpy/_array.py
+++ b/optype/numpy/_array.py
@@ -27,12 +27,14 @@ if TYPE_CHECKING:
 
 __all__ = [
     "Array",
+    "Array0D",
     "Array1D",
     "Array1D",
     "Array2D",
     "Array3D",
     "ArrayND",
     "CanArray",
+    "CanArray0D",
     "CanArray1D",
     "CanArray2D",
     "CanArray3D",
@@ -97,6 +99,11 @@ type ArrayND[
 ] = np.ndarray[ND, np.dtype[ST]]
 """
 
+Array0D = TypeAliasType(
+    "Array0D",
+    np.ndarray[tuple[()], np.dtype[_SCT]],
+    type_params=(_SCT,),
+)
 Array1D = TypeAliasType(
     "Array1D",
     np.ndarray[tuple[int], np.dtype[_SCT]],
@@ -151,6 +158,19 @@ else:
 
         def __len__(self, /) -> int: ...
         def __array__(self, /) -> np.ndarray[_NDT_any, np.dtype[_SCT_co]]: ...
+
+
+@runtime_checkable
+@set_module("optype.numpy")
+class CanArray0D(Protocol[_SCT_co]):
+    """
+    The 0-d variant of `optype.numpy.CanArrayND`.
+
+    This accepts e.g. `np.asarray(3.14)`, but rejects `np.float64(3.14)`.
+    """
+
+    def __len__(self, /) -> int: ...  # always 0
+    def __array__(self, /) -> np.ndarray[tuple[()], np.dtype[_SCT_co]]: ...
 
 
 @runtime_checkable


### PR DESCRIPTION
This adds the following type-aliases to `optype.numpy`:

- `Array0D`
- `CanArray0D`

Note that both only accept `np.ndarray` and reject "bare" scalars (i.e. `np.generic` subtype instances).

resolves #200