### PR TITLE
fix `To{}(2|3)D` not being assignable to `To{}ND`

### DIFF
--- a/optype/inspect.py
+++ b/optype/inspect.py
@@ -3,15 +3,20 @@ import types
 from collections.abc import Iterable
 from typing import Literal, TypeAlias, cast, get_args as _get_args, overload
 
+if sys.version_info >= (3, 12):
+    from typing import TypeAliasType
+else:
+    from typing_extensions import TypeAliasType
+
 if sys.version_info >= (3, 13):
-    from typing import TypeAliasType, TypeIs, _get_protocol_attrs, is_protocol
+    from typing import TypeIs, _get_protocol_attrs, is_protocol
 else:
     from typing_extensions import (  # type: ignore[attr-defined]
-        TypeAliasType,
         TypeIs,
         _get_protocol_attrs,  # noqa: PLC2701  # pyright: ignore[reportAttributeAccessIssue, reportUnknownVariableType]
         is_protocol,
     )
+
 
 from ._core import _can as _c
 from .types import (

--- a/optype/numpy/_scalar.py
+++ b/optype/numpy/_scalar.py
@@ -3,12 +3,10 @@
 import sys
 from typing import Any, Literal, Protocol, TypeAlias
 
-if sys.version_info >= (3, 13):
-    from types import CapsuleType
+if sys.version_info >= (3, 12):
     from typing import (
         Self,
         TypeAliasType,
-        TypeVar,
         overload,
         override,
         runtime_checkable,
@@ -18,11 +16,15 @@ else:
         CapsuleType,
         Self,
         TypeAliasType,
-        TypeVar,
         overload,
         override,
         runtime_checkable,
     )
+if sys.version_info >= (3, 13):
+    from types import CapsuleType
+    from typing import TypeVar
+else:
+    from typing_extensions import CapsuleType, TypeVar
 
 import numpy as np
 import numpy.typing as npt

--- a/optype/numpy/_to.py
+++ b/optype/numpy/_to.py
@@ -2,10 +2,15 @@ import sys
 from collections.abc import Sequence as Seq
 from typing import Literal, TypeAlias
 
-if sys.version_info >= (3, 13):
-    from typing import TypeAliasType, TypeVar
+if sys.version_info >= (3, 12):
+    from typing import TypeAliasType
 else:
-    from typing_extensions import TypeAliasType, TypeVar
+    from typing_extensions import TypeAliasType
+
+if sys.version_info >= (3, 13):
+    from typing import TypeVar
+else:
+    from typing_extensions import TypeVar
 
 import numpy as np
 
@@ -99,7 +104,7 @@ _To3D = TypeAliasType(
 )
 _ToND = TypeAliasType(
     "_ToND",
-    CanArrayND[SCT] | SeqND[CanArrayND[SCT]] | SeqND[_To0D[T, SCT]],
+    CanArrayND[SCT] | SeqND[CanArrayND[SCT] | _To0D[T, SCT]],
     type_params=(T, SCT),
 )
 

--- a/tests/numpy/test_to.pyi
+++ b/tests/numpy/test_to.pyi
@@ -348,3 +348,100 @@ def s3d_a3d() -> None:
     c16_co__c16: onp.ToComplex128Strict3D = c16_co_3d
     f8_co__f: onp.ToFloat64Strict3D = f_co_3d  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
     c16_co__c: onp.ToComplex128Strict3D = c_co_3d  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+
+# n-d
+
+def nd_sca() -> None:
+    x__x: onp.ToArrayND = x_  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+    b__b: onp.ToBoolND = b_  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+    i__i: onp.ToJustIntND = i_  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+    f__f: onp.ToJustFloatND = f_  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+    c__c: onp.ToJustComplexND = c_  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+    f8__f8: onp.ToJustFloat64_ND = f8  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+    c16__c16: onp.ToJustComplex128_ND = c16  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+    i_co__i_co: onp.ToIntND = i_co  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+    f_co__f_co: onp.ToFloatND = f_co  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+    c_co__c_co: onp.ToComplexND = c_co  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+    f8_co__f8_co: onp.ToFloat64_ND = f8_co  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+    c16_co__c16_co: onp.ToComplex128_ND = c16_co  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+
+def nd_1d() -> None:
+    to_x_1d: onp.ToArray1D
+    to_b_1d: onp.ToBool1D
+    to_i_1d: onp.ToJustInt1D
+    to_f_1d: onp.ToJustFloat1D
+    to_c_1d: onp.ToJustComplex1D
+    to_f8_1d: onp.ToJustFloat64_1D
+    to_c16_1d: onp.ToJustComplex128_1D
+    to_i_co_1d: onp.ToInt1D
+    to_f_co_1d: onp.ToFloat1D
+    to_c_co_1d: onp.ToComplex1D
+    to_f8_co_1d: onp.ToFloat64_1D
+    to_c16_co_1d: onp.ToComplex128_1D
+
+    x__x: onp.ToArrayND = to_x_1d
+    b__b: onp.ToBoolND = to_b_1d
+    i__i: onp.ToJustIntND = to_i_1d
+    f__f: onp.ToJustFloatND = to_f_1d
+    c__c: onp.ToJustComplexND = to_c_1d
+    f8__f8: onp.ToJustFloat64_ND = to_f8_1d
+    c16__c16: onp.ToJustComplex128_ND = to_c16_1d
+    i_co__i: onp.ToIntND = to_i_co_1d
+    f_co__f: onp.ToFloatND = to_f_co_1d
+    c_co__c: onp.ToComplexND = to_c_co_1d
+    f8_co__f8: onp.ToFloat64_ND = to_f8_co_1d
+    c16_co__c16: onp.ToComplex128_ND = to_c16_co_1d
+
+def nd_2d() -> None:
+    to_x_2d: onp.ToArray2D
+    to_b_2d: onp.ToBool2D
+    to_i_2d: onp.ToJustInt2D
+    to_f_2d: onp.ToJustFloat2D
+    to_c_2d: onp.ToJustComplex2D
+    to_f8_2d: onp.ToJustFloat64_2D
+    to_c16_2d: onp.ToJustComplex128_2D
+    to_i_co_2d: onp.ToInt2D
+    to_f_co_2d: onp.ToFloat2D
+    to_c_co_2d: onp.ToComplex2D
+    to_f8_co_2d: onp.ToFloat64_2D
+    to_c16_co_2d: onp.ToComplex128_2D
+
+    x__x: onp.ToArrayND = to_x_2d
+    b__b: onp.ToBoolND = to_b_2d
+    i__i: onp.ToJustIntND = to_i_2d
+    f__f: onp.ToJustFloatND = to_f_2d
+    c__c: onp.ToJustComplexND = to_c_2d
+    f8__f8: onp.ToJustFloat64_ND = to_f8_2d
+    c16__c16: onp.ToJustComplex128_ND = to_c16_2d
+    i_co__i: onp.ToIntND = to_i_co_2d
+    f_co__f: onp.ToFloatND = to_f_co_2d
+    c_co__c: onp.ToComplexND = to_c_co_2d
+    f8_co__f8: onp.ToFloat64_ND = to_f8_co_2d
+    c16_co__c16: onp.ToComplex128_ND = to_c16_co_2d
+
+def nd_3d() -> None:
+    to_x_3d: onp.ToArray3D
+    to_b_3d: onp.ToBool3D
+    to_i_3d: onp.ToJustInt3D
+    to_f_3d: onp.ToJustFloat3D
+    to_c_3d: onp.ToJustComplex3D
+    to_f8_3d: onp.ToJustFloat64_3D
+    to_c16_3d: onp.ToJustComplex128_3D
+    to_i_co_3d: onp.ToInt3D
+    to_f_co_3d: onp.ToFloat3D
+    to_c_co_3d: onp.ToComplex3D
+    to_f8_co_3d: onp.ToFloat64_3D
+    to_c16_co_3d: onp.ToComplex128_3D
+
+    x__x: onp.ToArrayND = to_x_3d
+    b__b: onp.ToBoolND = to_b_3d
+    i__i: onp.ToJustIntND = to_i_3d
+    f__f: onp.ToJustFloatND = to_f_3d
+    c__c: onp.ToJustComplexND = to_c_3d
+    f8__f8: onp.ToJustFloat64_ND = to_f8_3d
+    c16__c16: onp.ToJustComplex128_ND = to_c16_3d
+    i_co__i: onp.ToIntND = to_i_co_3d
+    f_co__f: onp.ToFloatND = to_f_co_3d
+    c_co__c: onp.ToComplexND = to_c_co_3d
+    f8_co__f8: onp.ToFloat64_ND = to_f8_co_3d
+    c16_co__c16: onp.ToComplex128_ND = to_c16_co_3d


### PR DESCRIPTION
This fixes an issue where the 2- and 3-d `optype.numpy.To(2|3)D` array-like types were not assignable to their `*ND` variants, e.g.:

```py
import numpy as np
import optype.numpy as onp

def fn(x: onp.ToFloatND) -> int:
    return np.asarray(x).size

def f2(x: onp.ToFloat2D) -> int:
    return fn(x)  # will no longer be rejected
```

This additionally works around a regression in `typing_extensions==4.13.0` that results in a `TypeError` being raised when taking the union of `typing.TypeAliasType` and `typing_extension.TypeAliasType` on (at least) Python 3.12.