### PR TITLE
new `optype.numpy.random` submodule

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,7 +248,8 @@ The API of `optype` is flat; a single `import optype as opt` is all you need
 - [`optype.numpy`](#optypenumpy)
     - [Shape-typing](#shape-typing)
     - [Array-likes](#array-likes)
-    - [`compat` module](#compat-module)
+    - [`compat` submodule](#compat-submodule)
+    - [`random` submodule](#random-submodule)
     - [`Any*Array` and `Any*DType`](#anyarray-and-anydtype)
     - [Low-level interfaces](#low-level-interfaces)
 
@@ -3030,7 +3031,7 @@ Source code: [`optype/numpy/_to.py`][CODE-NP-TO]
 
 Source code: [`optype/numpy/_to.py`][CODE-NP-TO]
 
-#### `compat` module
+#### `compat` submodule
 
 Compatibility module for supporting a wide (currently `1.23` - `2.2`) range of numpy
 versions. It contains two kinds of things:
@@ -3042,6 +3043,22 @@ I explained in the [`release notes`][NP-REL22].
 
 [NP-EXC]: https://numpy.org/doc/stable/reference/routines.exceptions.html
 [NP-REL22]: https://numpy.org/doc/stable/release/2.2.0-notes.html#new-features
+
+#### `random` submodule
+
+[SPEC 7](https://scientific-python.org/specs/spec-0007/) -compatible type aliases.
+The `optype.numpy.random` module provides three type aliases: `RNG`, `ToRNG`, and
+`ToSeed`.
+
+In general, the most useful one is `ToRNG`, which describes what can be
+passed to `numpy.random.default_rng`. It is defined as the union of `RNG`, `ToSeed`,
+and `numpy.random.BitGenerator`.
+
+The `RNG` is the union type of `numpy.random.Generator` and its legacy dual type,
+`numpy.random.RandomState`.
+
+`ToSeed` accepts integer-like scalars, sequences, and arrays, as well as instances of
+`numpy.random.SeedSequence`.
 
 #### `DType`
 

--- a/optype/numpy/__init__.py
+++ b/optype/numpy/__init__.py
@@ -12,6 +12,7 @@ from . import (
     _ufunc,
     compat,
     ctypeslib,
+    random,
 )
 from ._any_array import *
 from ._any_dtype import *
@@ -24,7 +25,7 @@ from ._shape import *
 from ._to import *
 from ._ufunc import *
 
-__all__ = ["compat", "ctypeslib"]
+__all__ = ["compat", "ctypeslib", "random"]
 __all__ += _array.__all__
 __all__ += _any_array.__all__
 __all__ += _sequence_nd.__all__

--- a/optype/numpy/random.py
+++ b/optype/numpy/random.py
@@ -1,0 +1,31 @@
+"""
+Type aliases for [SPEC 7](https://scientific-python.org/specs/spec-0007/).
+"""
+
+import sys
+from collections.abc import Sequence
+from typing import Any, TypeAlias
+
+if sys.version_info >= (3, 12):
+    from typing import TypeAliasType
+else:
+    from typing_extensions import TypeAliasType
+
+import numpy as np
+
+__all__ = ["RNG", "ToRNG", "ToSeed"]
+
+###
+
+_Integral: TypeAlias = np.integer[Any] | np.timedelta64
+_IntOrSequence: TypeAlias = int | _Integral | Sequence[int | _Integral]
+
+ToSeed = TypeAliasType(
+    "ToSeed",
+    np.random.SeedSequence
+    | _IntOrSequence
+    | np.ndarray[Any, np.dtype[_Integral | np.flexible | np.object_]],
+)
+
+RNG = TypeAliasType("RNG", np.random.Generator | np.random.RandomState)
+ToRNG = TypeAliasType("ToRNG", RNG | np.random.BitGenerator | ToSeed)


### PR DESCRIPTION
[SPEC 7](https://scientific-python.org/specs/spec-0007/) -compatible type aliases.
The `optype.numpy.random` module provides three type aliases: `RNG`, `ToRNG`, and
`ToSeed`.

In general, the most useful one is `ToRNG`, which describes what can be
passed to `numpy.random.default_rng`. It is defined as the union of `RNG`, `ToSeed`,
and `numpy.random.BitGenerator`.

The `RNG` is the union type of `numpy.random.Generator` and its legacy dual type,
`numpy.random.RandomState`.

`ToSeed` accepts integer-like scalars, sequences, and arrays, as well as instances of
`numpy.random.SeedSequence`.