### PR TITLE
require `python >= 3.11`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
         uses: astral-sh/setup-uv@v6
         with:
           activate-environment: true
-          python-version: "3.10"
+          python-version: "3.11"
       - run: uv sync
 
       - name: Install numpy ${{ matrix.np }}
@@ -87,10 +87,10 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        py: ["3.10", "3.13"]
+        py: ["3.11", "3.12", "3.13"]
         include:
           - os: ubuntu-latest
-            py: "3.10"
+            py: "3.11"
             np: "1.25"
 
     steps:

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ With this, the `twice` function can written as:
 
 <table>
 <tr>
-<th width="415px">Python 3.10</th>
+<th width="415px">Python 3.11</th>
 <th width="415px">Python 3.12+</th>
 </tr>
 <tr>
@@ -165,7 +165,7 @@ Because the `optype.Can*` protocols are runtime-checkable, the revised
 
 <table>
 <tr>
-<th width="415px">Python 3.10</th>
+<th width="415px">Python 3.11</th>
 <th width="415px">Python 3.12+</th>
 </tr>
 <tr>

--- a/examples/functor.py
+++ b/examples/functor.py
@@ -3,12 +3,12 @@ from __future__ import annotations
 import sys
 import optype as op
 
-from typing import Generic
+from typing import Generic, final, overload
 
 if sys.version_info >= (3, 13):
-    from typing import final, override, overload, TypeVar
+    from typing import override, TypeVar
 else:
-    from typing_extensions import final, override, overload, TypeVar
+    from typing_extensions import override, TypeVar
 
 from collections.abc import Callable as CanCall
 from types import NotImplementedType

--- a/examples/twice.py
+++ b/examples/twice.py
@@ -1,15 +1,5 @@
 # %%
-import sys
-from typing import (
-    Literal,
-    TypeAlias,
-    TypeVar,
-)
-
-if sys.version_info >= (3, 12):
-    from typing import assert_type
-else:
-    from typing_extensions import assert_type
+from typing import Literal, TypeAlias, TypeVar, assert_type
 
 import optype as op
 

--- a/optype/_core/_can.py
+++ b/optype/_core/_can.py
@@ -2,26 +2,12 @@
 import sys
 import types
 from collections.abc import Generator
-from typing import Protocol, SupportsIndex, TypeAlias
+from typing import Protocol, Self, SupportsIndex, TypeAlias, overload
 
 if sys.version_info >= (3, 13):
-    from typing import (
-        ParamSpec,
-        Self,
-        TypeVar,
-        overload,
-        override,
-        runtime_checkable,
-    )
+    from typing import ParamSpec, TypeVar, override, runtime_checkable
 else:
