### PR TITLE
prefer `Just{Float,Complex}` over `Just[{float,complex}]` in `optype.numpy`

### DIFF
--- a/optype/numpy/_any_array.py
+++ b/optype/numpy/_any_array.py
@@ -103,23 +103,20 @@ _AnyArray = TypeAliasType(
     type_params=(_ST, _VT),
 )
 
-_JustFloat: TypeAlias = opt.Just[float]
-_JustComplex: TypeAlias = opt.Just[complex]
-
 ###
 
 AnyArray: TypeAlias = _AnyArray[_ST, object] | CanBuffer
 
 AnyNumberArray: TypeAlias = _AnyArray[
     _sc.number,
-    _sc.number | opt.JustInt | _JustFloat | _JustComplex,
+    _sc.number | opt.JustInt | opt.JustFloat | opt.JustComplex,
 ]
 AnyIntegerArray: TypeAlias = _AnyArray[_sc.integer, _sc.integer | opt.JustInt]
 AnySignedIntegerArray: TypeAlias = _AnyArray[_sc.sinteger, _sc.sinteger | opt.JustInt]
 AnyUnsignedIntegerArray: TypeAlias = _AnyArray[_sc.uinteger]
 AnyInexactArray: TypeAlias = _AnyArray[
     _sc.inexact,
-    _sc.inexact | _JustFloat | _JustComplex,
+    _sc.inexact | opt.JustFloat | opt.JustComplex,
 ]
 
 AnyBoolArray: TypeAlias = _AnyArray[_x.Bool, _x.Bool | bool]
@@ -148,18 +145,20 @@ AnyLongArray: TypeAlias = _AnyArray[_x.Long]  # no int (numpy<=1)
 AnyIntPArray: TypeAlias = _AnyArray[np.intp]  # no int (numpy>=2)
 AnyIntArray: TypeAlias = _AnyArray[np.int_, np.int_ | opt.JustInt]
 
-AnyFloatingArray: TypeAlias = _AnyArray[_sc.floating, _sc.floating | _JustFloat]
+AnyFloatingArray: TypeAlias = _AnyArray[_sc.floating, _sc.floating | opt.JustFloat]
 AnyFloat16Array: TypeAlias = _AnyArray[np.float16]
 AnyFloat32Array: TypeAlias = _AnyArray[np.float32]
-AnyFloat64Array: TypeAlias = _AnyArray[np.float64, np.float64 | _JustFloat]
+AnyFloat64Array: TypeAlias = _AnyArray[np.float64, np.float64 | opt.JustFloat]
 AnyLongDoubleArray: TypeAlias = _AnyArray[np.longdouble]
 
 AnyComplexFloatingArray: TypeAlias = _AnyArray[
     _sc.cfloating,
-    _sc.cfloating | _JustComplex,
+    _sc.cfloating | opt.JustComplex,
 ]
 AnyComplex64Array: TypeAlias = _AnyArray[np.complex64]
-AnyComplex128Array: TypeAlias = _AnyArray[np.complex128, np.complex128 | _JustComplex]
+AnyComplex128Array: TypeAlias = _AnyArray[
+    np.complex128, np.complex128 | opt.JustComplex
+]
 AnyCLongDoubleArray: TypeAlias = _AnyArray[np.clongdouble]
 
 AnyCharacterArray: TypeAlias = _AnyArray[np.character, np.character | bytes | str]

