### PR TITLE
`optype.numpy.is_` typeguard

### DIFF
--- a/README.md
+++ b/README.md
@@ -2521,9 +2521,9 @@ For masked arrays with specific `ndim`, you could also use one of the four
 
 ##### Array typeguards
 
-To check whether a given object is an instance of `Array{0,1,2,3,N}D`, while also
-narrow static type accordingly, the following [PEP 742][PEP742] (`typing.TypeIs`)
-typeguards can be used:
+To check whether a given object is an instance of `Array{0,1,2,3,N}D`, in a way that
+static type-checkers also understand it, the following [PEP 742][PEP742] typeguards can
+be used:
 
 <table>
     <tr>
@@ -2562,22 +2562,18 @@ typeguards can be used:
     </tr>
 </table>
 
-These functions additionally accept an optional `dtype` argument, that accepts either
+These functions additionally accept an optional `dtype` argument, that can either be
 a `np.dtype[ST]` instance, a `type[ST]`, or something that has a `dtype: np.dtype[ST]`
-attribute, for type parameter `ST: np.generic`.
-
-Their signatures are almost identical, and look something like
+attribute.
+The signatures are almost identical to each other, and in the `0d` case it roughly
+looks like this:
 
 ```py
-def is_array_�d[
-    ST: np.generic = np.generic
-](
-    a: object,
-    /,
-    dtype: type[ST] | np.dtype[ST] | HasDType[np.dtype[ST]],
-) -> TypeIs[
-    Array�D[ST]
-]: ...
+ST = TypeVar("ST", bound=np.generic, default=np.generic)
+_ToDType: TypeAlias = type[ST] | np.dtype[ST] | HasDType[np.dtype[ST]]
+
+
+def is_array_0d(a, /, dtype: _ToDType[ST] | None = None) -> TypeIs[Array0D[ST]]: ...
 ```
 
 ##### Shape aliases

