### PR TITLE
common numpy literal types 

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,7 @@ The API of `optype` is flat; a single `import optype as opt` is all you need
 - [`optype.numpy`](#optypenumpy)
     - [Shape-typing](#shape-typing)
     - [Array-likes](#array-likes)
+    - [Literals](#literals)
     - [`compat` submodule](#compat-submodule)
     - [`random` submodule](#random-submodule)
     - [`Any*Array` and `Any*DType`](#anyarray-and-anydtype)
@@ -3030,6 +3031,26 @@ Source code: [`optype/numpy/_to.py`][CODE-NP-TO]
 > their non-strict dual type, `ToArray{1,2,3}D`.
 
 Source code: [`optype/numpy/_to.py`][CODE-NP-TO]
+
+#### Literals
+
+| Type Alias      | String values                                                      |
+| --------------- | ------------------------------------------------------------------ |
+| `ByteOrder`     | `ByteOrderChar \| ByteOrderName \| {L, B, N, I, S}`                |
+| `ByteOrderChar` | `{<, >, =, \|}`                                                    |
+| `ByteOrderName` | `{little, big, native, ignore, swap}`                              |
+| `Casting`       | `CastingUnsafe \| CastingSafe`                                     |
+| `CastingUnsafe` | `{unsafe}`                                                         |
+| `CastingSafe`   | `{no, equiv, safe, same_kind}`                                     |
+| `ConvolveMode`  | `{full, same, valid}`                                              |
+| `Device`        | `{cpu}`                                                            |
+| `IndexMode`     | `{raise, wrap, clip}`                                              |
+| `OrderCF`       | `{C, F}`                                                           |
+| `OrderACF`      | `{A, C, F}`                                                        |
+| `OrderKACF`     | `{K, A, C, F}`                                                     |
+| `PartitionKind` | `{introselect}`                                                    |
+| `SortKind`      | `{Q, quick[sort], M, merge[sort], H, heap[sort], S, stable[sort]}` |
+| `SortSide`      | `{left, right}`                                                    |
 
 #### `compat` submodule
 

--- a/optype/numpy/__init__.py
+++ b/optype/numpy/__init__.py
@@ -5,6 +5,7 @@ from . import (
     _array,
     _dtype,
     _is,
+    _literals,
     _scalar,
     _sequence_nd,
     _shape,
@@ -19,6 +20,7 @@ from ._any_dtype import *
 from ._array import *
 from ._dtype import *
 from ._is import *
+from ._literals import *
 from ._scalar import *
 from ._sequence_nd import *
 from ._shape import *
@@ -26,6 +28,7 @@ from ._to import *
 from ._ufunc import *
 
 __all__ = ["compat", "ctypeslib", "random"]
+__all__ += _literals.__all__
 __all__ += _array.__all__
 __all__ += _any_array.__all__
 __all__ += _sequence_nd.__all__

--- a/optype/numpy/_literals.py
+++ b/optype/numpy/_literals.py
@@ -1,0 +1,47 @@
+from typing import Literal, TypeAlias
+
+__all__ = [
+    "ByteOrder",
+    "ByteOrderChar",
+    "ByteOrderName",
+    "Casting",
+    "CastingSafe",
+    "CastingUnsafe",
+    "ConvolveMode",
+    "Device",
+    "OrderACF",
+    "OrderCF",
+    "OrderKACF",
+    "PartitionKind",
+    "SortKind",
+    "SortSide",
+]
+
+Device: TypeAlias = Literal["cpu"]
+
+ByteOrderChar: TypeAlias = Literal["<", ">", "=", "|"]
+ByteOrderName: TypeAlias = Literal["little", "big", "native", "ignore", "swap"]
+_ByteOrderShort: TypeAlias = Literal["L", "B", "N", "I", "S"]
+ByteOrder: TypeAlias = Literal[ByteOrderChar, _ByteOrderShort, ByteOrderName]
+
+CastingSafe: TypeAlias = Literal["no", "equiv", "safe", "same_kind"]
+CastingUnsafe: TypeAlias = Literal["unsafe"]
+Casting: TypeAlias = Literal[CastingSafe, CastingUnsafe]
+
+OrderCF: TypeAlias = Literal["C", "F"]
+OrderACF: TypeAlias = Literal["A", OrderCF]
+OrderKACF: TypeAlias = Literal["K", OrderACF]
+
+IndexMode: TypeAlias = Literal["raise", "wrap", "clip"]
+
+PartitionKind: TypeAlias = Literal["introselect"]
+
+SortKind: TypeAlias = Literal[
+    "Q", "quick", "quicksort",
+    "M", "merge", "mergesort",
+    "H", "heap", "heapsort",
+    "S", "stable", "stablesort",
+]  # fmt: skip
+SortSide: TypeAlias = Literal["left", "right"]
+
+ConvolveMode: TypeAlias = Literal["full", "same", "valid"]


### PR DESCRIPTION
| Type Alias      | String values                                                      |
| --------------- | ------------------------------------------------------------------ |
| `ByteOrder`     | `ByteOrderChar \| ByteOrderName \| {L, B, N, I, S}`                |
| `ByteOrderChar` | `{<, >, =, \|}`                                                    |
| `ByteOrderName` | `{little, big, native, ignore, swap}`                              |
| `Casting`       | `CastingUnsafe \| CastingSafe`                                     |
| `CastingUnsafe` | `{unsafe}`                                                         |
| `CastingSafe`   | `{no, equiv, safe, same_kind}`                                     |
| `ConvolveMode`  | `{full, same, valid}`                                              |
| `Device`        | `{cpu}`                                                            |
| `IndexMode`     | `{raise, wrap, clip}`                                              |
| `OrderCF`       | `{C, F}`                                                           |
| `OrderACF`      | `{A, C, F}`                                                        |
| `OrderKACF`     | `{K, A, C, F}`                                                     |
| `PartitionKind` | `{introselect}`                                                    |
| `SortKind`      | `{Q, quick[sort], M, merge[sort], H, heap[sort], S, stable[sort]}` |
| `SortSide`      | `{left, right}`                                                    |