### PR TITLE
bump `basedmypy` to `2.8.0` and `basedpyright` to `1.22.1`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,7 +40,7 @@ repos:
     hooks:
       - id: blacken-docs
         additional_dependencies:
-          - black==24.10.0
+          - black==24.10.*
 
   - repo: https://github.com/igorshubovych/markdownlint-cli
     rev: v0.43.0
@@ -48,7 +48,7 @@ repos:
       - id: markdownlint
 
   - repo: https://github.com/crate-ci/typos
-    rev: v1.28.1
+    rev: v1.28.2
     hooks:
       - id: typos
 

--- a/optype/_core/_can.py
+++ b/optype/_core/_can.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import sys
-from typing import TYPE_CHECKING, Literal, Protocol, TypeAlias
+from typing import TYPE_CHECKING, Protocol, TypeAlias
 
 
 if sys.version_info >= (3, 13):
@@ -45,13 +45,7 @@ _V_contra = TypeVar("_V_contra", contravariant=True)
 _V_co = TypeVar("_V_co", covariant=True)
 _VV_co = TypeVar("_VV_co", covariant=True, default=_V_co)
 
-_JustBoolT_co = TypeVar(
-    "_JustBoolT_co",
-    Literal[False], Literal[True], Literal[False, True], bool,  # noqa: RUF038
-    covariant=True,
-    default=bool,
-)  # fmt: skip
-
+_BoolT_co = TypeVar("_BoolT_co", bound=bool, default=bool, covariant=True)
 _IntT_contra = TypeVar("_IntT_contra", bound=int, contravariant=True, default=int)
 _IntT_co = TypeVar("_IntT_co", bound=int, covariant=True, default=int)
 _BytesT_co = TypeVar("_BytesT_co", bound=bytes, covariant=True, default=bytes)
@@ -73,8 +67,8 @@ _AnyNoneT_co = TypeVar("_AnyNoneT_co", covariant=True, default=None)
 
 @set_module("optype")
 @runtime_checkable
-class CanBool(Protocol[_JustBoolT_co]):
-    def __bool__(self, /) -> _JustBoolT_co: ...
+class CanBool(Protocol[_BoolT_co]):
+    def __bool__(self, /) -> _BoolT_co: ...
 
 
 @set_module("optype")
@@ -418,10 +412,10 @@ class CanReversed(Protocol[_T_co]):
 
 @set_module("optype")
 @runtime_checkable
-class CanContains(Protocol[_ObjectT_contra, _JustBoolT_co]):
+class CanContains(Protocol[_ObjectT_contra, _BoolT_co]):
     # usually the key is required to also be a hashable object, but this
     # isn't strictly required