--- a/optype/numpy/_any_dtype.py
+++ b/optype/numpy/_any_dtype.py
@@ -95,8 +95,8 @@ __all__ = [
 _SCT = TypeVar("_SCT", bound=np.generic)
 _SCT_co = TypeVar("_SCT_co", covariant=True, bound=np.generic)
 
-_IsFloat: Alias = type[opt.Just[float]]
-_IsComplex: Alias = type[opt.Just[complex]]
+_IsFloat: Alias = type[opt.JustFloat]
+_IsComplex: Alias = type[opt.JustComplex]
 _IsObject: Alias = type[opt.Just[object]]
 
 

--- a/optype/numpy/_to.py
+++ b/optype/numpy/_to.py
@@ -1,4 +1,3 @@
-# mypy: disable-error-code="no-any-explicit"
 import sys
 from collections.abc import Sequence as Seq
 from typing import Literal, TypeAlias
@@ -71,6 +70,9 @@ _PyBool: TypeAlias = bool | Literal[0, 1]  # 0 and 1 are sometimes used as bool 
 _PyScalar: TypeAlias = complex | bytes | str  # `complex` equivs `complex | float | int`
 
 T = TypeVar("T", default=_PyScalar)
+
+# https://github.com/KotlinIsland/basedmypy/issues/861
+# mypy: disable-error-code="no-any-explicit"
 SCT = TypeVar("SCT", bound=np.generic, default=np.generic)
 
 _To0D = TypeAliasType("_To0D", T | SCT | CanArray0D[SCT], type_params=(T, SCT))
@@ -182,29 +184,29 @@ ToJustInt2D: TypeAlias = _To2D[opt.JustInt, npc.integer]
 ToJustInt3D: TypeAlias = _To3D[opt.JustInt, npc.integer]
 ToJustIntND: TypeAlias = _ToND[opt.JustInt, npc.integer]
 
-ToJustFloat64: TypeAlias = opt.Just[float] | np.float64
-ToJustFloat64_1D: TypeAlias = _To1D[opt.Just[float], np.float64]
-ToJustFloat64_2D: TypeAlias = _To2D[opt.Just[float], np.float64]
-ToJustFloat64_3D: TypeAlias = _To3D[opt.Just[float], np.float64]
-ToJustFloat64_ND: TypeAlias = _ToND[opt.Just[float], np.float64]
+ToJustFloat64: TypeAlias = opt.JustFloat | np.float64
+ToJustFloat64_1D: TypeAlias = _To1D[opt.JustFloat, np.float64]
+ToJustFloat64_2D: TypeAlias = _To2D[opt.JustFloat, np.float64]
+ToJustFloat64_3D: TypeAlias = _To3D[opt.JustFloat, np.float64]
+ToJustFloat64_ND: TypeAlias = _ToND[opt.JustFloat, np.float64]
 
-ToJustFloat: TypeAlias = opt.Just[float] | npc.floating
-ToJustFloat1D: TypeAlias = _To1D[opt.Just[float], npc.floating]
-ToJustFloat2D: TypeAlias = _To2D[opt.Just[float], npc.floating]
-ToJustFloat3D: TypeAlias = _To3D[opt.Just[float], npc.floating]
-ToJustFloatND: TypeAlias = _ToND[opt.Just[float], npc.floating]
+ToJustFloat: TypeAlias = opt.JustFloat | npc.floating
+ToJustFloat1D: TypeAlias = _To1D[opt.JustFloat, npc.floating]
+ToJustFloat2D: TypeAlias = _To2D[opt.JustFloat, npc.floating]
+ToJustFloat3D: TypeAlias = _To3D[opt.JustFloat, npc.floating]
+ToJustFloatND: TypeAlias = _ToND[opt.JustFloat, npc.floating]
 
-ToJustComplex: TypeAlias = opt.Just[complex] | npc.complexfloating
-ToJustComplex1D: TypeAlias = _To1D[opt.Just[complex], npc.complexfloating]
-ToJustComplex2D: TypeAlias = _To2D[opt.Just[complex], npc.complexfloating]
-ToJustComplex3D: TypeAlias = _To3D[opt.Just[complex], npc.complexfloating]
-ToJustComplexND: TypeAlias = _ToND[opt.Just[complex], npc.complexfloating]
+ToJustComplex: TypeAlias = opt.JustComplex | npc.complexfloating
+ToJustComplex1D: TypeAlias = _To1D[opt.JustComplex, npc.complexfloating]
+ToJustComplex2D: TypeAlias = _To2D[opt.JustComplex, npc.complexfloating]
+ToJustComplex3D: TypeAlias = _To3D[opt.JustComplex, npc.complexfloating]
+ToJustComplexND: TypeAlias = _ToND[opt.JustComplex, npc.complexfloating]
 
-ToJustComplex128: TypeAlias = opt.Just[complex] | np.complex128
-ToJustComplex128_1D: TypeAlias = _To1D[opt.Just[complex], np.complex128]
-ToJustComplex128_2D: TypeAlias = _To2D[opt.Just[complex], np.complex128]
-ToJustComplex128_3D: TypeAlias = _To3D[opt.Just[complex], np.complex128]
-ToJustComplex128_ND: TypeAlias = _ToND[opt.Just[complex], np.complex128]
+ToJustComplex128: TypeAlias = opt.JustComplex | np.complex128
+ToJustComplex128_1D: TypeAlias = _To1D[opt.JustComplex, np.complex128]
+ToJustComplex128_2D: TypeAlias = _To2D[opt.JustComplex, np.complex128]
+ToJustComplex128_3D: TypeAlias = _To3D[opt.JustComplex, np.complex128]
+ToJustComplex128_ND: TypeAlias = _ToND[opt.JustComplex, np.complex128]
 
 # array-likes, with "coercible" shape-types, and "strict" shape-types
 
@@ -246,18 +248,18 @@ ToJustIntStrict1D: TypeAlias = _ToStrict1D[opt.JustInt, npc.integer]
 ToJustIntStrict3D: TypeAlias = _ToStrict3D[opt.JustInt, npc.integer]
 ToJustIntStrict2D: TypeAlias = _ToStrict2D[opt.JustInt, npc.integer]
 
-ToJustFloat64Strict1D: TypeAlias = _ToStrict1D[opt.Just[float], np.float64]
-ToJustFloat64Strict3D: TypeAlias = _ToStrict3D[opt.Just[float], np.float64]
-ToJustFloat64Strict2D: TypeAlias = _ToStrict2D[opt.Just[float], np.float64]
+ToJustFloat64Strict1D: TypeAlias = _ToStrict1D[opt.JustFloat, np.float64]
+ToJustFloat64Strict3D: TypeAlias = _ToStrict3D[opt.JustFloat, np.float64]
+ToJustFloat64Strict2D: TypeAlias = _ToStrict2D[opt.JustFloat, np.float64]
 
-ToJustFloatStrict1D: TypeAlias = _ToStrict1D[opt.Just[float], npc.floating]
-ToJustFloatStrict3D: TypeAlias = _ToStrict3D[opt.Just[float], npc.floating]
-ToJustFloatStrict2D: TypeAlias = _ToStrict2D[opt.Just[float], npc.floating]
+ToJustFloatStrict1D: TypeAlias = _ToStrict1D[opt.JustFloat, npc.floating]
+ToJustFloatStrict3D: TypeAlias = _ToStrict3D[opt.JustFloat, npc.floating]
+ToJustFloatStrict2D: TypeAlias = _ToStrict2D[opt.JustFloat, npc.floating]
 
-ToJustComplex128Strict1D: TypeAlias = _ToStrict1D[opt.Just[complex], np.complex128]
-ToJustComplex128Strict3D: TypeAlias = _ToStrict3D[opt.Just[complex], np.complex128]
-ToJustComplex128Strict2D: TypeAlias = _ToStrict2D[opt.Just[complex], np.complex128]
+ToJustComplex128Strict1D: TypeAlias = _ToStrict1D[opt.JustComplex, np.complex128]
+ToJustComplex128Strict3D: TypeAlias = _ToStrict3D[opt.JustComplex, np.complex128]
+ToJustComplex128Strict2D: TypeAlias = _ToStrict2D[opt.JustComplex, np.complex128]
 
-ToJustComplexStrict1D: TypeAlias = _ToStrict1D[opt.Just[complex], npc.complexfloating]
-ToJustComplexStrict3D: TypeAlias = _ToStrict3D[opt.Just[complex], npc.complexfloating]
-ToJustComplexStrict2D: TypeAlias = _ToStrict2D[opt.Just[complex], npc.complexfloating]
+ToJustComplexStrict1D: TypeAlias = _ToStrict1D[opt.JustComplex, npc.complexfloating]
+ToJustComplexStrict3D: TypeAlias = _ToStrict3D[opt.JustComplex, npc.complexfloating]
+ToJustComplexStrict2D: TypeAlias = _ToStrict2D[opt.JustComplex, npc.complexfloating]


### PR DESCRIPTION
closes #236