-    from typing_extensions import (
-        ParamSpec,
-        Self,
-        TypeVar,
-        overload,
-        override,
-        runtime_checkable,
-    )
+    from typing_extensions import ParamSpec, TypeVar, override, runtime_checkable
 
 __all__ = [
     "CanAEnter",

--- a/optype/_core/_do.py
+++ b/optype/_core/_do.py
@@ -3,13 +3,12 @@
 import math
 import operator as _o
 import sys
-from collections.abc import Callable
-from typing import TYPE_CHECKING, Final, Literal, cast
+from typing import TYPE_CHECKING, Final, Literal, cast, overload
 
 if sys.version_info >= (3, 13):
-    from typing import ParamSpec, TypeVar, overload
+    from typing import TypeVar
 else:
-    from typing_extensions import ParamSpec, TypeVar, overload
+    from typing_extensions import TypeVar
 
 import optype._core._can as _c
 import optype._core._does as _d
@@ -143,14 +142,8 @@ do_dir: Final = cast("_d.DoesDir", dir)
 
 # callables
 
-if sys.version_info >= (3, 11):
-    do_call: Final = cast("_d.DoesCall", _o.call)
-else:
-    _Pss = ParamSpec("_Pss")
-    _R = TypeVar("_R")
 
-    def do_call(f: Callable[_Pss, _R], /, *args: _Pss.args, **kw: _Pss.kwargs) -> _R:
-        return f(*args, **kw)
+do_call: Final = cast("_d.DoesCall", _o.call)
 
 # containers and sequences
 

--- a/optype/_core/_does.py
+++ b/optype/_core/_does.py
@@ -1,11 +1,11 @@
 import sys
 from collections.abc import AsyncIterator, Callable, Iterable, Iterator
-from typing import Literal, Protocol, TypeAlias
+from typing import Literal, Protocol, TypeAlias, overload
 
 if sys.version_info >= (3, 13):
-    from typing import ParamSpec, TypeVar, overload
+    from typing import ParamSpec, TypeVar
 else:
-    from typing_extensions import ParamSpec, TypeVar, overload
+    from typing_extensions import ParamSpec, TypeVar
 
 import optype._core._can as _c
 

--- a/optype/_core/_has.py
+++ b/optype/_core/_has.py
@@ -1,11 +1,10 @@
 import sys
 import types
 from collections.abc import Callable, Iterable, Mapping
-from typing import Any, ClassVar, TypeAlias
+from typing import Any, ClassVar, LiteralString, TypeAlias
 
 if sys.version_info >= (3, 13):
     from typing import (
-        LiteralString,
         ParamSpec,
         Protocol,
         TypeVar,
@@ -15,7 +14,6 @@ if sys.version_info >= (3, 13):
     )
 else:
     from typing_extensions import (
-        LiteralString,
         ParamSpec,
         Protocol,
         TypeVar,

--- a/optype/_core/_just.py
+++ b/optype/_core/_just.py
@@ -1,19 +1,19 @@
 import datetime as dt
 import sys
-from typing import Any, Generic, Protocol, TypeAlias, _ProtocolMeta  # noqa: PLC2701
+from typing import (
+    Any,
+    Generic,
+    Protocol,
+    Self,
+    TypeAlias,
+    _ProtocolMeta,  # noqa: PLC2701
+    final,
+)
 
 if sys.version_info >= (3, 13):
-    from typing import Self, TypeIs, TypeVar, Unpack, final, override, runtime_checkable
+    from typing import TypeIs, TypeVar, override, runtime_checkable
 else:
-    from typing_extensions import (
-        Self,
-        TypeIs,
-        TypeVar,
-        Unpack,
-        final,
-        override,
-        runtime_checkable,
-    )
+    from typing_extensions import TypeIs, TypeVar, override, runtime_checkable
 
 from ._can import CanFloat, CanIndex
 
@@ -97,7 +97,7 @@ class _JustMeta(_ProtocolMeta, Generic[_ObjectT]):
     def __new__(  # noqa: PYI019
         mcls: type[_TypeT],
         /,
-        *args: Unpack[tuple[str, tuple[type, ...], dict[str, Any]]],
+        *args: *tuple[str, tuple[type, ...], dict[str, Any]],
         just: type[_ObjectT],
     ) -> _TypeT:
         self = super().__new__(mcls, *args)  # type: ignore[misc]

--- a/optype/_utils.py
+++ b/optype/_utils.py
@@ -1,12 +1,12 @@
 import sys
 import types
 from collections.abc import Callable
-from typing import Protocol
+from typing import LiteralString, Protocol
 
 if sys.version_info >= (3, 13):
-    from typing import LiteralString, TypeVar, is_protocol
+    from typing import TypeVar, is_protocol
 else:
-    from typing_extensions import LiteralString, TypeVar, is_protocol
+    from typing_extensions import TypeVar, is_protocol
 
 __all__ = "get_callables", "set_module"
 

--- a/optype/copy.py
+++ b/optype/copy.py
@@ -4,12 +4,12 @@ https://docs.python.org/3/library/copy.html
 """
 
 import sys
-from typing import Protocol
+from typing import Protocol, Self
 
 if sys.version_info >= (3, 13):
-    from typing import Self, TypeVar, override, runtime_checkable
+    from typing import TypeVar, override, runtime_checkable
 else:
-    from typing_extensions import Self, TypeVar, override, runtime_checkable
+    from typing_extensions import TypeVar, override, runtime_checkable
 
 __all__ = (
     "CanCopy",

--- a/optype/inspect.py
+++ b/optype/inspect.py
@@ -3,15 +3,11 @@ import types
 from collections.abc import Iterable
 from typing import Literal, TypeAlias, cast, get_args as _get_args, overload
 
-if sys.version_info >= (3, 12):
-    from typing import TypeAliasType
-else:
-    from typing_extensions import TypeAliasType
-
 if sys.version_info >= (3, 13):
-    from typing import TypeIs, _get_protocol_attrs, is_protocol
+    from typing import TypeAliasType, TypeIs, _get_protocol_attrs, is_protocol
 else:
     from typing_extensions import (  # type: ignore[attr-defined]
+        TypeAliasType,
         TypeIs,
         _get_protocol_attrs,  # noqa: PLC2701  # pyright: ignore[reportAttributeAccessIssue, reportUnknownVariableType]
         is_protocol,
@@ -101,9 +97,6 @@ def is_final(arg: object, /) -> bool:
     """
     Check if the type, method, classmethod, staticmethod, or property, is
     decorated with `@typing.final` or `@typing_extensions.final`.
-
-    IMPORTANT: On Python 3.10, `@typing_extensions.final` should be used
-    instead of `@typing.final`.
 
     IMPORTANT: A final `@property` won't be recognized unless `@final` is
     applied before the `@property` decorator, i.e. directly on the method.

--- a/optype/numpy/_any_array.py
+++ b/optype/numpy/_any_array.py
@@ -1,11 +1,11 @@
 import sys
 from collections.abc import Iterator
-from typing import Any, Protocol, TypeAlias
+from typing import Any, Never, Protocol, TypeAlias
 
 if sys.version_info >= (3, 13):
-    from typing import Never, TypeAliasType, TypeVar
+    from typing import TypeAliasType, TypeVar
 else:
-    from typing_extensions import Never, TypeAliasType, TypeVar
+    from typing_extensions import TypeAliasType, TypeVar
 
 import numpy as np
 

--- a/optype/numpy/_any_dtype.py
+++ b/optype/numpy/_any_dtype.py
@@ -5,12 +5,12 @@ The names are analogous to those in `numpy.dtypes`.
 
 import sys
 from collections.abc import Sequence
-from typing import Any, TypeAlias
+from typing import Any, Never, TypeAlias
 
 if sys.version_info >= (3, 13):
-    from typing import Never, TypeAliasType
+    from typing import TypeAliasType
 else:
-    from typing_extensions import Never, TypeAliasType
+    from typing_extensions import TypeAliasType
 
 import numpy as np
 

--- a/optype/numpy/_array.py
+++ b/optype/numpy/_array.py
@@ -1,11 +1,11 @@
 import sys
 from collections.abc import Mapping
-from typing import Any, Protocol, TypeAlias
+from typing import Any, Protocol, Self, TypeAlias
 
 if sys.version_info >= (3, 13):
-    from typing import Self, TypeAliasType, TypeVar, runtime_checkable
+    from typing import TypeAliasType, TypeVar, runtime_checkable
 else:
-    from typing_extensions import Self, TypeAliasType, TypeVar, runtime_checkable
+    from typing_extensions import TypeAliasType, TypeVar, runtime_checkable
 
 import numpy as np
 

--- a/optype/numpy/_scalar.py
+++ b/optype/numpy/_scalar.py
@@ -1,30 +1,19 @@
 # ruff: noqa: PYI042
 
 import sys
-from typing import Any, Literal, Protocol, TypeAlias
+from typing import Any, Literal, Protocol, Self, TypeAlias, overload
 
-if sys.version_info >= (3, 12):
-    from typing import (
-        Self,
-        TypeAliasType,
-        overload,
-        override,
-        runtime_checkable,
-    )
+if sys.version_info >= (3, 13):
+    from types import CapsuleType
+    from typing import TypeAliasType, TypeVar, override, runtime_checkable
 else:
     from typing_extensions import (
         CapsuleType,
-        Self,
         TypeAliasType,
-        overload,
+        TypeVar,
         override,
         runtime_checkable,
     )
-if sys.version_info >= (3, 13):
-    from types import CapsuleType
-    from typing import TypeVar
-else:
-    from typing_extensions import CapsuleType, TypeVar
 
 import numpy as np
 import numpy.typing as npt

--- a/optype/numpy/_shape.py
+++ b/optype/numpy/_shape.py
@@ -2,9 +2,9 @@ import sys
 from typing import Any, Literal, TypeAlias
 
 if sys.version_info >= (3, 13):
-    from typing import TypeAliasType, TypeVar, Unpack
+    from typing import TypeAliasType, TypeVar
 else:
-    from typing_extensions import TypeAliasType, TypeVar, Unpack
+    from typing_extensions import TypeAliasType, TypeVar
 
 
 __all__ = [
@@ -32,25 +32,13 @@ AxT = TypeVar("AxT", int, Any, default=int)
 ###
 # Shape types with at least N dimensions. They're fully static by default, but can be
 # turned "gradual" by passing `Any` as type argument.
-AtLeast0D = TypeAliasType(
-    "AtLeast0D",
-    tuple[AxT, ...],
-    type_params=(AxT,),
-)
-AtLeast1D = TypeAliasType(
-    "AtLeast1D",
-    tuple[int, Unpack[tuple[AxT, ...]]],
-    type_params=(AxT,),
-)
+AtLeast0D = TypeAliasType("AtLeast0D", tuple[AxT, ...], type_params=(AxT,))
+AtLeast1D = TypeAliasType("AtLeast1D", tuple[int, *tuple[AxT, ...]], type_params=(AxT,))
 AtLeast2D = TypeAliasType(
-    "AtLeast2D",
-    tuple[int, int, Unpack[tuple[AxT, ...]]],
-    type_params=(AxT,),
+    "AtLeast2D", tuple[int, int, *tuple[AxT, ...]], type_params=(AxT,)
 )
 AtLeast3D = TypeAliasType(
-    "AtLeast3D",
-    tuple[int, int, int, Unpack[tuple[AxT, ...]]],
-    type_params=(AxT,),
+    "AtLeast3D", tuple[int, int, int, *tuple[AxT, ...]], type_params=(AxT,)
 )
 
 ###

--- a/optype/numpy/_to.py
+++ b/optype/numpy/_to.py
@@ -2,15 +2,10 @@ import sys
 from collections.abc import Sequence as Seq
 from typing import Literal, TypeAlias
 
-if sys.version_info >= (3, 12):
-    from typing import TypeAliasType
-else:
-    from typing_extensions import TypeAliasType
-
 if sys.version_info >= (3, 13):
-    from typing import TypeVar
+    from typing import TypeAliasType, TypeVar
 else:
-    from typing_extensions import TypeVar
+    from typing_extensions import TypeAliasType, TypeVar
 
 import numpy as np
 

--- a/optype/numpy/_ufunc.py
+++ b/optype/numpy/_ufunc.py
@@ -1,12 +1,12 @@
 import sys
 import types
 from collections.abc import Callable, Iterable, Mapping, Sequence
-from typing import Any, Literal as L, Protocol, TypeAlias  # noqa: N817
+from typing import Any, Literal as L, LiteralString, Protocol, TypeAlias  # noqa: N817
 
 if sys.version_info >= (3, 13):
-    from typing import LiteralString, TypeVar, runtime_checkable
+    from typing import TypeVar, runtime_checkable
 else:
-    from typing_extensions import LiteralString, TypeVar, runtime_checkable
+    from typing_extensions import TypeVar, runtime_checkable
 
 import numpy as np
 import numpy.typing as npt

--- a/optype/numpy/ctypeslib.py
+++ b/optype/numpy/ctypeslib.py
@@ -42,12 +42,12 @@ from ctypes import (
     c_ulonglong as ULongLong,
     c_ushort as UShort,
 )
-from typing import TYPE_CHECKING, Final, Literal, TypeAlias, cast
+from typing import TYPE_CHECKING, Final, Literal, Never, TypeAlias, cast
 
 if sys.version_info >= (3, 12):
-    from typing import Never, TypeAliasType, TypeVar
+    from typing import TypeAliasType, TypeVar
 else:
-    from typing_extensions import Never, TypeAliasType, TypeVar
+    from typing_extensions import TypeAliasType, TypeVar
 
 if sys.version_info >= (3, 14):
     from ctypes import (

--- a/optype/pickle.py
+++ b/optype/pickle.py
@@ -5,12 +5,12 @@ https://docs.python.org/3/library/pickle.html
 
 import sys
 from collections.abc import Callable, Iterable
-from typing import Protocol, SupportsIndex, TypeAlias
+from typing import Protocol, Self, SupportsIndex, TypeAlias
 
 if sys.version_info >= (3, 13):
-    from typing import ParamSpec, Self, TypeVar, override, runtime_checkable
+    from typing import ParamSpec, TypeVar, override, runtime_checkable
 else:
-    from typing_extensions import ParamSpec, Self, TypeVar, override, runtime_checkable
+    from typing_extensions import ParamSpec, TypeVar, override, runtime_checkable
 
 
 __all__ = (
@@ -84,14 +84,8 @@ class CanGetstate(Protocol[_StateT_co]):
     https://docs.python.org/3/library/pickle.html#object.__getstate__
     """
 
-    if sys.version_info >= (3, 11):
-
-        @override
-        def __getstate__(self, /) -> _StateT_co: ...
-
-    else:
-
-        def __getstate__(self, /) -> _StateT_co: ...
+    @override
+    def __getstate__(self, /) -> _StateT_co: ...
 
 
 @runtime_checkable

--- a/optype/types/__init__.py
+++ b/optype/types/__init__.py
@@ -1,10 +1,10 @@
 import sys
-from typing import Literal, Protocol
+from typing import Literal, LiteralString, Protocol
 
 if sys.version_info >= (3, 13):
-    from typing import LiteralString, runtime_checkable
+    from typing import runtime_checkable
 else:
-    from typing_extensions import LiteralString, runtime_checkable
+    from typing_extensions import runtime_checkable
 
 from ._typeforms import AnnotatedAlias, GenericType, LiteralAlias, UnionAlias
 

--- a/optype/types/_typeforms.pyi
+++ b/optype/types/_typeforms.pyi
@@ -1,17 +1,7 @@
-import sys
 import types as _types
 from collections.abc import Iterator
-from typing import Any, Generic, TypeAlias, _SpecialForm, type_check_only
-from typing_extensions import (
-    ParamSpec,
-    Self,
-    TypeAliasType,
-    TypeVar,
-    TypeVarTuple,
-    Unpack,
-    final,
-    override,
-)
+from typing import Any, Generic, Self, TypeAlias, _SpecialForm, final, type_check_only
+from typing_extensions import ParamSpec, TypeAliasType, TypeVar, TypeVarTuple, override
 
 __all__ = "AnnotatedAlias", "GenericType", "LiteralAlias", "UnionAlias"
 
@@ -45,10 +35,7 @@ class GenericType:
     def __ror__(self, lhs: type | object, /) -> UnionAlias: ...
     def __getitem__(self, args: type | object, /) -> GenericType: ...
     def copy_with(self, params: object, /) -> GenericType: ...
-
-    if sys.version_info >= (3, 11):
-        def __iter__(self, /) -> Iterator[UnpackAlias[Self]]: ...
-
+    def __iter__(self, /) -> Iterator[UnpackAlias[Self]]: ...
     def __call__(self, /, *args: object, **kwargs: object) -> _SpecialForm | object: ...
     def __instancecheck__(self, obj: object, /) -> bool: ...
     def __subclasscheck__(self, obj: type, /) -> bool: ...
@@ -66,7 +53,7 @@ class AnnotatedAlias(GenericType):
     @override
     def __origin__(self, /) -> _TypeExpr: ...
     @property
-    def __metadata__(self, /) -> tuple[object, Unpack[tuple[object, ...]]]: ...
+    def __metadata__(self, /) -> tuple[object, *tuple[object, ...]]: ...
 
 @type_check_only
 class UnpackAlias(GenericType, Generic[_Ts_co]):

--- a/optype/typing.py
+++ b/optype/typing.py
@@ -2,6 +2,8 @@ import sys
 from typing import (
     TYPE_CHECKING,
     Literal,
+    LiteralString,
+    Never,
     NoReturn,
     Protocol,
     TypeAlias,
@@ -13,9 +15,9 @@ if TYPE_CHECKING:
     import enum
 
 if sys.version_info >= (3, 13):
-    from typing import LiteralString, Never, TypedDict, TypeVar, Unpack
+    from typing import TypedDict, TypeVar
 else:
-    from typing_extensions import LiteralString, Never, TypedDict, TypeVar, Unpack
+    from typing_extensions import TypedDict, TypeVar
 
 from ._core import _can as _c, _just
 
@@ -101,11 +103,7 @@ JustComplex.__doc__ = _just.JustComplex.__doc__  # pyright: ignore[reportDepreca
 AnyInt: TypeAlias = _IntT | _c.CanInt[_IntT] | _c.CanIndex[_IntT]
 
 AnyFloat: TypeAlias = _c.CanFloat | _c.CanIndex
-if sys.version_info >= (3, 11):
-    AnyComplex: TypeAlias = _c.CanComplex | _c.CanFloat | _c.CanIndex
-else:
-    # `complex.__complex__` didn't exists before Python 3.11
-    AnyComplex: TypeAlias = complex | _c.CanComplex | _c.CanFloat | _c.CanIndex
+AnyComplex: TypeAlias = _c.CanComplex | _c.CanFloat | _c.CanIndex
 
 # Anything that can be iterated over, e.g. in a `for` loop,`builtins.iter`,
 # `builtins.enumerate`, or `numpy.array`.
@@ -138,7 +136,7 @@ EmptyTuple: TypeAlias = (
     # in pyright `NoReturn` and `Never` aren't identical, only equivalent
     | tuple[NoReturn, ...]
     # this is what infers the result of `tuple[Never, ...] + tuple[()]` as...
-    | tuple[Unpack[tuple[Never, ...]]]
+    | tuple[*tuple[Never, ...]]
 )
 EmptyList: TypeAlias = list[Never]
 EmptySet: TypeAlias = set[Never]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,13 +15,12 @@ classifiers = [
     "Development Status :: 4 - Beta",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Typing :: Typed",
 ]
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 dependencies = ["typing-extensions>=4.10; python_version<'3.13'"]
 
     [project.optional-dependencies]
@@ -338,7 +337,7 @@ force-exclude = true
 
 [tool.tox]
 isolated_build = true
-env_list = ["repo-review", "3.10", "3.11", "3.12", "3.13"]
+env_list = ["repo-review", "3.11", "3.12", "3.13"]
 
     [tool.tox.env_run_base]
     description = "test with {base_python}"

--- a/scripts/bmp.py
+++ b/scripts/bmp.py
@@ -14,6 +14,7 @@ _NP1_MIN: Final = 1, 25
 _NP1_MAX: Final = 1, 26
 _NP2_MIN: Final = 2, 0
 _NP2_MAX: Final = 2, 3
+_NP_SKIP: Final = frozenset({(1, 26)})
 
 
 def _np_version() -> _Version:
@@ -43,14 +44,16 @@ def _np_version_range(
             v0, v1 = _NP2_MIN
             break
 
-        yield v0, v1
+        if (v0, v1) not in _NP_SKIP:
+            yield v0, v1
         v1 += 1
 
     assert v0 == last[0]
     assert v1 <= last[1]
 
     for v in range(v1, last[1] + 1):
-        yield v0, v
+        if (v0, v) not in _NP_SKIP:
+            yield v0, v
 
 
 def main(*args: str) -> int:

--- a/tests/core/test_does.py
+++ b/tests/core/test_does.py
@@ -1,12 +1,6 @@
-import sys
-from typing import final
+from typing import assert_type, final
 
 from optype import do_iadd
-
-if sys.version_info >= (3, 13):
-    from typing import assert_type
-else:
-    from typing_extensions import assert_type
 
 
 def test_iadd_iadd() -> None:

--- a/tests/core/test_has_types.pyi
+++ b/tests/core/test_has_types.pyi
@@ -1,7 +1,6 @@
 # pyright: reportInvalidStubStatement=false
 
-from typing import TypedDict, TypeVar
-from typing_extensions import LiteralString, assert_type
+from typing import LiteralString, TypedDict, TypeVar, assert_type
 
 import optype as op
 

--- a/tests/numpy/test_any_dtype.py
+++ b/tests/numpy/test_any_dtype.py
@@ -1,11 +1,5 @@
-import sys
 import types
-from typing import Any, Final
-
-if sys.version_info >= (3, 11):
-    from typing import Never
-else:
-    from typing_extensions import Never
+from typing import Any, Final, Never
 
 import numpy as np
 import pytest

--- a/tests/numpy/test_scalar.py
+++ b/tests/numpy/test_scalar.py
@@ -1,14 +1,8 @@
 # mypy: disable-error-code="unreachable"
-import sys
-from typing import Literal
+from typing import Literal, assert_type
 
 import numpy as np
 import pytest
-
-if sys.version_info >= (3, 13):
-    from typing import assert_type
-else:
-    from typing_extensions import assert_type
 
 from optype.numpy import Scalar, _scalar as _sc
 

--- a/tests/numpy/test_ufunc.py
+++ b/tests/numpy/test_ufunc.py
@@ -1,12 +1,6 @@
 import math
-import sys
 from collections.abc import Callable as Fn
-from typing import Any, Literal, TypeAlias, TypeVar, cast
-
-if sys.version_info >= (3, 13):
-    from typing import LiteralString
-else:
-    from typing_extensions import LiteralString
+from typing import Any, Literal, LiteralString, TypeAlias, TypeVar, cast
 
 import numpy as np
 

--- a/tests/test_inspect.py
+++ b/tests/test_inspect.py
@@ -4,7 +4,7 @@ import typing as tp
 import typing_extensions as tpx
 from inspect import getattr_static
 
-if sys.version_info >= (3, 12):
+if sys.version_info >= (3, 13):
     from typing import TypeAliasType
 else:
     from typing_extensions import TypeAliasType
@@ -35,7 +35,6 @@ class GenericTPX(tp.Generic[_T_tpx]): ...
 
 @tpx.runtime_checkable
 class CanInit(tpx.Protocol[_Pss]):
-    # on Python 3.10 this requires `typing_extensions.Protocol` to work
     def __init__(self, *args: _Pss.args, **kwargs: _Pss.kwargs) -> None: ...
 
 
@@ -212,30 +211,26 @@ def test_type_is_final() -> None:
     assert not op.inspect.is_final(Proto)
     assert not op.inspect.is_final(ProtoX)
     assert not op.inspect.is_final(ProtoRuntime)
-    if sys.version_info >= (3, 11):
-        assert op.inspect.is_final(ProtoFinal)
+    assert op.inspect.is_final(ProtoFinal)
     assert op.inspect.is_final(ProtoFinalX)
 
 
 def test_property_is_final() -> None:
     assert not op.inspect.is_final(FinalMembers.p)
-    if sys.version_info >= (3, 11):
-        assert op.inspect.is_final(FinalMembers.p_final)
+    assert op.inspect.is_final(FinalMembers.p_final)
     assert op.inspect.is_final(FinalMembers.p_final_x)
 
 
 def test_method_is_final() -> None:
     assert not op.inspect.is_final(FinalMembers.f)
-    if sys.version_info >= (3, 11):
-        assert op.inspect.is_final(FinalMembers.f_final)
+    assert op.inspect.is_final(FinalMembers.f_final)
     assert op.inspect.is_final(FinalMembers.f_final_x)
 
 
 def test_classmethod_is_final() -> None:
     assert not op.inspect.is_final(FinalMembers.cf)
-    if sys.version_info >= (3, 11):
-        assert op.inspect.is_final(getattr_static(FinalMembers, "cf_final1"))
-        assert op.inspect.is_final(getattr_static(FinalMembers, "cf_final2"))
+    assert op.inspect.is_final(getattr_static(FinalMembers, "cf_final1"))
+    assert op.inspect.is_final(getattr_static(FinalMembers, "cf_final2"))
 
     assert op.inspect.is_final(
         tp.cast(
@@ -253,9 +248,8 @@ def test_classmethod_is_final() -> None:
 
 def test_staticmethod_is_final() -> None:
     assert not op.inspect.is_final(FinalMembers.sf)
-    if sys.version_info >= (3, 11):
-        assert op.inspect.is_final(getattr_static(FinalMembers, "sf_final1"))
-        assert op.inspect.is_final(getattr_static(FinalMembers, "sf_final2"))
+    assert op.inspect.is_final(getattr_static(FinalMembers, "sf_final1"))
+    assert op.inspect.is_final(getattr_static(FinalMembers, "sf_final2"))
 
     assert op.inspect.is_final(
         tp.cast(

--- a/tests/test_string.py
+++ b/tests/test_string.py
@@ -1,11 +1,5 @@
 import string
-import sys
-from typing import Final, Protocol, TypeVar
-
-if sys.version_info >= (3, 13):
-    from typing import LiteralString
-else:
-    from typing_extensions import LiteralString
+from typing import Final, LiteralString, Protocol, TypeVar
 
 import pytest
 

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,6 @@
 version = 1
 revision = 2
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 
 [[package]]
 name = "basedmypy"
@@ -9,16 +9,10 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "basedtyping" },
     { name = "mypy-extensions" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
     { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/24/f5/223ddf7be63d4549a0e0351e37a54f799d18ef4b799af95093c8359ddf48/basedmypy-2.10.0.tar.gz", hash = "sha256:85dd20aa8de401982073970a90a78a5d47442251140401b4863f0018247e533f", size = 5516524, upload-time = "2025-03-09T15:05:44.44Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7a/bb/3e7fda299de3fa9b62b03f744d92d24124d40d1ce02d4f2e8e9a6acc683a/basedmypy-2.10.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:531f8c9e18b7b97cc11fd981c529115d2e3282ffff439a6487d83c4c4881aebf", size = 11088450, upload-time = "2025-03-09T15:04:42.67Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/9a/386d825e43ccda3676dcbd96cc30968b3f939a964cc98d7465c26e4e78a1/basedmypy-2.10.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:0359e002801ed0bdb5ac2d2ce32abdeda2c15d8f0206c8cdef22b3bccc4f75d0", size = 10191181, upload-time = "2025-03-09T15:04:48.156Z" },
-    { url = "https://files.pythonhosted.org/packages/63/a9/54beaef65f195e4833d9aec4bbb877acecbe1f5cbb35e6b59ace159d0919/basedmypy-2.10.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ac9b8416834fad37a092f957c0caec78d63a09684055597e9c12380c54d6b7bb", size = 12761715, upload-time = "2025-03-09T15:05:03.31Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/08/614913c64008c5c514ab3c8f0dd1d5b20d6546916ff9344824350244f755/basedmypy-2.10.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:3a124f7c31d2c65003213e0c60ea2913774bdb122e971fa6eb080d152df5fe61", size = 12954329, upload-time = "2025-03-09T15:04:53.02Z" },
-    { url = "https://files.pythonhosted.org/packages/79/29/77ee3c18582524781d2c99917e8e94f501c6ddb94e419c5ed3a07683c30c/basedmypy-2.10.0-cp310-cp310-win_amd64.whl", hash = "sha256:a7ee1defe6807ce2e2a3f2cd9b7edbb4465c5cad3d822be9dc4caa9f0427da29", size = 9577577, upload-time = "2025-03-09T15:05:20.843Z" },
     { url = "https://files.pythonhosted.org/packages/ef/ba/f2e5905c3e5ac0c4f50912dfbe181087da24e299380db555c0eb02fcf96f/basedmypy-2.10.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:4704fe9fc164234ccc707a030bda765db57e26baa11975689d488ce37be18c32", size = 11012707, upload-time = "2025-03-09T15:04:45.726Z" },
     { url = "https://files.pythonhosted.org/packages/3d/65/cb862eb79edee57fb7954a12406b019189fb210507724c11616aacea1bed/basedmypy-2.10.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:ae94e57b12e6cf97be83680f4ea039b722bd3d902b36ad45aabf92b5f42b891e", size = 10108023, upload-time = "2025-03-09T15:05:18.731Z" },
     { url = "https://files.pythonhosted.org/packages/11/93/04dfe0756ef8f9201b721306c943c2cb0b27ce77c4ab05f77e00e40bf5aa/basedmypy-2.10.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bd3f41c8d26bef408b7e3abf6baebf0267fedf3d393e360761a6d38ed770e398", size = 12677726, upload-time = "2025-03-09T15:05:16.653Z" },
@@ -124,18 +118,6 @@ wheels = [
 ]
 
 [[package]]
-name = "exceptiongroup"
-version = "1.3.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/0b/9f/a65090624ecf468cdca03533906e7c69ed7588582240cfe7cc9e770b50eb/exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88", size = 29749, upload-time = "2025-05-10T17:42:51.123Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/36/f4/c6e662dade71f56cd2f3735141b265c3c79293c109549c1e6933b0651ffc/exceptiongroup-1.3.0-py3-none-any.whl", hash = "sha256:4d111e6e0c13d0644cad6ddaa7ed0261a0b36971f6d23e7ec9b4b9097da78a10", size = 16674, upload-time = "2025-05-10T17:42:49.33Z" },
-]
-
-[[package]]
 name = "filelock"
 version = "3.18.0"
 source = { registry = "https://pypi.org/simple" }
@@ -205,16 +187,6 @@ version = "2.2.6"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/76/21/7d2a95e4bba9dc13d043ee156a356c0a8f0c6309dff6b21b4d71a073b8a8/numpy-2.2.6.tar.gz", hash = "sha256:e29554e2bef54a90aa5cc07da6ce955accb83f21ab5de01a62c8478897b264fd", size = 20276440, upload-time = "2025-05-17T22:38:04.611Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9a/3e/ed6db5be21ce87955c0cbd3009f2803f59fa08df21b5df06862e2d8e2bdd/numpy-2.2.6-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:b412caa66f72040e6d268491a59f2c43bf03eb6c96dd8f0307829feb7fa2b6fb", size = 21165245, upload-time = "2025-05-17T21:27:58.555Z" },
-    { url = "https://files.pythonhosted.org/packages/22/c2/4b9221495b2a132cc9d2eb862e21d42a009f5a60e45fc44b00118c174bff/numpy-2.2.6-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:8e41fd67c52b86603a91c1a505ebaef50b3314de0213461c7a6e99c9a3beff90", size = 14360048, upload-time = "2025-05-17T21:28:21.406Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/77/dc2fcfc66943c6410e2bf598062f5959372735ffda175b39906d54f02349/numpy-2.2.6-cp310-cp310-macosx_14_0_arm64.whl", hash = "sha256:37e990a01ae6ec7fe7fa1c26c55ecb672dd98b19c3d0e1d1f326fa13cb38d163", size = 5340542, upload-time = "2025-05-17T21:28:30.931Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/4f/1cb5fdc353a5f5cc7feb692db9b8ec2c3d6405453f982435efc52561df58/numpy-2.2.6-cp310-cp310-macosx_14_0_x86_64.whl", hash = "sha256:5a6429d4be8ca66d889b7cf70f536a397dc45ba6faeb5f8c5427935d9592e9cf", size = 6878301, upload-time = "2025-05-17T21:28:41.613Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/17/96a3acd228cec142fcb8723bd3cc39c2a474f7dcf0a5d16731980bcafa95/numpy-2.2.6-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:efd28d4e9cd7d7a8d39074a4d44c63eda73401580c5c76acda2ce969e0a38e83", size = 14297320, upload-time = "2025-05-17T21:29:02.78Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/63/3de6a34ad7ad6646ac7d2f55ebc6ad439dbbf9c4370017c50cf403fb19b5/numpy-2.2.6-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fc7b73d02efb0e18c000e9ad8b83480dfcd5dfd11065997ed4c6747470ae8915", size = 16801050, upload-time = "2025-05-17T21:29:27.675Z" },
-    { url = "https://files.pythonhosted.org/packages/07/b6/89d837eddef52b3d0cec5c6ba0456c1bf1b9ef6a6672fc2b7873c3ec4e2e/numpy-2.2.6-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:74d4531beb257d2c3f4b261bfb0fc09e0f9ebb8842d82a7b4209415896adc680", size = 15807034, upload-time = "2025-05-17T21:29:51.102Z" },
-    { url = "https://files.pythonhosted.org/packages/01/c8/dc6ae86e3c61cfec1f178e5c9f7858584049b6093f843bca541f94120920/numpy-2.2.6-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:8fc377d995680230e83241d8a96def29f204b5782f371c532579b4f20607a289", size = 18614185, upload-time = "2025-05-17T21:30:18.703Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/c5/0064b1b7e7c89137b471ccec1fd2282fceaae0ab3a9550f2568782d80357/numpy-2.2.6-cp310-cp310-win32.whl", hash = "sha256:b093dd74e50a8cba3e873868d9e93a85b78e0daf2e98c6797566ad8044e8363d", size = 6527149, upload-time = "2025-05-17T21:30:29.788Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/dd/4b822569d6b96c39d1215dbae0582fd99954dcbcf0c1a13c61783feaca3f/numpy-2.2.6-cp310-cp310-win_amd64.whl", hash = "sha256:f0fd6321b839904e15c46e0d257fdd101dd7f530fe03fd6359c1ea63738703f3", size = 12904620, upload-time = "2025-05-17T21:30:48.994Z" },
     { url = "https://files.pythonhosted.org/packages/da/a8/4f83e2aa666a9fbf56d6118faaaf5f1974d456b1823fda0a176eff722839/numpy-2.2.6-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f9f1adb22318e121c5c69a09142811a201ef17ab257a1e66ca3025065b7f53ae", size = 21176963, upload-time = "2025-05-17T21:31:19.36Z" },
     { url = "https://files.pythonhosted.org/packages/b3/2b/64e1affc7972decb74c9e29e5649fac940514910960ba25cd9af4488b66c/numpy-2.2.6-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:c820a93b0255bc360f53eca31a0e676fd1101f673dda8da93454a12e23fc5f7a", size = 14406743, upload-time = "2025-05-17T21:31:41.087Z" },
     { url = "https://files.pythonhosted.org/packages/4a/9f/0121e375000b5e50ffdd8b25bf78d8e1a5aa4cca3f185d41265198c7b834/numpy-2.2.6-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:3d70692235e759f260c3d837193090014aebdf026dfd167834bcba43e30c2a42", size = 5352616, upload-time = "2025-05-17T21:31:50.072Z" },
@@ -255,10 +227,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/76/95/bef5b37f29fc5e739947e9ce5179ad402875633308504a52d188302319c8/numpy-2.2.6-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8e9ace4a37db23421249ed236fdcdd457d671e25146786dfc96835cd951aa7c1", size = 18385260, upload-time = "2025-05-17T21:43:05.189Z" },
     { url = "https://files.pythonhosted.org/packages/09/04/f2f83279d287407cf36a7a8053a5abe7be3622a4363337338f2585e4afda/numpy-2.2.6-cp313-cp313t-win32.whl", hash = "sha256:038613e9fb8c72b0a41f025a7e4c3f0b7a1b5d768ece4796b674c8f3fe13efff", size = 6377225, upload-time = "2025-05-17T21:43:16.254Z" },
     { url = "https://files.pythonhosted.org/packages/67/0e/35082d13c09c02c011cf21570543d202ad929d961c02a147493cb0c2bdf5/numpy-2.2.6-cp313-cp313t-win_amd64.whl", hash = "sha256:6031dd6dfecc0cf9f668681a37648373bddd6421fff6c66ec1624eed0180ee06", size = 12771374, upload-time = "2025-05-17T21:43:35.479Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/3b/d94a75f4dbf1ef5d321523ecac21ef23a3cd2ac8b78ae2aac40873590229/numpy-2.2.6-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:0b605b275d7bd0c640cad4e5d30fa701a8d59302e127e5f79138ad62762c3e3d", size = 21040391, upload-time = "2025-05-17T21:44:35.948Z" },
-    { url = "https://files.pythonhosted.org/packages/17/f4/09b2fa1b58f0fb4f7c7963a1649c64c4d315752240377ed74d9cd878f7b5/numpy-2.2.6-pp310-pypy310_pp73-macosx_14_0_x86_64.whl", hash = "sha256:7befc596a7dc9da8a337f79802ee8adb30a552a94f792b9c9d18c840055907db", size = 6786754, upload-time = "2025-05-17T21:44:47.446Z" },
-    { url = "https://files.pythonhosted.org/packages/af/30/feba75f143bdc868a1cc3f44ccfa6c4b9ec522b36458e738cd00f67b573f/numpy-2.2.6-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ce47521a4754c8f4593837384bd3424880629f718d87c5d44f8ed763edd63543", size = 16643476, upload-time = "2025-05-17T21:45:11.871Z" },
-    { url = "https://files.pythonhosted.org/packages/37/48/ac2a9584402fb6c0cd5b5d1a91dcf176b15760130dd386bbafdbfe3640bf/numpy-2.2.6-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:d042d24c90c41b54fd506da306759e06e568864df8ec17ccc17e9e884634fd00", size = 12812666, upload-time = "2025-05-17T21:45:31.426Z" },
 ]
 
 [[package]]
@@ -339,19 +307,6 @@ version = "3.10.18"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/81/0b/fea456a3ffe74e70ba30e01ec183a9b26bec4d497f61dcfce1b601059c60/orjson-3.10.18.tar.gz", hash = "sha256:e8da3947d92123eda795b68228cafe2724815621fe35e8e320a9e9593a4bcd53", size = 5422810, upload-time = "2025-04-29T23:30:08.423Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/27/16/2ceb9fb7bc2b11b1e4a3ea27794256e93dee2309ebe297fd131a778cd150/orjson-3.10.18-cp310-cp310-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:a45e5d68066b408e4bc383b6e4ef05e717c65219a9e1390abc6155a520cac402", size = 248927, upload-time = "2025-04-29T23:28:08.643Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/e1/d3c0a2bba5b9906badd121da449295062b289236c39c3a7801f92c4682b0/orjson-3.10.18-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:be3b9b143e8b9db05368b13b04c84d37544ec85bb97237b3a923f076265ec89c", size = 136995, upload-time = "2025-04-29T23:28:11.503Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/51/698dd65e94f153ee5ecb2586c89702c9e9d12f165a63e74eb9ea1299f4e1/orjson-3.10.18-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:9b0aa09745e2c9b3bf779b096fa71d1cc2d801a604ef6dd79c8b1bfef52b2f92", size = 132893, upload-time = "2025-04-29T23:28:12.751Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/e5/155ce5a2c43a85e790fcf8b985400138ce5369f24ee6770378ee6b691036/orjson-3.10.18-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:53a245c104d2792e65c8d225158f2b8262749ffe64bc7755b00024757d957a13", size = 137017, upload-time = "2025-04-29T23:28:14.498Z" },
-    { url = "https://files.pythonhosted.org/packages/46/bb/6141ec3beac3125c0b07375aee01b5124989907d61c72c7636136e4bd03e/orjson-3.10.18-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f9495ab2611b7f8a0a8a505bcb0f0cbdb5469caafe17b0e404c3c746f9900469", size = 138290, upload-time = "2025-04-29T23:28:16.211Z" },
-    { url = "https://files.pythonhosted.org/packages/77/36/6961eca0b66b7809d33c4ca58c6bd4c23a1b914fb23aba2fa2883f791434/orjson-3.10.18-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:73be1cbcebadeabdbc468f82b087df435843c809cd079a565fb16f0f3b23238f", size = 142828, upload-time = "2025-04-29T23:28:18.065Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/2f/0c646d5fd689d3be94f4d83fa9435a6c4322c9b8533edbb3cd4bc8c5f69a/orjson-3.10.18-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fe8936ee2679e38903df158037a2f1c108129dee218975122e37847fb1d4ac68", size = 132806, upload-time = "2025-04-29T23:28:19.782Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/af/65907b40c74ef4c3674ef2bcfa311c695eb934710459841b3c2da212215c/orjson-3.10.18-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:7115fcbc8525c74e4c2b608129bef740198e9a120ae46184dac7683191042056", size = 135005, upload-time = "2025-04-29T23:28:21.367Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/d1/68bd20ac6a32cd1f1b10d23e7cc58ee1e730e80624e3031d77067d7150fc/orjson-3.10.18-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:771474ad34c66bc4d1c01f645f150048030694ea5b2709b87d3bda273ffe505d", size = 413418, upload-time = "2025-04-29T23:28:23.097Z" },
-    { url = "https://files.pythonhosted.org/packages/31/31/c701ec0bcc3e80e5cb6e319c628ef7b768aaa24b0f3b4c599df2eaacfa24/orjson-3.10.18-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:7c14047dbbea52886dd87169f21939af5d55143dad22d10db6a7514f058156a8", size = 153288, upload-time = "2025-04-29T23:28:25.02Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/31/5e1aa99a10893a43cfc58009f9da840990cc8a9ebb75aa452210ba18587e/orjson-3.10.18-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:641481b73baec8db14fdf58f8967e52dc8bda1f2aba3aa5f5c1b07ed6df50b7f", size = 137181, upload-time = "2025-04-29T23:28:26.318Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/8c/daba0ac1b8690011d9242a0f37235f7d17df6d0ad941021048523b76674e/orjson-3.10.18-cp310-cp310-win32.whl", hash = "sha256:607eb3ae0909d47280c1fc657c4284c34b785bae371d007595633f4b1a2bbe06", size = 142694, upload-time = "2025-04-29T23:28:28.092Z" },
-    { url = "https://files.pythonhosted.org/packages/16/62/8b687724143286b63e1d0fab3ad4214d54566d80b0ba9d67c26aaf28a2f8/orjson-3.10.18-cp310-cp310-win_amd64.whl", hash = "sha256:8770432524ce0eca50b7efc2a9a5f486ee0113a5fbb4231526d414e6254eba92", size = 134600, upload-time = "2025-04-29T23:28:29.422Z" },
     { url = "https://files.pythonhosted.org/packages/97/c7/c54a948ce9a4278794f669a353551ce7db4ffb656c69a6e1f2264d563e50/orjson-3.10.18-cp311-cp311-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:e0a183ac3b8e40471e8d843105da6fbe7c070faab023be3b08188ee3f85719b8", size = 248929, upload-time = "2025-04-29T23:28:30.716Z" },
     { url = "https://files.pythonhosted.org/packages/9e/60/a9c674ef1dd8ab22b5b10f9300e7e70444d4e3cda4b8258d6c2488c32143/orjson-3.10.18-cp311-cp311-macosx_15_0_arm64.whl", hash = "sha256:5ef7c164d9174362f85238d0cd4afdeeb89d9e523e4651add6a5d458d6f7d42d", size = 133364, upload-time = "2025-04-29T23:28:32.392Z" },
     { url = "https://files.pythonhosted.org/packages/c1/4e/f7d1bdd983082216e414e6d7ef897b0c2957f99c545826c06f371d52337e/orjson-3.10.18-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:afd14c5d99cdc7bf93f22b12ec3b294931518aa019e2a147e8aa2f31fd3240f7", size = 136995, upload-time = "2025-04-29T23:28:34.024Z" },
@@ -441,7 +396,6 @@ version = "1.9.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "packaging" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/19/fd/437901c891f58a7b9096511750247535e891d2d5a5a6eefbc9386a2b41d5/pyproject_api-1.9.1.tar.gz", hash = "sha256:43c9918f49daab37e302038fc1aed54a8c7a91a9fa935d00b9a485f37e0f5335", size = 22710, upload-time = "2025-05-12T14:41:58.025Z" }
 wheels = [
@@ -454,11 +408,9 @@ version = "8.3.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
     { name = "iniconfig" },
     { name = "packaging" },
     { name = "pluggy" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ae/3c/c9d525a414d506893f0cd8a8d0de7706446213181570cdbd766691164e40/pytest-8.3.5.tar.gz", hash = "sha256:f4efe70cc14e511565ac476b57c279e12a855b11f48f212af1080ef2263d3845", size = 1450891, upload-time = "2025-03-02T12:54:54.503Z" }
 wheels = [
@@ -471,15 +423,6 @@ version = "6.0.2"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/54/ed/79a089b6be93607fa5cdaedf301d7dfb23af5f25c398d5ead2525b063e17/pyyaml-6.0.2.tar.gz", hash = "sha256:d584d9ec91ad65861cc08d42e834324ef890a082e591037abe114850ff7bbc3e", size = 130631, upload-time = "2024-08-06T20:33:50.674Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9b/95/a3fac87cb7158e231b5a6012e438c647e1a87f09f8e0d123acec8ab8bf71/PyYAML-6.0.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:0a9a2848a5b7feac301353437eb7d5957887edbf81d56e903999a75a3d743086", size = 184199, upload-time = "2024-08-06T20:31:40.178Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/7a/68bd47624dab8fd4afbfd3c48e3b79efe09098ae941de5b58abcbadff5cb/PyYAML-6.0.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:29717114e51c84ddfba879543fb232a6ed60086602313ca38cce623c1d62cfbf", size = 171758, upload-time = "2024-08-06T20:31:42.173Z" },
-    { url = "https://files.pythonhosted.org/packages/49/ee/14c54df452143b9ee9f0f29074d7ca5516a36edb0b4cc40c3f280131656f/PyYAML-6.0.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8824b5a04a04a047e72eea5cec3bc266db09e35de6bdfe34c9436ac5ee27d237", size = 718463, upload-time = "2024-08-06T20:31:44.263Z" },
-    { url = "https://files.pythonhosted.org/packages/4d/61/de363a97476e766574650d742205be468921a7b532aa2499fcd886b62530/PyYAML-6.0.2-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7c36280e6fb8385e520936c3cb3b8042851904eba0e58d277dca80a5cfed590b", size = 719280, upload-time = "2024-08-06T20:31:50.199Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/4e/1523cb902fd98355e2e9ea5e5eb237cbc5f3ad5f3075fa65087aa0ecb669/PyYAML-6.0.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ec031d5d2feb36d1d1a24380e4db6d43695f3748343d99434e6f5f9156aaa2ed", size = 751239, upload-time = "2024-08-06T20:31:52.292Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/33/5504b3a9a4464893c32f118a9cc045190a91637b119a9c881da1cf6b7a72/PyYAML-6.0.2-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:936d68689298c36b53b29f23c6dbb74de12b4ac12ca6cfe0e047bedceea56180", size = 695802, upload-time = "2024-08-06T20:31:53.836Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/20/8347dcabd41ef3a3cdc4f7b7a2aff3d06598c8779faa189cdbf878b626a4/PyYAML-6.0.2-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:23502f431948090f597378482b4812b0caae32c22213aecf3b55325e049a6c68", size = 720527, upload-time = "2024-08-06T20:31:55.565Z" },
-    { url = "https://files.pythonhosted.org/packages/be/aa/5afe99233fb360d0ff37377145a949ae258aaab831bde4792b32650a4378/PyYAML-6.0.2-cp310-cp310-win32.whl", hash = "sha256:2e99c6826ffa974fe6e27cdb5ed0021786b03fc98e5ee3c5bfe1fd5015f42b99", size = 144052, upload-time = "2024-08-06T20:31:56.914Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/84/0fa4b06f6d6c958d207620fc60005e241ecedceee58931bb20138e1e5776/PyYAML-6.0.2-cp310-cp310-win_amd64.whl", hash = "sha256:a4d3091415f010369ae4ed1fc6b79def9416358877534caf6a0fdd2146c87a3e", size = 161774, upload-time = "2024-08-06T20:31:58.304Z" },
     { url = "https://files.pythonhosted.org/packages/f8/aa/7af4e81f7acba21a4c6be026da38fd2b872ca46226673c89a758ebdc4fd2/PyYAML-6.0.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:cc1c1159b3d456576af7a3e4d1ba7e6924cb39de8f67111c735f6fc832082774", size = 184612, upload-time = "2024-08-06T20:32:03.408Z" },
     { url = "https://files.pythonhosted.org/packages/8b/62/b9faa998fd185f65c1371643678e4d58254add437edb764a08c5a98fb986/PyYAML-6.0.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:1e2120ef853f59c7419231f3bf4e7021f1b936f6ebd222406c3b60212205d2ee", size = 172040, upload-time = "2024-08-06T20:32:04.926Z" },
     { url = "https://files.pythonhosted.org/packages/ad/0c/c804f5f922a9a6563bab712d8dcc70251e8af811fce4524d57c2c0fd49a4/PyYAML-6.0.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5d225db5a45f21e78dd9358e58a98702a0302f2659a3c6cd320564b75b86f47c", size = 736829, upload-time = "2024-08-06T20:32:06.459Z" },
@@ -516,8 +459,6 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown-it-py" },
     { name = "pyyaml" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6f/a2/44609412bcb7666c20868f027e6bfaf81c37030572574bca8a64a1ed788a/repo_review-0.12.2.tar.gz", hash = "sha256:24393ac48132ae2b50c1208bc54b6126ccb30e5932d123deb12d74f805d91422", size = 46642, upload-time = "2025-05-21T16:47:33.605Z" }
 wheels = [
@@ -538,7 +479,6 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown-it-py" },
     { name = "pygments" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a1/53/830aa4c3066a8ab0ae9a9955976fb770fe9c6102117c8ec4ab3ea62d89e8/rich-14.0.0.tar.gz", hash = "sha256:82f1bc23a6a21ebca4ae0c45af9bdbc492ed20231dcb63f297d6d1021a9d5725", size = 224078, upload-time = "2025-03-30T14:15:14.23Z" }
 wheels = [
@@ -591,7 +531,6 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyyaml" },
     { name = "repo-review" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ec/3e/8d8c72e1ea8c4e9e8494c08057a98dd420327bdd7f5d2341cc626209d06b/sp_repo_review-2025.5.2.tar.gz", hash = "sha256:3bf9074ea64c780d15916dc426438315b30bfc8e0b802b0c46026a9a8b4a9288", size = 158493, upload-time = "2025-05-02T15:15:24.114Z" }
 wheels = [
@@ -601,45 +540,6 @@ wheels = [
 [package.optional-dependencies]
 cli = [
     { name = "repo-review", extra = ["cli"] },
-]
-
-[[package]]
-name = "tomli"
-version = "2.2.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/18/87/302344fed471e44a87289cf4967697d07e532f2421fdaf868a303cbae4ff/tomli-2.2.1.tar.gz", hash = "sha256:cd45e1dc79c835ce60f7404ec8119f2eb06d38b1deba146f07ced3bbc44505ff", size = 17175, upload-time = "2024-11-27T22:38:36.873Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/43/ca/75707e6efa2b37c77dadb324ae7d9571cb424e61ea73fad7c56c2d14527f/tomli-2.2.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:678e4fa69e4575eb77d103de3df8a895e1591b48e740211bd1067378c69e8249", size = 131077, upload-time = "2024-11-27T22:37:54.956Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/16/51ae563a8615d472fdbffc43a3f3d46588c264ac4f024f63f01283becfbb/tomli-2.2.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:023aa114dd824ade0100497eb2318602af309e5a55595f76b626d6d9f3b7b0a6", size = 123429, upload-time = "2024-11-27T22:37:56.698Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/dd/4f6cd1e7b160041db83c694abc78e100473c15d54620083dbd5aae7b990e/tomli-2.2.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ece47d672db52ac607a3d9599a9d48dcb2f2f735c6c2d1f34130085bb12b112a", size = 226067, upload-time = "2024-11-27T22:37:57.63Z" },
-    { url = "https://files.pythonhosted.org/packages/a9/6b/c54ede5dc70d648cc6361eaf429304b02f2871a345bbdd51e993d6cdf550/tomli-2.2.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6972ca9c9cc9f0acaa56a8ca1ff51e7af152a9f87fb64623e31d5c83700080ee", size = 236030, upload-time = "2024-11-27T22:37:59.344Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/47/999514fa49cfaf7a92c805a86c3c43f4215621855d151b61c602abb38091/tomli-2.2.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c954d2250168d28797dd4e3ac5cf812a406cd5a92674ee4c8f123c889786aa8e", size = 240898, upload-time = "2024-11-27T22:38:00.429Z" },
-    { url = "https://files.pythonhosted.org/packages/73/41/0a01279a7ae09ee1573b423318e7934674ce06eb33f50936655071d81a24/tomli-2.2.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:8dd28b3e155b80f4d54beb40a441d366adcfe740969820caf156c019fb5c7ec4", size = 229894, upload-time = "2024-11-27T22:38:02.094Z" },
-    { url = "https://files.pythonhosted.org/packages/55/18/5d8bc5b0a0362311ce4d18830a5d28943667599a60d20118074ea1b01bb7/tomli-2.2.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:e59e304978767a54663af13c07b3d1af22ddee3bb2fb0618ca1593e4f593a106", size = 245319, upload-time = "2024-11-27T22:38:03.206Z" },
-    { url = "https://files.pythonhosted.org/packages/92/a3/7ade0576d17f3cdf5ff44d61390d4b3febb8a9fc2b480c75c47ea048c646/tomli-2.2.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:33580bccab0338d00994d7f16f4c4ec25b776af3ffaac1ed74e0b3fc95e885a8", size = 238273, upload-time = "2024-11-27T22:38:04.217Z" },
-    { url = "https://files.pythonhosted.org/packages/72/6f/fa64ef058ac1446a1e51110c375339b3ec6be245af9d14c87c4a6412dd32/tomli-2.2.1-cp311-cp311-win32.whl", hash = "sha256:465af0e0875402f1d226519c9904f37254b3045fc5084697cefb9bdde1ff99ff", size = 98310, upload-time = "2024-11-27T22:38:05.908Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/1c/4a2dcde4a51b81be3530565e92eda625d94dafb46dbeb15069df4caffc34/tomli-2.2.1-cp311-cp311-win_amd64.whl", hash = "sha256:2d0f2fdd22b02c6d81637a3c95f8cd77f995846af7414c5c4b8d0545afa1bc4b", size = 108309, upload-time = "2024-11-27T22:38:06.812Z" },
-    { url = "https://files.pythonhosted.org/packages/52/e1/f8af4c2fcde17500422858155aeb0d7e93477a0d59a98e56cbfe75070fd0/tomli-2.2.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:4a8f6e44de52d5e6c657c9fe83b562f5f4256d8ebbfe4ff922c495620a7f6cea", size = 132762, upload-time = "2024-11-27T22:38:07.731Z" },
-    { url = "https://files.pythonhosted.org/packages/03/b8/152c68bb84fc00396b83e7bbddd5ec0bd3dd409db4195e2a9b3e398ad2e3/tomli-2.2.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8d57ca8095a641b8237d5b079147646153d22552f1c637fd3ba7f4b0b29167a8", size = 123453, upload-time = "2024-11-27T22:38:09.384Z" },
-    { url = "https://files.pythonhosted.org/packages/c8/d6/fc9267af9166f79ac528ff7e8c55c8181ded34eb4b0e93daa767b8841573/tomli-2.2.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4e340144ad7ae1533cb897d406382b4b6fede8890a03738ff1683af800d54192", size = 233486, upload-time = "2024-11-27T22:38:10.329Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/51/51c3f2884d7bab89af25f678447ea7d297b53b5a3b5730a7cb2ef6069f07/tomli-2.2.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:db2b95f9de79181805df90bedc5a5ab4c165e6ec3fe99f970d0e302f384ad222", size = 242349, upload-time = "2024-11-27T22:38:11.443Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/df/bfa89627d13a5cc22402e441e8a931ef2108403db390ff3345c05253935e/tomli-2.2.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:40741994320b232529c802f8bc86da4e1aa9f413db394617b9a256ae0f9a7f77", size = 252159, upload-time = "2024-11-27T22:38:13.099Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/6e/fa2b916dced65763a5168c6ccb91066f7639bdc88b48adda990db10c8c0b/tomli-2.2.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:400e720fe168c0f8521520190686ef8ef033fb19fc493da09779e592861b78c6", size = 237243, upload-time = "2024-11-27T22:38:14.766Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/04/885d3b1f650e1153cbb93a6a9782c58a972b94ea4483ae4ac5cedd5e4a09/tomli-2.2.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:02abe224de6ae62c19f090f68da4e27b10af2b93213d36cf44e6e1c5abd19fdd", size = 259645, upload-time = "2024-11-27T22:38:15.843Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/de/6b432d66e986e501586da298e28ebeefd3edc2c780f3ad73d22566034239/tomli-2.2.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:b82ebccc8c8a36f2094e969560a1b836758481f3dc360ce9a3277c65f374285e", size = 244584, upload-time = "2024-11-27T22:38:17.645Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/9a/47c0449b98e6e7d1be6cbac02f93dd79003234ddc4aaab6ba07a9a7482e2/tomli-2.2.1-cp312-cp312-win32.whl", hash = "sha256:889f80ef92701b9dbb224e49ec87c645ce5df3fa2cc548664eb8a25e03127a98", size = 98875, upload-time = "2024-11-27T22:38:19.159Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/60/9b9638f081c6f1261e2688bd487625cd1e660d0a85bd469e91d8db969734/tomli-2.2.1-cp312-cp312-win_amd64.whl", hash = "sha256:7fc04e92e1d624a4a63c76474610238576942d6b8950a2d7f908a340494e67e4", size = 109418, upload-time = "2024-11-27T22:38:20.064Z" },
-    { url = "https://files.pythonhosted.org/packages/04/90/2ee5f2e0362cb8a0b6499dc44f4d7d48f8fff06d28ba46e6f1eaa61a1388/tomli-2.2.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:f4039b9cbc3048b2416cc57ab3bda989a6fcf9b36cf8937f01a6e731b64f80d7", size = 132708, upload-time = "2024-11-27T22:38:21.659Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/ec/46b4108816de6b385141f082ba99e315501ccd0a2ea23db4a100dd3990ea/tomli-2.2.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:286f0ca2ffeeb5b9bd4fcc8d6c330534323ec51b2f52da063b11c502da16f30c", size = 123582, upload-time = "2024-11-27T22:38:22.693Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/bd/b470466d0137b37b68d24556c38a0cc819e8febe392d5b199dcd7f578365/tomli-2.2.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a92ef1a44547e894e2a17d24e7557a5e85a9e1d0048b0b5e7541f76c5032cb13", size = 232543, upload-time = "2024-11-27T22:38:24.367Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/e5/82e80ff3b751373f7cead2815bcbe2d51c895b3c990686741a8e56ec42ab/tomli-2.2.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9316dc65bed1684c9a98ee68759ceaed29d229e985297003e494aa825ebb0281", size = 241691, upload-time = "2024-11-27T22:38:26.081Z" },
-    { url = "https://files.pythonhosted.org/packages/05/7e/2a110bc2713557d6a1bfb06af23dd01e7dde52b6ee7dadc589868f9abfac/tomli-2.2.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e85e99945e688e32d5a35c1ff38ed0b3f41f43fad8df0bdf79f72b2ba7bc5272", size = 251170, upload-time = "2024-11-27T22:38:27.921Z" },
-    { url = "https://files.pythonhosted.org/packages/64/7b/22d713946efe00e0adbcdfd6d1aa119ae03fd0b60ebed51ebb3fa9f5a2e5/tomli-2.2.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ac065718db92ca818f8d6141b5f66369833d4a80a9d74435a268c52bdfa73140", size = 236530, upload-time = "2024-11-27T22:38:29.591Z" },
-    { url = "https://files.pythonhosted.org/packages/38/31/3a76f67da4b0cf37b742ca76beaf819dca0ebef26d78fc794a576e08accf/tomli-2.2.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:d920f33822747519673ee656a4b6ac33e382eca9d331c87770faa3eef562aeb2", size = 258666, upload-time = "2024-11-27T22:38:30.639Z" },
-    { url = "https://files.pythonhosted.org/packages/07/10/5af1293da642aded87e8a988753945d0cf7e00a9452d3911dd3bb354c9e2/tomli-2.2.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:a198f10c4d1b1375d7687bc25294306e551bf1abfa4eace6650070a5c1ae2744", size = 243954, upload-time = "2024-11-27T22:38:31.702Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/b9/1ed31d167be802da0fc95020d04cd27b7d7065cc6fbefdd2f9186f60d7bd/tomli-2.2.1-cp313-cp313-win32.whl", hash = "sha256:d3f5614314d758649ab2ab3a62d4f2004c825922f9e370b29416484086b264ec", size = 98724, upload-time = "2024-11-27T22:38:32.837Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/32/b0963458706accd9afcfeb867c0f9175a741bf7b19cd424230714d722198/tomli-2.2.1-cp313-cp313-win_amd64.whl", hash = "sha256:a38aa0308e754b0e3c67e344754dff64999ff9b513e691d0e786265c93583c69", size = 109383, upload-time = "2024-11-27T22:38:34.455Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/c2/61d3e0f47e2b74ef40a68b9e6ad5984f6241a942f7cd3bbfbdbd03861ea9/tomli-2.2.1-py3-none-any.whl", hash = "sha256:cb55c73c5f4408779d0cf3eef9f762b9c9f147a77de7b258bef0a5628adc85cc", size = 14257, upload-time = "2024-11-27T22:38:35.385Z" },
 ]
 
 [[package]]
@@ -655,8 +555,6 @@ dependencies = [
     { name = "platformdirs" },
     { name = "pluggy" },
     { name = "pyproject-api" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
     { name = "virtualenv" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/fd/3c/dcec0c00321a107f7f697fd00754c5112572ea6dcacb40b16d8c3eea7c37/tox-4.26.0.tar.gz", hash = "sha256:a83b3b67b0159fa58e44e646505079e35a43317a62d2ae94725e0586266faeca", size = 197260, upload-time = "2025-05-13T15:04:28.481Z" }


### PR DESCRIPTION
As recommended by [SPEC 0](https://scientific-python.org/specs/spec-0000/), and compatible with `scipy==1.16.*`.

Related to #320