-    def __contains__(self, key: _ObjectT_contra, /) -> _JustBoolT_co: ...
+    def __contains__(self, key: _ObjectT_contra, /) -> _BoolT_co: ...
 
 
 @set_module("optype")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,13 +46,13 @@ common = [
 ]
 type = [
     {include-group = "common"},
-    "basedmypy[faster-cache]>=2.7.0",
-    "basedpyright>=1.22.0",
+    "basedmypy[faster-cache]>=2.8.0",
+    "basedpyright>=1.22.1",
 ]
 test = [
     {include-group = "common"},
     "beartype>=0.19.0",
-    "pytest>=8.3.3",
+    "pytest>=8.3.4",
 ]
 typetest = [
     {include-group = "type"},

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -213,18 +213,14 @@ def test_just_custom() -> None:
 
     b_b: opt.Just[B] = b
     b_a: opt.Just[B] = a  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
-
-    # TODO: `pyright: ignore` after https://github.com/python/typeshed/issues/12997
-    b_c: opt.Just[B] = c  # type: ignore[assignment]
+    b_c: opt.Just[B] = c  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
 
 
 def test_just_object() -> None:
     class A: ...
 
     tn_object: opt.Just[object] = object()
-
-    # TODO: `pyright: ignore` after https://github.com/python/typeshed/issues/12997
-    tp_custom: opt.Just[object] = A()  # type: ignore[assignment]
+    tp_custom: opt.Just[object] = A()  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
 
 
 def test_just_int() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -3,7 +3,7 @@ requires-python = ">=3.10"
 
 [[package]]
 name = "basedmypy"
-version = "2.7.0"
+version = "2.8.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "basedtyping" },
@@ -11,29 +11,29 @@ dependencies = [
     { name = "tomli", marker = "python_full_version < '3.11'" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b1/1f/de937c1535462ebaba5b639215b33bd94e157a958f6e809e0f46ba6e8677/basedmypy-2.7.0.tar.gz", hash = "sha256:a8ff08c667d8ca06c6ab5acd574e683b557ce64671b2a0e0c2503979f1186411", size = 5435024 }
+sdist = { url = "https://files.pythonhosted.org/packages/3e/89/1fd8dd2fb827d183127f750f47c70bb7133d6b71bbe11607051ece352114/basedmypy-2.8.0.tar.gz", hash = "sha256:5ca42099197d042d69a487ea0075f1baff3d60570ee3fca688f8484ec9584e56", size = 5437221 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ab/67/e0ac30fa29643cb26ed3f291c6bf933c29637b2f487baae078b8e351cc80/basedmypy-2.7.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:283635cb57c917c7f88146e801005dc0034a74c25d48397bb65699e2359d1085", size = 11358422 },
-    { url = "https://files.pythonhosted.org/packages/55/7b/ef7c97422560f4e2ae9f2f5d76513142d8cd55a655b5ed29fe7069c2737e/basedmypy-2.7.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:5158709f8c04fdb0f62d97551ad75366f3838e5dd3db0ffd83c32c3b64867e7d", size = 10486231 },
-    { url = "https://files.pythonhosted.org/packages/9c/55/47bb0e39a4d3bf9cb0b226f10ba61be6fd09174022fd636966e1eb3c2032/basedmypy-2.7.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6d76a8ee5e755024dcfb4e1ec0309ae6f95a0330cd71151cbe956a6740da5bc8", size = 12961616 },
-    { url = "https://files.pythonhosted.org/packages/98/fd/3a91fe615fae65de1f5fbba60055fdd639a2671ef3d63e881ad86faffa87/basedmypy-2.7.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:0794aa3281bae1e88922223da6da5db9c6e495694bdc65cfc03acd97d1a94602", size = 13509169 },
-    { url = "https://files.pythonhosted.org/packages/42/c2/6b39b0fe1560fcde2b9310703baf9ba567a00a0b71ee376a40ea945ec57d/basedmypy-2.7.0-cp310-cp310-win_amd64.whl", hash = "sha256:58a75892e74a8679a54a18b8e5959ae8c1612e925ccb8ccc07a5e767c44eaf8d", size = 9922469 },
-    { url = "https://files.pythonhosted.org/packages/1f/f7/935e8249da989b1546cc0882ec81dc37595215a36d11c14a94770cdd5419/basedmypy-2.7.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f7a467856b12fc5b8085f065eaa36e1c08ea4e048a11777f47715dc4a9108e39", size = 11277220 },
-    { url = "https://files.pythonhosted.org/packages/e5/68/6769b01d4eefa6d60dba1123943a509728a45ceafd68d4a3f55258c84a1f/basedmypy-2.7.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:94988835eec3c886daeae717b5dc16befbd339b520bd3d1d005b562836530d21", size = 10408011 },
-    { url = "https://files.pythonhosted.org/packages/35/d7/23b31814e6d07aff02b4a9d05fb8840d0ff92cd4dbadd0c76e03da0ba744/basedmypy-2.7.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:cab30d2bfbba4e8bbd36b7bc1ea8811b40a062796edc653a8e4fd0881d4899e6", size = 12884427 },
-    { url = "https://files.pythonhosted.org/packages/68/66/cc7de13bb872836fb952710d59f18a6779f4c8b468708c312a0862d9fe46/basedmypy-2.7.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:40f2324c82e7befc94ad722fc3e0fe9362b7607b93d29ae7930831e30e22ff6a", size = 13384613 },
-    { url = "https://files.pythonhosted.org/packages/db/9a/758eb4e8fca3a60de7c70fab8cdc82f6b834efaa1259cad35550d8e80d97/basedmypy-2.7.0-cp311-cp311-win_amd64.whl", hash = "sha256:9470812c9a977d832bee52ebdd9b76bd30cea8f37f42ab1ce509e871b79996d3", size = 9916651 },
-    { url = "https://files.pythonhosted.org/packages/28/f8/91eb12e00aa8ab424adb4c7ac74451ab50c8e275adecb1297ead7d8e575a/basedmypy-2.7.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:678fc29448b87c92df4c035fac2ae53a8e675a3b29d46d08d6328147f95b4832", size = 11420273 },
-    { url = "https://files.pythonhosted.org/packages/b5/e3/753aa78fad1439f31bc911e39f31e919729d0541fa13852939886be0c1ec/basedmypy-2.7.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:5a770fb4e4714ef359b766dc29f44212f562ca387883c6ee5997cad2f4b6a838", size = 10373827 },
-    { url = "https://files.pythonhosted.org/packages/d1/4d/018b76e4dd3c12fde9502834c2ad10973a31097d60a37d47a1aa72bbe3da/basedmypy-2.7.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:91caccc79132091e62dce7d6927003dda5b6930deb50c18bdae2b19c22c1c924", size = 12976992 },
-    { url = "https://files.pythonhosted.org/packages/7d/7b/d4962e0361b395eccacc2b005806c0c3953744bc8126a5931ece8712e087/basedmypy-2.7.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:1e3f32699843071df47445e71d53495e4e120b2df6469cc7efb3837080b770ab", size = 13446050 },
-    { url = "https://files.pythonhosted.org/packages/f6/5e/e0c2c69f5e4f9b24381fc345112ad661d236c317bc8c76da8f673a0573f8/basedmypy-2.7.0-cp312-cp312-win_amd64.whl", hash = "sha256:f7f0e7d2f5bd943a7f3dfa6b314e0684d38fd7665f560bcec0c4958d2dd710d1", size = 10020738 },
-    { url = "https://files.pythonhosted.org/packages/8c/ff/4b999f7441c75ba5749a4f9fcd387c7c71fef0b940f3d8331bc90044f56d/basedmypy-2.7.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:4269027ee62f6ed4ded804e523a69a71eaec888ced8b6bc94c05b902b4dc970f", size = 11412795 },
-    { url = "https://files.pythonhosted.org/packages/d6/ff/c9a0be388eb2399e10955d50e8ee79ddd67686155c1d2b6f0c588fbfb5a8/basedmypy-2.7.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:ee773922a22a3aba0eb2ce8f9b8733e1b6086b7b75b885f887cff0f9746bf607", size = 10374562 },
-    { url = "https://files.pythonhosted.org/packages/4a/c0/57dd357faee7ef5172a3434565c823b84e6ec6625c7e80d9813e4e7b5e15/basedmypy-2.7.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fa155eb6506c2caf7296e97eb57e3870bc65e271af2582f2bb245b49acd283b0", size = 12970058 },
-    { url = "https://files.pythonhosted.org/packages/1c/11/558950128ae9b3ca1449e6e0716af850a5fa71f02b8c489d898bf01c4f9f/basedmypy-2.7.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:f938bc49ebe8ae81c1091f1934ac014b03464ead3cf93893b69f5da98c3ffbde", size = 13444481 },
-    { url = "https://files.pythonhosted.org/packages/e9/3c/c6243926f5710becd95abd6af4d496e04f03fe43d76d1ef50937399ec2ed/basedmypy-2.7.0-cp313-cp313-win_amd64.whl", hash = "sha256:0758a45dc099f57110b21fd480dae82d289620501acbbb2854db5d22d6dd7b2a", size = 10025002 },
-    { url = "https://files.pythonhosted.org/packages/48/aa/95f5d986b4b827372c74f7d7014c2740709ae269f05be8bd5b4b9a537cab/basedmypy-2.7.0-py3-none-any.whl", hash = "sha256:59661555a2637e0ece7ac65aca774451d60c3a9c1bd2613a96a067418fc381a7", size = 2686981 },
+    { url = "https://files.pythonhosted.org/packages/57/00/4b96b8dfc91c6325081c601687cb1238e56bc108bad177854bd9073116e9/basedmypy-2.8.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:26ce52469942912ce3e38e1ad51b91593b59a4772f678e0b17d3ce2e85a5de2e", size = 11367658 },
+    { url = "https://files.pythonhosted.org/packages/69/e2/8f6ad3fcd5f9d47c637634582d01f2040ec825c94867dc12155cd198babf/basedmypy-2.8.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:22bf3df434702a6c1e6ae6c565dee2702803971ab1caaf4743ff39cd11393834", size = 10491063 },
+    { url = "https://files.pythonhosted.org/packages/7f/13/a1cd896e4cb5009d5f455170ce934a42e03cd078fdbe5502134c38fb4ca5/basedmypy-2.8.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a1b8d2d5fc2e58c37790913dd9f8704c7f22661adb6eee99986953c79ff33bd0", size = 13029873 },
+    { url = "https://files.pythonhosted.org/packages/9d/3b/ccc5c56a2b51d51203b70b860582c87c8926587a89a77c777022a73998d6/basedmypy-2.8.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:ca64c2b52a26deaade41ef1bc5b13d75e03e429194a8e33b61aba9ebbc5cbcdc", size = 13216498 },
+    { url = "https://files.pythonhosted.org/packages/a5/42/6acb2fd7f32ac10d811a7534e7a65357acf02b5912a3eaac76044eaf8d46/basedmypy-2.8.0-cp310-cp310-win_amd64.whl", hash = "sha256:e2c9fa91b94f944934dea126b97e1db44173a96abacd9bf48be71a1f2d3ffcb0", size = 9925557 },
+    { url = "https://files.pythonhosted.org/packages/46/ba/1cdadaa977f501f992506ed58fffb45499ff6312b8c89b32bb4558d1a1e5/basedmypy-2.8.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:b2dc2ddca67e22f582dac01b27e7f1bd14405a17c41f6c0b64fdb823ecb3923a", size = 11287122 },
+    { url = "https://files.pythonhosted.org/packages/9d/ff/5fd042fdb7b372e46b46f2a3013e9afb8b657821107af4a5f68eb103a9bf/basedmypy-2.8.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:2e273d1a7686c23cef5c6986cf812a3a66adadbd6ca459029d931f9dd61c9069", size = 10416042 },
+    { url = "https://files.pythonhosted.org/packages/01/c7/c476b33d197b6f1678c5b7cf950909ecf4af750de33d07d49a3d67cf2c6a/basedmypy-2.8.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ae5268b3661f901d26bcd34dbf30f33906acd40ca87e44bc40bdbff623686178", size = 12943509 },
+    { url = "https://files.pythonhosted.org/packages/c8/48/ef21e628ecfc656ab06c7ea58e85697e65d299567eec64f0af17a1d7dfdf/basedmypy-2.8.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:a5a526c2516fb4045adf0e8f5af0c42edfc5f407b26c14a14d41877d3b3e849c", size = 13089967 },
+    { url = "https://files.pythonhosted.org/packages/a1/bd/a8f26ed5eee4ececd6ce438211f051d58d88de86cc0c84b9636235e1f4c1/basedmypy-2.8.0-cp311-cp311-win_amd64.whl", hash = "sha256:1020fa51e2db3300bc95e9bab242a04a85a8863c0f0776831a149eb703cd9d52", size = 9918897 },
+    { url = "https://files.pythonhosted.org/packages/35/d1/30d16db99a188f7b7ad2e1fd2ded66122ff96a7931e3198e8e631ca6e6f9/basedmypy-2.8.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:e39cfe9b3c2f7cbbc66933ed4002ae10ff3984ce75350b5cb37b49829e81c1d1", size = 11433787 },
+    { url = "https://files.pythonhosted.org/packages/d5/9a/1bdcbe72a19f0e784ebdf7bd6b3b3f6d57beb20a033ff38ce934f3a3cd1c/basedmypy-2.8.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ce566a8255dfd6bda42cc371c247e6536e2e4a2fb6068f75172f1c06a031d03a", size = 10387443 },
+    { url = "https://files.pythonhosted.org/packages/be/ba/93ebd2c4091116974c813747b14206f144cea07cdd9ebb88f80a2149305e/basedmypy-2.8.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:68238f0ae59201755fe5e9e79c90f3cdaeff57f7bac03dd278a430b10ba8bb68", size = 13068359 },
+    { url = "https://files.pythonhosted.org/packages/b6/cf/9de380489d2607de9b2404ddd27e90619d8a16d246e4cfdf672c0f20fed1/basedmypy-2.8.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:1617709a448fb3268f40b22b21f28ce06424b897256da6fa977bb97585d32dcf", size = 13180854 },
+    { url = "https://files.pythonhosted.org/packages/c8/21/81e4ecfa2d517f8219456e362ed099d20e104c2ef23180930fe08097f5fb/basedmypy-2.8.0-cp312-cp312-win_amd64.whl", hash = "sha256:6cbe9c9bf38c7cc7e95c26b225f334f3fe8c0a9afc54dac5e9f4b6528667b290", size = 10024300 },
+    { url = "https://files.pythonhosted.org/packages/b5/81/05c7e7c6165e561a77c11192026cbd4fa3ee106b5e2bb1980e32955ee8d6/basedmypy-2.8.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:4bd294928bb565c45dfbc1f77b8c2795149111e5c22925665e73c5b5515be3b6", size = 11419416 },
+    { url = "https://files.pythonhosted.org/packages/b3/f3/67eba9d4ec1cb352e6506b6ba09956f112ab205b6ffce1e9e9d520d723f3/basedmypy-2.8.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:d64babe39d447f1dbbc7c475d8b0dd5bfe8c83470b0482b9253096c8f2c4d13a", size = 10375404 },
+    { url = "https://files.pythonhosted.org/packages/66/e1/86075f2def0e03e127bfccdaba705e5187d7045ec2a53be76504b8960422/basedmypy-2.8.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:816a6082132e837e9a73ebc286bb94c528a91eafadec443542f297b678d27030", size = 13067494 },
+    { url = "https://files.pythonhosted.org/packages/18/c7/8d672d4fa3177a85f42e0d1d77e37572509c44a409af1457b81720e8d9bf/basedmypy-2.8.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:54a014c82a5530930e92cdf31c6d3200203758ca6ef828c5a465367a12351e34", size = 13177549 },
+    { url = "https://files.pythonhosted.org/packages/f6/20/eabe6dcb88fdce65ccdbb64bc10da1deaeecd3a1cae8cb827a1bfcb275de/basedmypy-2.8.0-cp313-cp313-win_amd64.whl", hash = "sha256:15afa499b9b00dc4cdb9c74e635c869aa57d303441734cede2da8a0391863770", size = 10031522 },
+    { url = "https://files.pythonhosted.org/packages/fb/d0/0d4ee8394a78c31240ac172d9db108b3aba1c7ab8234356ca2c92ce2cf4d/basedmypy-2.8.0-py3-none-any.whl", hash = "sha256:b7cfb7e7934acb5e3c98f7ba795ad37ee12b19b27641e852b222e08786e7aa9a", size = 2687683 },
 ]
 
 [package.optional-dependencies]
@@ -43,14 +43,14 @@ faster-cache = [
 
 [[package]]
 name = "basedpyright"
-version = "1.22.0"
+version = "1.22.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "nodejs-wheel-binaries" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c3/d7/27e8cc2f223ff49833a5a46928735c51f6ebc0e5ba1e501a2d3f0be3b02c/basedpyright-1.22.0.tar.gz", hash = "sha256:457e97ac4c3f694b900453d3f8824af36d17b9cef3d76c623e665dd4c7872d9c", size = 20860430 }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/f6/145cb984914358a546ae24ec185ea5a955e9d900e6a7e7ddba3b06d84920/basedpyright-1.22.1.tar.gz", hash = "sha256:f7a2d0e49c7d375ce9e02a7c235536e824833c9df89c2ca7e605ab1a2995808f", size = 21203428 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1b/d2/1783a17c041a48faa1fd056a7dd1029e419a0026ecc2c070b7c7516018d0/basedpyright-1.22.0-py3-none-any.whl", hash = "sha256:6376107086ad25525429b8a94a2ffdb67c6dd2b1a6be38bf3c6ea9b5c3d1f688", size = 11188885 },
+    { url = "https://files.pythonhosted.org/packages/2f/53/478be813de0f35c934b5f0c763defbe4df21514a4b3b77d14e269d9894de/basedpyright-1.22.1-py3-none-any.whl", hash = "sha256:b25597757400ec082b1099eb99f0fc74857ff4dcd7caa198bf1e236d17214ebf", size = 11302975 },
 ]
 
 [[package]]
@@ -349,12 +349,12 @@ common = [
     { name = "typing-extensions", specifier = ">=4.10" },
 ]
 dev = [
-    { name = "basedmypy", extras = ["faster-cache"], specifier = ">=2.7.0" },
-    { name = "basedpyright", specifier = ">=1.22.0" },
+    { name = "basedmypy", extras = ["faster-cache"], specifier = ">=2.8.0" },
+    { name = "basedpyright", specifier = ">=1.22.1" },
     { name = "beartype", specifier = ">=0.19.0" },
     { name = "numpy", specifier = ">=1.24" },
     { name = "pre-commit", specifier = ">=4.0.1" },
-    { name = "pytest", specifier = ">=8.3.3" },
+    { name = "pytest", specifier = ">=8.3.4" },
     { name = "ruff", specifier = ">=0.8.1" },
     { name = "sp-repo-review", extras = ["cli"], specifier = ">=2024.8.19" },
     { name = "tox", specifier = ">=4.23.2" },
@@ -367,21 +367,21 @@ lint = [
 test = [
     { name = "beartype", specifier = ">=0.19.0" },
     { name = "numpy", specifier = ">=1.24" },
-    { name = "pytest", specifier = ">=8.3.3" },
+    { name = "pytest", specifier = ">=8.3.4" },
     { name = "typing-extensions", specifier = ">=4.10" },
 ]
 type = [
-    { name = "basedmypy", extras = ["faster-cache"], specifier = ">=2.7.0" },
-    { name = "basedpyright", specifier = ">=1.22.0" },
+    { name = "basedmypy", extras = ["faster-cache"], specifier = ">=2.8.0" },
+    { name = "basedpyright", specifier = ">=1.22.1" },
     { name = "numpy", specifier = ">=1.24" },
     { name = "typing-extensions", specifier = ">=4.10" },
 ]
 typetest = [
-    { name = "basedmypy", extras = ["faster-cache"], specifier = ">=2.7.0" },
-    { name = "basedpyright", specifier = ">=1.22.0" },
+    { name = "basedmypy", extras = ["faster-cache"], specifier = ">=2.8.0" },
+    { name = "basedpyright", specifier = ">=1.22.1" },
     { name = "beartype", specifier = ">=0.19.0" },
     { name = "numpy", specifier = ">=1.24" },
-    { name = "pytest", specifier = ">=8.3.3" },
+    { name = "pytest", specifier = ">=8.3.4" },
     { name = "typing-extensions", specifier = ">=4.10" },
 ]
 
@@ -508,7 +508,7 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "8.3.3"
+version = "8.3.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -518,9 +518,9 @@ dependencies = [
     { name = "pluggy" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8b/6c/62bbd536103af674e227c41a8f3dcd022d591f6eed5facb5a0f31ee33bbc/pytest-8.3.3.tar.gz", hash = "sha256:70b98107bd648308a7952b06e6ca9a50bc660be218d53c257cc1fc94fda10181", size = 1442487 }
+sdist = { url = "https://files.pythonhosted.org/packages/05/35/30e0d83068951d90a01852cb1cef56e5d8a09d20c7f511634cc2f7e0372a/pytest-8.3.4.tar.gz", hash = "sha256:965370d062bce11e73868e0335abac31b4d3de0e82f4007408d242b4f8610761", size = 1445919 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6b/77/7440a06a8ead44c7757a64362dd22df5760f9b12dc5f11b6188cd2fc27a0/pytest-8.3.3-py3-none-any.whl", hash = "sha256:a6853c7375b2663155079443d2e45de913a911a11d669df02a50814944db57b2", size = 342341 },
+    { url = "https://files.pythonhosted.org/packages/11/92/76a1c94d3afee238333bc0a42b82935dd8f9cf8ce9e336ff87ee14d9e1cf/pytest-8.3.4-py3-none-any.whl", hash = "sha256:50e16d954148559c9a74109af1eaf0c945ba2d8f30f0a3d3335edde19788b6f6", size = 343083 },
 ]
 
 [[package]]
@@ -605,16 +605,16 @@ wheels = [
 
 [[package]]
 name = "rich-click"
-version = "1.8.4"
+version = "1.8.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
     { name = "rich" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fc/f4/e48dc2850662526a26fb0961aacb0162c6feab934312b109b748ae4efee2/rich_click-1.8.4.tar.gz", hash = "sha256:0f49471f04439269d0e66a6f43120f52d11d594869a2a0be600cfb12eb0616b9", size = 38247 }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/31/103501e85e885e3e202c087fa612cfe450693210372766552ce1ab5b57b9/rich_click-1.8.5.tar.gz", hash = "sha256:a3eebe81da1c9da3c32f3810017c79bd687ff1b3fa35bfc9d8a3338797f1d1a1", size = 38229 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/84/f3/72f93d8494ee641bde76bfe1208cf4abc44c6f9448673762f6077bc162d6/rich_click-1.8.4-py3-none-any.whl", hash = "sha256:2d2841b3cebe610d5682baa1194beaf78ab00c4fa31931533261b5eba2ee80b7", size = 35071 },
+    { url = "https://files.pythonhosted.org/packages/aa/0b/e2de98c538c0ee9336211d260f88b7e69affab44969750aaca0b48a697c8/rich_click-1.8.5-py3-none-any.whl", hash = "sha256:0fab7bb5b66c15da17c210b4104277cd45f3653a7322e0098820a169880baee0", size = 35081 },
 ]
 
 [[package]]


### PR DESCRIPTION
Pyright now fully supports `optype.typing.Just`