### PR TITLE
`numpy.Any[U]Int{DType,Array}` for `np.int_`

### DIFF
--- a/optype/numpy/_any_array.py
+++ b/optype/numpy/_any_array.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import sys
-from typing import TYPE_CHECKING, Any, TypeAlias
+from typing import TYPE_CHECKING, Any, Protocol, TypeAlias
 
 import numpy as np
 
@@ -13,9 +13,9 @@ from optype._core._utils import set_module
 
 
 if sys.version_info >= (3, 13):
-    from typing import Never, Protocol, TypeAliasType, TypeVar
+    from typing import Never, TypeAliasType, TypeVar
 else:
-    from typing_extensions import Never, Protocol, TypeAliasType, TypeVar
+    from typing_extensions import Never, TypeAliasType, TypeVar
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -36,6 +36,7 @@ __all__ = [
 
     "AnyBoolArray",
 
+    "AnyUIntArray", "AnyIntArray",
     "AnyUInt8Array", "AnyInt8Array",
     "AnyUInt8Array", "AnyInt8Array",
     "AnyUInt16Array", "AnyInt16Array",
@@ -60,15 +61,14 @@ __all__ = [
     "AnyStrArray",
     "AnyVoidArray",
     "AnyObjectArray",
-
     "AnyStringArray",
 ]  # fmt: skip
 
 
-_T = TypeVar("_T")
 _T_co = TypeVar("_T_co", covariant=True)
+_T = TypeVar("_T")
+_ST_co = TypeVar("_ST_co", bound=np.generic, covariant=True)
 _ST = TypeVar("_ST", bound=np.generic, default=np.generic)
-_ST_co = TypeVar("_ST_co", covariant=True, bound=np.generic)
 _VT = TypeVar("_VT", default=_ST)
 
 
@@ -115,9 +115,10 @@ AnyUShortArray = AnyUInt16Array
 AnyUInt32Array: TypeAlias = _AnyArray[np.uint32]
 AnyUInt64Array: TypeAlias = _AnyArray[np.uint64]
 AnyUIntCArray: TypeAlias = _AnyArray[np.uintc]
-AnyUIntPArray: TypeAlias = _AnyArray[np.uintp]
-AnyULongArray: TypeAlias = _AnyArray[_x.ULong]
 AnyULongLongArray: TypeAlias = _AnyArray[np.ulonglong]
+AnyULongArray: TypeAlias = _AnyArray[_x.ULong]
+AnyUIntPArray: TypeAlias = _AnyArray[np.uintp]
+AnyUIntArray: TypeAlias = _AnyArray[np.uint]
 
 AnyInt8Array: TypeAlias = _AnyArray[np.int8]
 AnyByteArray = AnyInt8Array
@@ -126,10 +127,11 @@ AnyShortArray = AnyInt16Array
 AnyInt32Array: TypeAlias = _AnyArray[np.int32]
 AnyInt64Array: TypeAlias = _AnyArray[np.int64]
 AnyIntCArray: TypeAlias = _AnyArray[np.intc]
-# TODO: also allow `Just[int]` values
-AnyIntPArray: TypeAlias = _AnyArray[np.intp]  # no int (numpy>=2)
-AnyLongArray: TypeAlias = _AnyArray[_x.Long]  # no int (numpy<=1)
 AnyLongLongArray: TypeAlias = _AnyArray[np.longlong]
+# TODO: also allow `Just[int]` values
+AnyLongArray: TypeAlias = _AnyArray[_x.Long]  # no int (numpy<=1)
+AnyIntPArray: TypeAlias = _AnyArray[np.intp]  # no int (numpy>=2)
+AnyIntArray: TypeAlias = _AnyArray[np.int_]  # no int
 
 # TODO: also allow `Just[float]` values
 AnyFloatingArray: TypeAlias = _AnyArray[_sc.floating]

--- a/optype/numpy/_any_dtype.py
+++ b/optype/numpy/_any_dtype.py
@@ -41,6 +41,7 @@ __all__ = [
 
     "AnyBoolDType",
 
+    "AnyUIntDType",
     "AnyUInt8DType",
     "AnyUInt8DType",
     "AnyUInt16DType",
@@ -53,6 +54,7 @@ __all__ = [
     "AnyULongDType",
     "AnyULongLongDType",
 
+    "AnyIntDType",
     "AnyInt8DType",
     "AnyInt8DType",
     "AnyInt16DType",
@@ -99,52 +101,13 @@ class _HasScalarType(Protocol[_SCT_co]):
 
 _AnyDType: Alias = np.dtype[_SCT] | _HasScalarType[_SCT]
 
-# unsigned integers
 
-_Name_u1: Alias = L["uint8", "ubyte"]
-_Char_u1: Alias = L["B", "u1", "|u1"]  # irrelevant byteorder, but `.str == "|u1"`
-_Code_u1: Alias = L[_Name_u1, _Char_u1]
-AnyUInt8DType: Alias = _AnyDType[np.uint8] | _Code_u1
-AnyUByteDType = AnyUInt8DType
+# bool
+_Name_b1: Alias = L["bool", "bool_"]  # 'bool0' was removed in NumPy 2.0
+_Char_b1: Alias = L["?", "b1", "|b1"]
+_Code_b1: Alias = L[_Name_b1, _Char_b1]
+AnyBoolDType: Alias = type[bool] | _AnyDType[_x.Bool] | _Code_b1
 
-_Name_u2: Alias = L["uint16", "ushort"]
-_Char_u2: Alias = L["H", "u2", "<u2", ">u2"]
-_Code_u2: Alias = L[_Name_u2, _Char_u2]
-AnyUInt16DType: Alias = _AnyDType[np.uint16] | _Code_u2
-AnyUShortDType = AnyUInt16DType
-
-_Name_u4: Alias = L["uint32"]
-_Char_u4: Alias = L["u4", "<u4", ">u4"]
-_Code_u4: Alias = L[_Name_u4, _Char_u4]
-AnyUInt32DType: Alias = _AnyDType[np.uint32] | _Code_u4
-
-# `uintc` is an alias for `uint32` on linux
-_Name_I: Alias = L["uintc"]
-_Char_I: Alias = L["I"]
-_Code_I: Alias = L[_Name_I, _Char_I]
-AnyUIntCDType: Alias = _AnyDType[np.uintc] | _Code_I
-
-_Name_u8: Alias = L["uint64"]
-_Char_u8: Alias = L["u8", "<u8", ">u8"]
-_Code_u8: Alias = L[_Name_u8, _Char_u8]
-AnyUInt64DType: Alias = _AnyDType[np.uint64] | _Code_u8
-
-_Name_Q: Alias = L["ulonglong"]
-_Char_Q: Alias = L["Q"]
-_Code_Q: Alias = L[_Name_Q, _Char_Q]
-AnyULongLongDType: Alias = _AnyDType[np.ulonglong] | _Code_Q
-
-# `UInt`, `UIntP`, and `ULong` are defined later as they differ in numpy 1 and 2
-_Name_u0_common: Alias = L["uint"]
-_Char_L: Alias = L["L", "<L", ">L"]
-_Char_P: Alias = L["P", "<P", ">P"]  # not associated to any scalar type in numpy>=2.0
-
-_Name_ux: Alias = L[
-    "uint", "uintp",
-    "uint8", "uint16", "uint32", "uint64",
-    "ubyte", "ushort", "uintc", "ulong", "ulonglong",
-]  # fmt: skip
-_Char_ux_common: Alias = L[_Char_u1, _Char_u2, _Char_u4, _Char_u8, _Char_L, _Char_P]
 
 # signed integers
 
@@ -160,31 +123,81 @@ _Code_i2: Alias = L[_Name_i2, _Char_i2]
 AnyInt16DType: Alias = _AnyDType[np.int16] | _Code_i2
 AnyShortDType = AnyInt16DType
 
-_Name_i4: Alias = L["int32"]
-_Char_i4: Alias = L["i4", "<i4", ">i4"]
-_Code_i4: Alias = L[_Name_i4, _Char_i4]
-AnyInt32DType: Alias = _AnyDType[np.int32] | _Code_i4
-
-# `intc` is an alias for `int32` on linux
+# `intc` is an alias for `int32` on linux, and almost always of same size if not
 _Name_i: Alias = L["intc"]
 _Char_i: Alias = L["i"]
 _Code_i: Alias = L[_Char_i, _Name_i]
 AnyIntCDType: Alias = _AnyDType[np.intc] | _Code_i
 
-_Name_i8: Alias = L["int64"]
-_Char_i8: Alias = L["i8", "<i8", ">i8"]
-_Code_i8: Alias = L[_Name_i8, _Char_i8]
-AnyInt64DType: Alias = _AnyDType[np.int64] | _Code_i8
+_Name_i4: Alias = L["int32", _Name_i]
+_Char_i4: Alias = L[_Char_i, "i4", "<i4", ">i4"]
+_Code_i4: Alias = L[_Name_i4, _Char_i4]
+AnyInt32DType: Alias = _AnyDType[np.int32] | _Code_i4
 
 _Name_q: Alias = L["longlong"]
 _Char_q: Alias = L["q"]
 _Code_q: Alias = L[_Name_q, _Char_q]
 AnyLongLongDType: Alias = _AnyDType[np.longlong] | _Code_q
 
+_Name_i8: Alias = L["int64", _Name_q]
+_Char_i8: Alias = L[_Char_q, "i8", "<i8", ">i8"]
+_Code_i8: Alias = L[_Name_i8, _Char_i8]
+AnyInt64DType: Alias = _AnyDType[np.int64] | _Code_i8
+
 # `Int_`, `IntP`, and `Long` are defined later as they differ in numpy 1 and 2
 _Name_i0_common: Alias = L["int", "int_"]
 _Char_l: Alias = L["l", "<l", ">l"]
 _Char_p: Alias = L["p", "<p", ">p"]  # not associated to any scalar type in numpy>=2.0
+
+
+# unsigned integers
+
+_Name_u1: Alias = L["uint8", "ubyte"]
+_Char_u1: Alias = L["B", "u1", "|u1"]  # irrelevant byteorder, but `.str == "|u1"`
+_Code_u1: Alias = L[_Name_u1, _Char_u1]
+AnyUInt8DType: Alias = _AnyDType[np.uint8] | _Code_u1
+AnyUByteDType = AnyUInt8DType
+
+_Name_u2: Alias = L["uint16", "ushort"]
+_Char_u2: Alias = L["H", "u2", "<u2", ">u2"]
+_Code_u2: Alias = L[_Name_u2, _Char_u2]
+AnyUInt16DType: Alias = _AnyDType[np.uint16] | _Code_u2
+AnyUShortDType = AnyUInt16DType
+
+# `uintc` is an alias for `uint32` on linux (e.g. the Win16 API uses 16-bit, but
+# realistically no-one is using that anymore)
+_Name_I: Alias = L["uintc"]
+_Char_I: Alias = L["I"]
+_Code_I: Alias = L[_Name_I, _Char_I]
+AnyUIntCDType: Alias = _AnyDType[np.uintc] | _Code_I
+
+_Name_u4: Alias = L["uint32", _Name_I]
+_Char_u4: Alias = L[_Char_I, "u4", "<u4", ">u4"]
+_Code_u4: Alias = L[_Name_u4, _Char_u4]
+AnyUInt32DType: Alias = _AnyDType[np.uint32] | _Code_u4
+
+_Name_Q: Alias = L["ulonglong"]
+_Char_Q: Alias = L["Q"]
+_Code_Q: Alias = L[_Name_Q, _Char_Q]
+AnyULongLongDType: Alias = _AnyDType[np.ulonglong] | _Code_Q
+
+_Name_u8: Alias = L["uint64", _Name_Q]
+_Char_u8: Alias = L[_Char_Q, "u8", "<u8", ">u8"]
+_Code_u8: Alias = L[_Name_u8, _Char_u8]
+AnyUInt64DType: Alias = _AnyDType[np.uint64] | _Code_u8
+
+# `UInt`, `UIntP`, and `ULong` are defined later as they differ in numpy 1 and 2
+_Name_u0_common: Alias = L["uint"]
+_Char_L: Alias = L["L", "<L", ">L"]
+_Char_P: Alias = L["P", "<P", ">P"]  # not associated to any scalar type in numpy>=2.0
+
+_Name_ux: Alias = L[
+    "uint", "uintp",
+    "uint8", "uint16", "uint32", "uint64",
+    "ubyte", "ushort", "uintc", "ulong", "ulonglong",
+]  # fmt: skip
+_Char_ux_common: Alias = L[_Char_u1, _Char_u2, _Char_u4, _Char_u8, _Char_L, _Char_P]
+
 
 # real floating
 
@@ -211,6 +224,7 @@ AnyLongDoubleDType: Alias = _AnyDType[np.longdouble] | _Code_g
 _Code_fx: Alias = L[_Code_f2, _Code_f4, _Code_f8, _Code_g]
 AnyFloatingDType: Alias = _AnyDType[_sc.floating] | _Code_fx
 
+
 # complex floating
 
 _Name_c8: Alias = L["complex64", "csingle"]
@@ -230,6 +244,7 @@ AnyCLongDoubleDType: Alias = _AnyDType[np.clongdouble] | _Code_G
 
 _Code_cx: Alias = L[_Code_c8, _Code_c16, _Code_G]
 AnyComplexFloatingDType: Alias = _AnyDType[_sc.cfloating] | _Code_cx
+
 
 # temporal
 
@@ -303,6 +318,7 @@ _Char_m8: Alias = L[
 _Code_m8: Alias = L[_Name_m8, _Char_m8]
 AnyTimeDelta64DType: Alias = _AnyDType[np.timedelta64] | _Code_m8
 
+
 # flexible
 
 _Name_U: Alias = L["str_", "str", "unicode"]
@@ -329,12 +345,6 @@ _Code_SUV: Alias = L[_Code_SU, _Code_V]
 AnyFlexibleDType: Alias = (
     type[bytes | str | memoryview] | _AnyDType[np.flexible] | _Code_SUV
 )
-
-# bool_
-_Name_b1: Alias = L["bool", "bool_"]  # 'bool0' was removed in NumPy 2.0
-_Char_b1: Alias = L["?", "b1", "|b1"]
-_Code_b1: Alias = L[_Name_b1, _Char_b1]
-AnyBoolDType: Alias = type[bool] | _AnyDType[_x.Bool] | _Code_b1
 
 # object
 _Name_O: Alias = L["object", "object_"]
@@ -365,6 +375,7 @@ if _x.NP2:
     _Char_u0: Alias = L["N", "<N", ">N"]
     _Code_u0: Alias = L[_Name_u0, _Char_u0]
     AnyUIntPDType: Alias = _AnyDType[np.uintp] | _Code_u0
+    AnyUIntDType: Alias = AnyUIntPDType
 
     _Name_L: Alias = L["ulong"]
     _Code_L: Alias = L[_Name_L, _Char_L]
@@ -374,6 +385,7 @@ if _x.NP2:
     _Char_i0: Alias = L["n", "<n", ">n"]
     _Code_i0: Alias = L[_Name_i0, _Char_i0]
     AnyIntPDType: Alias = _AnyDType[np.intp] | _Code_i0
+    AnyIntDType: Alias = AnyIntPDType
 
     _Name_l: Alias = L["long"]
     _Code_l: Alias = L[_Name_l, _Char_l]
@@ -417,6 +429,7 @@ else:
     _Name_L: Alias = L[_Name_u0_common, "ulong"]
     _Code_L: Alias = L[_Name_L, _Char_L]
     AnyULongDType: Alias = _AnyDType[_x.ULong] | _Code_L
+    AnyUIntDType: Alias = AnyULongDType
 
     _Name_i0: Alias = L["intp"]  # 'int0' is removed in NumPy 2.0
     _Char_i0: Alias = _Char_p
@@ -426,6 +439,7 @@ else:
     _Name_l: Alias = L["long", _Name_i0_common]
     _Code_l: Alias = L[_Name_l, _Char_l]
     AnyLongDType: Alias = _AnyDType[_x.Long] | _Code_l
+    AnyIntDType: Alias = AnyLongDType
 
     _Char_ux: Alias = L[_Char_ux_common, _Char_u0]
     _Code_ux: Alias = L[_Name_ux, _Char_ux]

--- a/optype/numpy/ctypeslib.py
+++ b/optype/numpy/ctypeslib.py
@@ -122,21 +122,32 @@ SIZE_INTP: Final = cast("Literal[4, 8]", ct.sizeof(ct.c_ssize_t))
 SIZE_LONG: Final = cast("Literal[4, 8]", ct.sizeof(ct.c_long))
 SIZE_LONGLONG: Final = cast("Literal[8]", ct.sizeof(ct.c_longlong))
 
-assert SIZE_BYTE == 1, f"`sizeof(byte) = {SIZE_BYTE}`, expected 1"
-assert SIZE_SHORT == 2, f"`sizeof(short) = {SIZE_SHORT}`, expected 2"
-assert SIZE_INTC == 4, f"`sizeof(int) = {SIZE_INTC}`, expected 4"
-assert SIZE_INTP in {4, 8}, f"`sizeof(ssize_t) = {SIZE_INTP}`, expected 4 or 8"
-assert SIZE_LONG in {4, 8}, f"`sizeof(long int) = {SIZE_LONG}`, expected 4 or 8"
-
 SIZE_SINGLE: Final = cast("Literal[4]", ct.sizeof(ct.c_float))
 SIZE_DOUBLE: Final = cast("Literal[8]", ct.sizeof(ct.c_double))
-SIZE_LONGDOUBLE: Final = cast("Literal[8, 12, 16]", ct.sizeof(ct.c_longdouble))
+SIZE_LONGDOUBLE: Final = cast("Literal[8, 10, 12, 16]", ct.sizeof(ct.c_longdouble))
 
-assert SIZE_SINGLE == 4, f"`sizeof(float) = {SIZE_SINGLE}`, expected 4"
-assert SIZE_DOUBLE == 8, f"`sizeof(double) = {SIZE_DOUBLE}`, expected 8"
-assert SIZE_LONGDOUBLE in {8, 12, 16}, (
-    f"`sizeof(long double) = {SIZE_LONGDOUBLE}`, expected 8, 12 or 16",
-)  # fmt: skip
+
+def __is_dev() -> bool:
+    from importlib import metadata  # noqa: PLC0415
+
+    return "dev" in metadata.version((__package__ or "optype").removesuffix(".numpy"))  # noqa: PLR2004
+
+
+if __is_dev():
+    assert SIZE_BYTE == 1, f"`sizeof(byte) = {SIZE_BYTE}`, expected 1"
+    assert SIZE_SHORT == 2, f"`sizeof(short) = {SIZE_SHORT}`, expected 2"
+    # If you run a 16-bit system and this assertion fails, please open an issue, or even
+    # better, upgrade to something that's younger than Joe fucking Biden.
+    assert SIZE_INTC == 4, f"`sizeof(int) = {SIZE_INTC}`, expected 4"
+    assert SIZE_INTP in {4, 8}, f"`sizeof(ssize_t) = {SIZE_INTP}`, expected 4 or 8"
+    assert SIZE_LONG in {4, 8}, f"`sizeof(long int) = {SIZE_LONG}`, expected 4 or 8"
+    assert SIZE_LONGLONG == 8, f"`sizeof(long long int) = {SIZE_LONGLONG}`, expected 8"
+
+    assert SIZE_SINGLE == 4, f"`sizeof(float) = {SIZE_SINGLE}`, expected 4"
+    assert SIZE_DOUBLE == 8, f"`sizeof(double) = {SIZE_DOUBLE}`, expected 8"
+    assert SIZE_LONGDOUBLE in {8, 10, 12, 16}, (
+        f"`sizeof(long double) = {SIZE_LONGDOUBLE}`, expected 8, 10, 12 or 16",
+    )  # fmt: skip
 
 
 CT = TypeVar("CT", bound=CType)

--- a/tests/numpy/test_any_dtype.py
+++ b/tests/numpy/test_any_dtype.py
@@ -73,6 +73,10 @@ _NAME_MAP: Final = {
 }
 
 
+def _normalized_dtype_name(dtype: np.dtype[np.generic]) -> str:
+    return dtype.name.split("[")[0]  # avoid e.g. "datetime64[ns]"
+
+
 @pytest.mark.parametrize(
     ("dtype", "names", "chars"),
     [(dtype, *_get_dtype_codes(dtype)) for dtype in _DTYPES],
@@ -89,15 +93,16 @@ def test_dtype_has_codes(
     assert dtype.str[1:] in chars, (dtype.str, chars)
 
     codes = names | chars
-    sctypes: set[type] = set()
+    out_names: set[str] = set()
     for code in codes:
         try:
             dtype_ = np.dtype(code)
         except TypeError:
             continue
-        sctypes.add(dtype_.type)
 
-    assert len(sctypes) == 1
+        out_names.add(_normalized_dtype_name(dtype_))
+
+    assert len(out_names) == 1
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
changed in `optype.numpy`:

- add `Any[U]IntDType` and `Any[U]IntArray` for the `np.int_` and `np.uint` scalar types
- assume `np.[u]intc` is 32-bits, and update `Any[U]Int32{DType,Array}` accordingly (but not vice-versa)
- assume `np.[u]longlong` is 64-bits, and update `Any[U]Int64{DType,Array}` accordingly (but not vice-versa). 

The `[U]IntC` and  `[U]LongLong` aliases will be removed in a future release.