--- a/README.md
+++ b/README.md
@@ -2519,6 +2519,67 @@ type Matrix[
 For masked arrays with specific `ndim`, you could also use one of the four
 `MArray{0,1,2,3}D` aliases.
 
+##### Array typeguards
+
+To check whether a given object is an instance of `Array{0,1,2,3,N}D`, while also
+narrow static type accordingly, the following [PEP 742][PEP742] (`typing.TypeIs`)
+typeguards can be used:
+
+<table>
+    <tr>
+        <th>typeguard</th>
+        <th>narrows to</th>
+        <th>shape type</th>
+    </tr>
+    <tr>
+        <th colspan="2"><code>optype.numpy._</code></th>
+        <th><code>builtins._</code></th>
+    </tr>
+    <tr>
+        <td><code>is_array_nd</code></td>
+        <td><code>ArrayND[ST]</code></td>
+        <td><code>tuple[int, ...]</code></td>
+    </tr>
+    <tr>
+        <td><code>is_array_0d</code></td>
+        <td><code>Array0D[ST]</code></td>
+        <td><code>tuple[()]</code></td>
+    </tr>
+    <tr>
+        <td><code>is_array_1d</code></td>
+        <td><code>Array1D[ST]</code></td>
+        <td><code>tuple[int]</code></td>
+    </tr>
+    <tr>
+        <td><code>is_array_2d</code></td>
+        <td><code>Array2D[ST]</code></td>
+        <td><code>tuple[int, int]</code></td>
+    </tr>
+    <tr>
+        <td><code>is_array_3d</code></td>
+        <td><code>Array3D[ST]</code></td>
+        <td><code>tuple[int, int, int]</code></td>
+    </tr>
+</table>
+
+These functions additionally accept an optional `dtype` argument, that accepts either
+a `np.dtype[ST]` instance, a `type[ST]`, or something that has a `dtype: np.dtype[ST]`
+attribute, for type parameter `ST: np.generic`.
+
+Their signatures are almost identical, and look something like
+
+```py
+def is_array_�d[
+    ST: np.generic = np.generic
+](
+    a: object,
+    /,
+    dtype: type[ST] | np.dtype[ST] | HasDType[np.dtype[ST]],
+) -> TypeIs[
+    Array�D[ST]
+]: ...
+```
+
 ##### Shape aliases
 
 A *shape* is nothing more than a tuple of (non-negative) integers, i.e.
@@ -3787,3 +3848,4 @@ dtype: DT
 
 [PEP695]: https://peps.python.org/pep-0695/
 [PEP696]: https://peps.python.org/pep-0696/
+[PEP742]: https://peps.python.org/pep-0742/

--- a/optype/numpy/__init__.py
+++ b/optype/numpy/__init__.py
@@ -4,6 +4,7 @@ from . import (
     _any_dtype,
     _array,
     _dtype,
+    _is,
     _scalar,
     _sequence_nd,
     _shape,
@@ -16,6 +17,7 @@ from ._any_array import *
 from ._any_dtype import *
 from ._array import *
 from ._dtype import *
+from ._is import *
 from ._scalar import *
 from ._sequence_nd import *
 from ._shape import *
@@ -23,15 +25,16 @@ from ._to import *
 from ._ufunc import *
 
 __all__ = ["compat", "ctypeslib"]
-__all__ += _any_array.__all__
-__all__ += _any_dtype.__all__
 __all__ += _array.__all__
-__all__ += _dtype.__all__
-__all__ += _scalar.__all__
+__all__ += _any_array.__all__
 __all__ += _sequence_nd.__all__
+__all__ += _dtype.__all__
+__all__ += _any_dtype.__all__
 __all__ += _shape.__all__
+__all__ += _is.__all__
 __all__ += _to.__all__
 __all__ += _ufunc.__all__
+__all__ += _scalar.__all__
 
 
 def __dir__() -> list[str]:

--- a/optype/numpy/_is.py
+++ b/optype/numpy/_is.py
@@ -1,0 +1,102 @@
+# mypy: disable-error-code="no-any-explicit, no-any-decorated"
+# pyright: reportPrivateUsage=false, reportExplicitAny=false
+
+import sys
+from typing import Any, TypeAlias
+
+if sys.version_info >= (3, 13):
+    from typing import TypeIs, TypeVar
+else:
+    from typing_extensions import TypeIs, TypeVar
+
+import numpy as np
+
+from ._any_dtype import _ToDType
+from ._array import Array0D, Array1D, Array2D, Array3D, ArrayND
+
+__all__ = [
+    "is_array_0d",
+    "is_array_1d",
+    "is_array_2d",
+    "is_array_3d",
+    "is_array_nd",
+    "is_dtype",
+    "is_sctype",
+]
+
+
+def __dir__() -> list[str]:
+    return __all__
+
+
+Shape: TypeAlias = tuple[int, ...]
+ShapeT = TypeVar("ShapeT", bound=Shape, default=Shape)
+DTypeT = TypeVar("DTypeT", bound=np.dtype[Any])
+ScalarT = TypeVar("ScalarT", bound=np.generic, default=np.generic)
+
+
+def is_dtype(
+    x: object,
+    /,
+    dtype: _ToDType[ScalarT] | None = None,
+) -> TypeIs[np.dtype[ScalarT]]:
+    return isinstance(x, np.dtype) and (dtype is None or np.issubdtype(x, dtype))
+
+
+def is_sctype(
+    x: object,
+    /,
+    dtype: _ToDType[ScalarT] | None = None,
+) -> TypeIs[type[ScalarT]]:
+    return (
+        isinstance(x, type)
+        and issubclass(x, np.generic)
+        and (dtype is None or np.issubdtype(x, dtype))
+    )
+
+
+def is_array_nd(
+    a: object,
+    /,
+    dtype: _ToDType[ScalarT] | None = None,
+) -> TypeIs[ArrayND[ScalarT, ShapeT]]:
+    """Checks if `a` is a `ndarray` of the given dtype (defaults to `generic`)."""
+    return isinstance(a, np.ndarray) and (
+        dtype is None or np.issubdtype(a.dtype, dtype)
+    )
+
+
+def is_array_0d(
+    a: object,
+    /,
+    dtype: _ToDType[ScalarT] | None = None,
+) -> TypeIs[Array0D[ScalarT]]:
+    """Checks if `a` is a 0-d `ndarray` of the given dtype (defaults to `generic`)."""
+    return is_array_nd(a, dtype) and a.ndim == 0
+
+
+def is_array_1d(
+    a: object,
+    /,
+    dtype: _ToDType[ScalarT] | None = None,
+) -> TypeIs[Array1D[ScalarT]]:
+    """Checks if `a` is a 1-d `ndarray` of the given dtype (defaults to `generic`)."""
+    return is_array_nd(a, dtype) and a.ndim == 1
+
+
+def is_array_2d(
+    a: object,
+    /,
+    dtype: _ToDType[ScalarT] | None = None,
+) -> TypeIs[Array2D[ScalarT]]:
+    """Checks if `a` is a 2-d `ndarray` of the given dtype (defaults to `generic`)."""
+    return is_array_nd(a, dtype) and a.ndim == 2
+
+
+def is_array_3d(
+    a: object,
+    /,
+    dtype: _ToDType[ScalarT] | None = None,
+) -> TypeIs[Array3D[ScalarT]]:
+    """Checks if `a` is a 3-d `ndarray` of the given dtype (defaults to `generic`)."""
+    return is_array_nd(a, dtype) and a.ndim == 3

--- a/tests/numpy/test_is.py
+++ b/tests/numpy/test_is.py
@@ -1,0 +1,103 @@
+# pyright: reportAny=false
+# pyright: reportUnknownArgumentType=false
+# pyright: reportUnknownLambdaType=false
+# pyright: reportUnknownMemberType=false
+import operator
+from collections.abc import Callable
+
+import numpy as np
+import pytest
+
+import optype.numpy as onp
+
+CHARS = "?BbHhIiLlQqNnPpefdgFDGSUVOMm"
+DTYPES = {np.dtype(char) for char in CHARS}
+SCTYPES = {dtype.type for dtype in DTYPES if issubclass(dtype.type, np.generic)}
+NDARRAY_TYPES = np.ndarray, np.ma.MaskedArray
+
+
+@pytest.mark.parametrize("dtype", DTYPES, ids=str)
+def test_is_dtype(dtype: onp.DType) -> None:
+    assert onp.is_dtype(dtype)
+    assert not onp.is_dtype(type(dtype))
+    assert not onp.is_dtype(dtype.type)
+    assert not onp.is_dtype(np.empty((), dtype))
+    assert not onp.is_dtype(np.empty((), dtype).item())
+
+
+@pytest.mark.parametrize("sctype", SCTYPES, ids=operator.attrgetter("__name__"))
+def test_is_sctype(sctype: type[np.generic]) -> None:
+    assert onp.is_sctype(sctype)
+    assert not onp.is_sctype(np.empty((), sctype))
+    assert not onp.is_sctype(np.empty((), sctype).item())
+    assert not onp.is_sctype(np.dtype(sctype))
+
+
+@pytest.mark.parametrize(
+    "dtype_map",
+    [
+        np.dtype,
+        operator.attrgetter("type"),
+        lambda dtype: dtype.type.mro()[1],
+        lambda dtype: dtype.type.mro()[-2],
+    ],
+    ids=["_", "_.type", "_.type.mro()[1]", "_.type.mro()[-2]"],
+)
+@pytest.mark.parametrize("dtype", DTYPES, ids=str)
+@pytest.mark.parametrize("ndtype", NDARRAY_TYPES)
+def test_is_array(
+    ndtype: type[onp.Array],
+    dtype: onp.DType,
+    dtype_map: Callable[[onp.DType], onp.DType | type[np.generic]],
+):
+    arr = [np.empty(tuple(range(ndim)), dtype).view(ndtype) for ndim in range(5)]
+
+    assert onp.is_array_nd(arr[0])
+    assert onp.is_array_0d(arr[0])
+    assert not onp.is_array_1d(arr[0])
+    assert not onp.is_array_2d(arr[0])
+    assert not onp.is_array_3d(arr[0])
+
+    assert onp.is_array_nd(arr[1])
+    assert not onp.is_array_0d(arr[1])
+    assert onp.is_array_1d(arr[1])
+    assert not onp.is_array_2d(arr[1])
+    assert not onp.is_array_3d(arr[1])
+
+    assert onp.is_array_nd(arr[2])
+    assert not onp.is_array_0d(arr[2])
+    assert not onp.is_array_1d(arr[2])
+    assert onp.is_array_2d(arr[2])
+    assert not onp.is_array_3d(arr[2])
+
+    assert onp.is_array_nd(arr[2].view(np.matrix))
+    assert not onp.is_array_0d(arr[2].view(np.matrix))
+    assert not onp.is_array_1d(arr[2].view(np.matrix))
+    assert onp.is_array_2d(arr[2].view(np.matrix))
+    assert not onp.is_array_3d(arr[2].view(np.matrix))
+
+    assert onp.is_array_nd(arr[3])
+    assert not onp.is_array_0d(arr[3])
+    assert not onp.is_array_1d(arr[3])
+    assert not onp.is_array_2d(arr[3])
+    assert onp.is_array_3d(arr[3])
+
+    assert onp.is_array_nd(arr[4])
+    assert not onp.is_array_0d(arr[4])
+    assert not onp.is_array_1d(arr[4])
+    assert not onp.is_array_2d(arr[4])
+    assert not onp.is_array_3d(arr[4])
+
+    dtype_is = dtype_map(dtype)
+    assert onp.is_array_0d(arr[0], dtype=dtype_is)
+    assert onp.is_array_1d(arr[1], dtype=dtype_is)
+    assert onp.is_array_2d(arr[2], dtype=dtype_is)
+    assert onp.is_array_3d(arr[3], dtype=dtype_is)
+    assert onp.is_array_nd(arr[4], dtype=dtype_is)
+
+    dtype_not = np.dtype("?") if dtype.char != "?" else np.dtype("B")
+    assert not onp.is_array_0d(arr[0], dtype=dtype_not)
+    assert not onp.is_array_1d(arr[1], dtype=dtype_not)
+    assert not onp.is_array_2d(arr[2], dtype=dtype_not)
+    assert not onp.is_array_3d(arr[3], dtype=dtype_not)
+    assert not onp.is_array_nd(arr[4], dtype=dtype_not)

--- a/tests/numpy/test_is.py
+++ b/tests/numpy/test_is.py
@@ -10,7 +10,11 @@ import pytest
 
 import optype.numpy as onp
 
-CHARS = "?BbHhIiLlQqNnPpefdgFDGSUVOMm"
+if np.__version__ >= "2":
+    CHARS = "?BbHhIiLlQqNnPpefdgFDGSUVOMm"
+else:
+    CHARS = "?BbHhIiLlQqPpefdgFDGSUVOMm"  # pyright: ignore[reportConstantRedefinition]
+
 DTYPES = {np.dtype(char) for char in CHARS}
 SCTYPES = {dtype.type for dtype in DTYPES if issubclass(dtype.type, np.generic)}
 NDARRAY_TYPES = np.ndarray, np.ma.MaskedArray

--- a/tests/numpy/test_is.py
+++ b/tests/numpy/test_is.py
@@ -15,7 +15,7 @@ if np.__version__ >= "2":
 else:
     CHARS = "?BbHhIiLlQqPpefdgFDGSUVOMm"  # pyright: ignore[reportConstantRedefinition]
 
-DTYPES = {np.dtype(char) for char in CHARS}
+DTYPES = [np.dtype(char) for char in CHARS]
 SCTYPES = {dtype.type for dtype in DTYPES if issubclass(dtype.type, np.generic)}
 NDARRAY_TYPES = np.ndarray, np.ma.MaskedArray
 


### PR DESCRIPTION
Closes #254.

---

To check whether a given object is an instance of `Array{0,1,2,3,N}D`, in a way that static type-checkers also understand it, the following PEP 742 typeguards can be used:
<table>
    <tr>
        <th>typeguard</th>
        <th>narrows to</th>
        <th>shape type</th>
    </tr>
    <tr>
        <th colspan="2"><code>optype.numpy._</code></th>
        <th><code>builtins._</code></th>
    </tr>
    <tr>
        <td><code>is_array_nd</code></td>
        <td><code>ArrayND[ST]</code></td>
        <td><code>tuple[int, ...]</code></td>
    </tr>
    <tr>
        <td><code>is_array_0d</code></td>
        <td><code>Array0D[ST]</code></td>
        <td><code>tuple[()]</code></td>
    </tr>
    <tr>
        <td><code>is_array_1d</code></td>
        <td><code>Array1D[ST]</code></td>
        <td><code>tuple[int]</code></td>
    </tr>
    <tr>
        <td><code>is_array_2d</code></td>
        <td><code>Array2D[ST]</code></td>
        <td><code>tuple[int, int]</code></td>
    </tr>
    <tr>
        <td><code>is_array_3d</code></td>
        <td><code>Array3D[ST]</code></td>
        <td><code>tuple[int, int, int]</code></td>
    </tr>
</table>

These functions additionally accept an optional `dtype` argument, that can either be a `np.dtype[ST]` instance, a `type[ST]`, or something that has a `dtype: np.dtype[ST]` attribute.
The signatures are almost identical to each other, and in the `0d` case it roughly looks like this:

```py
ST = TypeVar("ST", bound=np.generic, default=np.generic)
_ToDType: TypeAlias = type[ST] | np.dtype[ST] | HasDType[np.dtype[ST]]
def is_array_0d(a, /, dtype: _ToDType[ST] | None = None) -> TypeIs[Array0D[ST]]: ...
```

---

Ping @RandallPittmanOrSt