### PR TITLE
accept more valid numpy array-likes in `optype.numpy.To*{1,2,3,N}`

### DIFF
--- a/optype/numpy/_to.py
+++ b/optype/numpy/_to.py
@@ -7,9 +7,9 @@ import numpy as np
 
 import optype.typing as opt
 
-from ._array import CanArray1D, CanArray2D, CanArray3D, CanArrayND
+from ._array import CanArray0D, CanArray1D, CanArray2D, CanArray3D, CanArrayND
 from ._scalar import floating, integer, number
-from ._sequence_nd import SequenceND
+from ._sequence_nd import SequenceND as SeqND
 
 
 if sys.version_info >= (3, 13):
@@ -69,55 +69,37 @@ __all__ = [
     "ToScalar",
 ]  # fmt: skip
 
-ST = TypeVar("ST", bound=np.generic)
-T = TypeVar("T")
 
-_To1D = TypeAliasType(
-    "_To1D",
-    CanArrayND[ST] | Seq[ST | T],
-    type_params=(ST, T),
+V = TypeVar("V")
+S = TypeVar("S", bound=np.generic)
+
+_To0D: TypeAlias = V | S | CanArray0D[S]
+
+_To1D = TypeAliasType("_To1D", CanArrayND[S] | Seq[_To0D[V, S]], type_params=(V, S))
+_To2D = TypeAliasType("_To2D", CanArrayND[S] | Seq[_To1D[V, S]], type_params=(V, S))
+_To3D = TypeAliasType("_To3D", CanArrayND[S] | Seq[_To2D[V, S]], type_params=(V, S))
+_ToND = TypeAliasType(
+    "_ToND",
+    CanArrayND[S] | SeqND[CanArrayND[S]] | SeqND[_To0D[V, S]],
+    type_params=(V, S),
 )
+
 _ToStrict1D = TypeAliasType(
     "_ToStrict1D",
-    CanArray1D[ST] | Seq[ST | T],
-    type_params=(ST, T),
-)
-
-_To2D = TypeAliasType(
-    "_To2D",
-    CanArrayND[ST] | Seq[CanArrayND[ST]] | Seq[Seq[ST | T]],
-    type_params=(ST, T),
+    CanArray1D[S] | Seq[_To0D[V, S]],
+    type_params=(V, S),
 )
 _ToStrict2D = TypeAliasType(
     "_ToStrict2D",
-    CanArray2D[ST] | Seq[CanArray1D[ST]] | Seq[Seq[ST | T]],
-    type_params=(ST, T),
-)
-
-_To3D = TypeAliasType(
-    "_To3D",
-    (
-        CanArrayND[ST]
-        | Seq[CanArrayND[ST]]
-        | Seq[Seq[CanArrayND[ST]]]
-        | Seq[Seq[Seq[ST | T]]]
-    ),
-    type_params=(ST, T),
+    CanArray2D[S] | Seq[_ToStrict1D[V, S]],
+    type_params=(V, S),
 )
 _ToStrict3D = TypeAliasType(
     "_ToStrict3D",
-    (
-        CanArray3D[ST]
-        | Seq[CanArray2D[ST]]
-        | Seq[Seq[CanArray1D[ST]]]
-        | Seq[Seq[Seq[ST | T]]]
-    ),
-    type_params=(ST, T),
+    CanArray3D[S] | Seq[_ToStrict2D[V, S]],
+    type_params=(V, S),
 )
 
-# recursive sequence type cannot be used due to a mypy bug:
-# https://github.com/python/mypy/issues/18184
-_ToND: TypeAlias = CanArrayND[ST] | SequenceND[T | ST] | SequenceND[CanArrayND[ST]]
 
 _PyBool: TypeAlias = bool | Literal[0, 1]  # 0 and 1 are sometimes used as bool values
 _PyScalar: TypeAlias = complex | bytes | str  # `complex` equivs `complex | float | int`
@@ -126,56 +108,56 @@ _Int = TypeAliasType("_Int", integer | np.bool_)
 _Float = TypeAliasType("_Float", floating | integer | np.bool_)
 _Complex = TypeAliasType("_Complex", number | np.bool_)
 
-ToScalar: TypeAlias = np.generic | _PyScalar
-ToArray1D: TypeAlias = _To1D[np.generic, _PyScalar]
-ToArrayStrict1D: TypeAlias = _ToStrict1D[np.generic, _PyScalar]
-ToArray2D: TypeAlias = _To2D[np.generic, _PyScalar]
-ToArrayStrict2D: TypeAlias = _ToStrict2D[np.generic, _PyScalar]
-ToArray3D: TypeAlias = _To3D[np.generic, _PyScalar]
-ToArrayStrict3D: TypeAlias = _ToStrict3D[np.generic, _PyScalar]
-ToArrayND: TypeAlias = _ToND[np.generic, _PyScalar]
+ToScalar: TypeAlias = _PyScalar | np.generic
+ToArray1D: TypeAlias = _To1D[_PyScalar, np.generic]
+ToArray2D: TypeAlias = _To2D[_PyScalar, np.generic]
+ToArray3D: TypeAlias = _To3D[_PyScalar, np.generic]
+ToArrayND: TypeAlias = _ToND[_PyScalar, np.generic]
+ToArrayStrict1D: TypeAlias = _ToStrict1D[_PyScalar, np.generic]
+ToArrayStrict2D: TypeAlias = _ToStrict2D[_PyScalar, np.generic]
+ToArrayStrict3D: TypeAlias = _ToStrict3D[_PyScalar, np.generic]
 
-ToBool: TypeAlias = np.bool_ | _PyBool
-ToBool1D: TypeAlias = _To1D[np.bool_, _PyBool]
-ToBoolStrict1D: TypeAlias = _ToStrict1D[np.bool_, _PyBool]
-ToBool2D: TypeAlias = _To2D[np.bool_, _PyBool]
-ToBoolStrict2D: TypeAlias = _ToStrict2D[np.bool_, _PyBool]
-ToBool3D: TypeAlias = _To3D[np.bool_, _PyBool]
-ToBoolStrict3D: TypeAlias = _ToStrict3D[np.bool_, _PyBool]
-ToBoolND: TypeAlias = _ToND[np.bool_, _PyBool]
+ToBool: TypeAlias = _PyBool | np.bool_
+ToBool1D: TypeAlias = _To1D[_PyBool, np.bool_]
+ToBool2D: TypeAlias = _To2D[_PyBool, np.bool_]
+ToBool3D: TypeAlias = _To3D[_PyBool, np.bool_]
+ToBoolND: TypeAlias = _ToND[_PyBool, np.bool_]
+ToBoolStrict1D: TypeAlias = _ToStrict1D[_PyBool, np.bool_]
+ToBoolStrict2D: TypeAlias = _ToStrict2D[_PyBool, np.bool_]
+ToBoolStrict3D: TypeAlias = _ToStrict3D[_PyBool, np.bool_]
 
-ToJustInt: TypeAlias = integer | opt.JustInt
-ToJustInt1D: TypeAlias = _To1D[integer, opt.JustInt]
-ToJustIntStrict1D: TypeAlias = _ToStrict1D[integer, opt.JustInt]
-ToJustInt2D: TypeAlias = _To2D[integer, opt.JustInt]
-ToJustIntStrict2D: TypeAlias = _ToStrict2D[integer, opt.JustInt]
-ToJustInt3D: TypeAlias = _To3D[integer, opt.JustInt]
-ToJustIntStrict3D: TypeAlias = _ToStrict3D[integer, opt.JustInt]
-ToJustIntND: TypeAlias = _ToND[integer, opt.JustInt]
+ToJustInt: TypeAlias = opt.JustInt | integer
+ToJustInt1D: TypeAlias = _To1D[opt.JustInt, integer]
+ToJustInt2D: TypeAlias = _To2D[opt.JustInt, integer]
+ToJustInt3D: TypeAlias = _To3D[opt.JustInt, integer]
+ToJustIntND: TypeAlias = _ToND[opt.JustInt, integer]
+ToJustIntStrict1D: TypeAlias = _ToStrict1D[opt.JustInt, integer]
+ToJustIntStrict3D: TypeAlias = _ToStrict3D[opt.JustInt, integer]
+ToJustIntStrict2D: TypeAlias = _ToStrict2D[opt.JustInt, integer]
 
-ToInt: TypeAlias = _Int | int
-ToInt1D: TypeAlias = _To1D[_Int, int]
-ToIntStrict1D: TypeAlias = _ToStrict1D[_Int, int]
-ToInt2D: TypeAlias = _To2D[_Int, int]
-ToIntStrict2D: TypeAlias = _ToStrict2D[_Int, int]
-ToInt3D: TypeAlias = _To3D[_Int, int]
-ToIntStrict3D: TypeAlias = _ToStrict3D[_Int, int]
-ToIntND: TypeAlias = _ToND[_Int, int]
+ToInt: TypeAlias = int | _Int
+ToInt1D: TypeAlias = _To1D[int, _Int]
+ToInt2D: TypeAlias = _To2D[int, _Int]
+ToInt3D: TypeAlias = _To3D[int, _Int]
+ToIntND: TypeAlias = _ToND[int, _Int]
+ToIntStrict1D: TypeAlias = _ToStrict1D[int, _Int]
+ToIntStrict2D: TypeAlias = _ToStrict2D[int, _Int]
+ToIntStrict3D: TypeAlias = _ToStrict3D[int, _Int]
 
-ToFloat: TypeAlias = _Float | float
-ToFloat1D: TypeAlias = _To1D[_Float, float]
-ToFloatStrict1D: TypeAlias = _ToStrict1D[_Float, float]
-ToFloat2D: TypeAlias = _To2D[_Float, float]
-ToFloatStrict2D: TypeAlias = _ToStrict2D[_Float, float]
-ToFloat3D: TypeAlias = _To3D[_Float, float]
-ToFloatStrict3D: TypeAlias = _ToStrict3D[_Float, float]
-ToFloatND: TypeAlias = _ToND[_Float, float]
+ToFloat: TypeAlias = float | _Float
+ToFloat1D: TypeAlias = _To1D[float, _Float]
+ToFloat2D: TypeAlias = _To2D[float, _Float]
+ToFloat3D: TypeAlias = _To3D[float, _Float]
+ToFloatND: TypeAlias = _ToND[float, _Float]
+ToFloatStrict1D: TypeAlias = _ToStrict1D[float, _Float]
+ToFloatStrict2D: TypeAlias = _ToStrict2D[float, _Float]
+ToFloatStrict3D: TypeAlias = _ToStrict3D[float, _Float]
 
-ToComplex: TypeAlias = _Complex | complex
-ToComplex1D: TypeAlias = _To1D[_Complex, complex]
-ToComplexStrict1D: TypeAlias = _ToStrict1D[_Complex, complex]
-ToComplex2D: TypeAlias = _To2D[_Complex, complex]
-ToComplexStrict2D: TypeAlias = _ToStrict2D[_Complex, complex]
-ToComplex3D: TypeAlias = _To3D[_Complex, complex]
-ToComplexStrict3D: TypeAlias = _ToStrict3D[_Complex, complex]
-ToComplexND: TypeAlias = _ToND[_Complex, complex]
+ToComplex: TypeAlias = complex | _Complex
+ToComplex1D: TypeAlias = _To1D[complex, _Complex]
+ToComplex2D: TypeAlias = _To2D[complex, _Complex]
+ToComplex3D: TypeAlias = _To3D[complex, _Complex]
+ToComplexND: TypeAlias = _ToND[complex, _Complex]
+ToComplexStrict1D: TypeAlias = _ToStrict1D[complex, _Complex]
+ToComplexStrict2D: TypeAlias = _ToStrict2D[complex, _Complex]
+ToComplexStrict3D: TypeAlias = _ToStrict3D[complex, _Complex]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -249,6 +249,8 @@ force-exclude = true
         "F841",     # unused-variable
         # flake8-annotations
         "ANN201",   # missing-return-type
+        # flake8-pyi
+        "PYI015",
         # flake8-self
         "SLF001",   # private-member-access
         # pylint

--- a/tests/numpy/test_to.pyi
+++ b/tests/numpy/test_to.pyi
@@ -1,119 +1,170 @@
-# ruff: noqa: PYI015
+from collections.abc import Sequence as Seq
+from typing import Any, TypeAlias
+
 import numpy as np
 
 import optype.numpy as onp
 
-vec_b: onp.Array1D[np.bool] | list[bool | np.bool_]
-vec_i: onp.Array1D[np.intp] | list[int | np.intp] | range
-vec_f: onp.Array1D[np.longdouble] | list[float | np.longdouble] | range
-vec_c: onp.Array1D[np.clongdouble] | list[complex | np.clongdouble] | range
+# setup
 
-mat_b: onp.Array2D[np.bool] | list[list[bool | np.bool_]]
-mat_i: onp.Array2D[np.intp] | list[list[int | np.intp]]
-mat_f: onp.Array2D[np.longdouble] | list[list[float | np.longdouble]]
-mat_c: onp.Array2D[np.clongdouble] | list[list[complex | np.clongdouble]]
+_Scalar_b: TypeAlias = np.bool_
+_Scalar_j: TypeAlias = np.integer[Any]  # pyright: ignore[reportExplicitAny]
+_Scalar_i: TypeAlias = _Scalar_j | _Scalar_b
+_Scalar_f: TypeAlias = np.floating[Any] | _Scalar_i  # pyright: ignore[reportExplicitAny]
+_Scalar_c: TypeAlias = np.number[Any] | _Scalar_b  # pyright: ignore[reportExplicitAny]
+_Scalar_x: TypeAlias = np.generic
 
-arr_b: onp.ArrayND[np.bool] | list[list[list[bool | np.bool_]]]
-arr_i: onp.ArrayND[np.intp] | list[list[list[int | np.intp]]]
-arr_f: onp.ArrayND[np.longdouble] | list[list[list[float | np.longdouble]]]
-arr_c: onp.ArrayND[np.clongdouble] | list[list[list[complex | np.clongdouble]]]
+_Value_b: TypeAlias = _Scalar_b | bool
+_Value_j: TypeAlias = _Scalar_j | int
+_Value_i: TypeAlias = _Scalar_i | int
+_Value_f: TypeAlias = _Scalar_f | float
+_Value_c: TypeAlias = _Scalar_c | complex
+_Value_x: TypeAlias = _Scalar_x | complex | bytes | str
 
-# scalars
+_Array0_b: TypeAlias = onp.CanArray0D[_Scalar_b]
+_Array0_j: TypeAlias = onp.CanArray0D[_Scalar_j]
+_Array0_i: TypeAlias = onp.CanArray0D[_Scalar_i]
+_Array0_f: TypeAlias = onp.CanArray0D[_Scalar_f]
+_Array0_c: TypeAlias = onp.CanArray0D[_Scalar_c]
+_Array0_x: TypeAlias = onp.CanArray0D[_Scalar_x]
 
-sb0: onp.ToBool = True
-sb1: onp.ToBool = np.True_
+_Array1_b: TypeAlias = onp.CanArray1D[_Scalar_b] | Seq[_Array0_b | _Value_b]
+_Array1_j: TypeAlias = onp.CanArray1D[_Scalar_j] | Seq[_Array0_j | _Value_j]
+_Array1_i: TypeAlias = onp.CanArray1D[_Scalar_i] | Seq[_Array0_i | _Value_i]
+_Array1_f: TypeAlias = onp.CanArray1D[_Scalar_f] | Seq[_Array0_f | _Value_f]
+_Array1_c: TypeAlias = onp.CanArray1D[_Scalar_c] | Seq[_Array0_c | _Value_c]
+_Array1_x: TypeAlias = onp.CanArray1D[_Scalar_x] | Seq[_Array0_x | _Value_x]
 
-sj0: onp.ToJustInt = 42
-sj1: onp.ToJustInt = np.int_(42)
+_Array2_b: TypeAlias = onp.CanArray2D[_Scalar_b] | Seq[_Array1_b]
+_Array2_j: TypeAlias = onp.CanArray2D[_Scalar_j] | Seq[_Array1_j]
+_Array2_i: TypeAlias = onp.CanArray2D[_Scalar_i] | Seq[_Array1_i]
+_Array2_f: TypeAlias = onp.CanArray2D[_Scalar_f] | Seq[_Array1_f]
+_Array2_c: TypeAlias = onp.CanArray2D[_Scalar_c] | Seq[_Array1_c]
+_Array2_x: TypeAlias = onp.CanArray2D[_Scalar_x] | Seq[_Array1_x]
 
-si0: onp.ToInt = 42
-si1: onp.ToInt = np.int_(42)
+_Array3_b: TypeAlias = onp.CanArray3D[_Scalar_b] | Seq[_Array2_b]
+_Array3_j: TypeAlias = onp.CanArray3D[_Scalar_j] | Seq[_Array2_j]
+_Array3_i: TypeAlias = onp.CanArray3D[_Scalar_i] | Seq[_Array2_i]
+_Array3_f: TypeAlias = onp.CanArray3D[_Scalar_f] | Seq[_Array2_f]
+_Array3_c: TypeAlias = onp.CanArray3D[_Scalar_c] | Seq[_Array2_c]
+_Array3_x: TypeAlias = onp.CanArray3D[_Scalar_x] | Seq[_Array2_x]
 
-sf0: onp.ToFloat = 42.0
-sf1: onp.ToFloat = np.longdouble(42.0)
+b_: _Value_b
+j_: _Value_j
+i_: _Value_i
+f_: _Value_f
+c_: _Value_c
+x_: _Value_x
 
-sc0: onp.ToComplex = 42 + 0j
-sc1: onp.ToComplex = np.clongdouble(42.0 + 1j)
+b0: _Array0_b | _Value_b
+j0: _Array0_j | _Value_j
+i0: _Array0_i | _Value_i
+f0: _Array0_f | _Value_f
+c0: _Array0_c | _Value_c
+x0: _Array0_x | _Value_x
 
-# vectors
-vb: onp.ToBool1D = vec_b
-vj: onp.ToJustInt1D = vec_i
-vi: onp.ToInt1D = vec_i
-vf: onp.ToFloat1D = vec_f
-vc: onp.ToComplex1D = vec_c
+b1: _Array1_b
+j1: _Array1_j
+i1: _Array1_i
+f1: _Array1_f
+c1: _Array1_c
+x1: _Array1_x
 
-vsb: onp.ToBool1D = True  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
-vsj: onp.ToJustInt1D = 42  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
-vsi: onp.ToInt1D = 42  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
-vsf: onp.ToFloat1D = 42.0  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
-vsc: onp.ToComplex1D = 42 + 1j  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+b2: _Array2_b
+j2: _Array2_j
+i2: _Array2_i
+f2: _Array2_f
+c2: _Array2_c
+x2: _Array2_x
 
-vub: onp.ToBool1D = "illegal"  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
-vuj: onp.ToJustInt1D = "illegal"  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
-vui: onp.ToInt1D = "illegal"  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
-vuf: onp.ToFloat1D = "illegal"  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
-vuc: onp.ToComplex1D = "illegal"  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+b3: _Array3_b
+j3: _Array3_j
+i3: _Array3_i
+f3: _Array3_f
+c3: _Array3_c
+x3: _Array3_x
 
-# matrices
-mb: onp.ToBool2D = mat_b
-mj: onp.ToJustInt2D = mat_i
-mi: onp.ToInt2D = mat_i
-mf: onp.ToFloat2D = mat_f
-mc: onp.ToComplex2D = mat_c
+# scalar
 
-mvb: onp.ToBool2D = vec_b  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
-mvj: onp.ToJustInt2D = vec_i  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
-mvi: onp.ToInt2D = vec_i  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
-mvf: onp.ToFloat2D = vec_f  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
-mvc: onp.ToComplex2D = vec_c  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+# scalar :> scalar
+b__b_: onp.ToBool = b_
+j__j_: onp.ToJustInt = j_
+j__b_: onp.ToJustInt = b_  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+j__i_: onp.ToJustInt = i_  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+i__i_: onp.ToInt = i_
+f__f_: onp.ToFloat = f_
+c__c_: onp.ToComplex = c_
+x__x_: onp.ToScalar = x_
+# scalar :> 0-d (negative)
+b__b0: onp.ToBool = b0  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+j__j0: onp.ToJustInt = j0  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+i__i0: onp.ToInt = i0  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+f__f0: onp.ToFloat = f0  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+c__c0: onp.ToComplex = c0  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+x__x0: onp.ToScalar = x0  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
 
-msb: onp.ToBool2D = True  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
-msj: onp.ToJustInt2D = 42  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
-msi: onp.ToInt2D = 42  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
-msf: onp.ToFloat2D = 42.0  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
-msc: onp.ToComplex2D = 42 + 0j  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+# 1-d :> scalar (negative)
+b1_b_: onp.ToBool1D = b_  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+j1_j_: onp.ToJustInt1D = j_  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+i1_i_: onp.ToInt1D = i_  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+f1_f_: onp.ToFloat1D = f_  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+c1_c_: onp.ToComplex1D = c_  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+x1_x_: onp.ToArray1D = x_  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+# 1-d :> 1-d
+b1_b1: onp.ToBool1D = b1
+j1_j1: onp.ToJustInt1D = j1
+i1_i1: onp.ToInt1D = i1
+f1_f1: onp.ToFloat1D = f1
+c1_c1: onp.ToComplex1D = c1
+x1_x1: onp.ToArray1D = x1
+# 1-d :> 1-d [strict]
+b1s_b1: onp.ToBoolStrict1D = b1
+j1s_j1: onp.ToJustIntStrict1D = j1
+i1s_i1: onp.ToIntStrict1D = i1
+f1s_f1: onp.ToFloatStrict1D = f1
+c1s_c1: onp.ToComplexStrict1D = c1
+x1s_x1: onp.ToArrayStrict1D = x1
 
-mub: onp.ToBool2D = "illegal"  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
-muj: onp.ToJustInt2D = "illegal"  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
-mui: onp.ToInt2D = "illegal"  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
-muf: onp.ToFloat2D = "illegal"  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
-muz: onp.ToComplex2D = "illegal"  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+# 2-d :> 1-d (negative)
+b2_b1: onp.ToBool2D = b1  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+j2_j1: onp.ToJustInt2D = j1  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+i2_i1: onp.ToInt2D = i1  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+f2_f1: onp.ToFloat2D = f1  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+c2_c1: onp.ToComplex2D = c1  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+x2_x1: onp.ToArray2D = x1  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+# 2-d :> 2-d
+b2_b2: onp.ToBool2D = b2
+j2_j2: onp.ToJustInt2D = j2
+i2_i2: onp.ToInt2D = i2
+f2_f2: onp.ToFloat2D = f2
+c2_c2: onp.ToComplex2D = c2
+x2_x2: onp.ToArray2D = x2
+# 2-d :> 2-d [strict]
+b2s_b2: onp.ToBoolStrict2D = b2
+j2s_j2: onp.ToJustIntStrict2D = j2
+i2s_i2: onp.ToIntStrict2D = i2
+f2s_f2: onp.ToFloatStrict2D = f2
+c2s_c2: onp.ToComplexStrict2D = c2
+x2s_x2: onp.ToArrayStrict2D = x2
 
-# tensors
-tb: onp.ToBoolND = arr_b
-tj: onp.ToJustIntND = arr_i
-ti: onp.ToIntND = arr_i
-tf: onp.ToFloatND = arr_f
-tc: onp.ToComplexND = arr_c
-
-ttbj: onp.ToJustIntND = tb  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
-ttbi: onp.ToIntND = tb
-ttbf: onp.ToFloatND = tb
-ttif: onp.ToFloatND = ti
-ttbc: onp.ToComplexND = tb
-ttic: onp.ToComplexND = ti
-ttfc: onp.ToComplexND = tf
-
-tmb: onp.ToBoolND = mb
-tmj: onp.ToJustIntND = mj
-tmi: onp.ToIntND = mi
-tmf: onp.ToFloatND = mf
-tmc: onp.ToComplexND = mc
-
-tvb: onp.ToBoolND = vb
-tvj: onp.ToJustIntND = vj
-tvi: onp.ToIntND = vi
-tvf: onp.ToFloatND = vf
-tvc: onp.ToComplexND = vc
-
-tsb: onp.ToBoolND = True  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
-tsj: onp.ToJustIntND = 42  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
-tsi: onp.ToIntND = 42  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
-tsf: onp.ToFloatND = 42.0  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
-tsc: onp.ToComplexND = 42 + 0j  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
-
-tub: onp.ToBoolND = "illegal"  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
-tuj: onp.ToJustIntND = "illegal"  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
-tui: onp.ToIntND = "illegal"  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
-tuf: onp.ToFloatND = "illegal"  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
-tuc: onp.ToComplexND = "illegal"  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+# 3-d :> 2-d (negative)
+b3_b2: onp.ToBool3D = b2  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+j3_j2: onp.ToJustInt3D = j2  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+i3_i2: onp.ToInt3D = i2  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+f3_f2: onp.ToFloat3D = f2  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+c3_c2: onp.ToComplex3D = c2  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+x3_x2: onp.ToArray3D = x2  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+# 3-d :> 3-d
+b3_b3: onp.ToBool3D = b3
+j3_j3: onp.ToJustInt3D = j3
+i3_i3: onp.ToInt3D = i3
+f3_f3: onp.ToFloat3D = f3
+c3_c3: onp.ToComplex3D = c3
+x3_x3: onp.ToArray3D = x3
+# 3-d :> 3-d [strict]
+b3s_b3: onp.ToBoolStrict3D = b3
+j3s_j3: onp.ToJustIntStrict3D = j3
+i3s_i3: onp.ToIntStrict3D = i3
+f3s_f3: onp.ToFloatStrict3D = f3
+c3s_c3: onp.ToComplexStrict3D = c3
+x3s_x3: onp.ToArrayStrict3D = x3


### PR DESCRIPTION
These now also accept `CanArray0D` as scalars and combinations of sequences and ndarray's. 

Before this change, static type checkers would reject the following example.

```py
import optype.numpy as onp

three_0d: onp.Array0D[np.int_] = np.array(3, np.int_)
three_1d: onp.ToInt1D =  [3, np.int_(3), three_0d]
```

even though it was valid at runtime:

```pycon
>>> np.array([3, np.int_(3), np.array(3)])
array([3, 3, 3])
```

The tests for these aliases have also been improved.