### PR TITLE
fix dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,20 +2,24 @@ version: 2
 updates:
   - package-ecosystem: github-actions
     directory: /
-    target-branch: "dev"
+    target-branch: "master"
     schedule:
       interval: weekly
+    labels:
+      - "is: chore"
+      - "topic: github actions"
     groups:
       actions:
         patterns:
           - "*"
-
-  - package-ecosystem: pip
-    versioning-strategy: lockfile-only
+  - package-ecosystem: uv
     directory: /
-    target-branch: "dev"
+    target-branch: master
     schedule:
       interval: weekly
+    labels:
+      - "is: chorew"
+      - "topic: dependencies"
     groups:
       actions:
         patterns:


### PR DESCRIPTION
It apparently was still using the `dev` branch from the ancient git-flow era, as well as some ancient relic called "pip" or something.