### PR TITLE
read-only ci permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,5 @@
 name: CI
+permissions: read-all
 
 on:
   push:


### PR DESCRIPTION
mostly because the github code scanning tool was complaining about this