### PR TITLE
`ToJustInt64` numpy array-like aliases for `int64`

### DIFF
--- a/README.md
+++ b/README.md
@@ -2773,7 +2773,13 @@ matrix-likes, and cuboid-likes, and the `To{}` aliases for "bare" scalar types.
     <td align="left"><code>ToBoolStrict{}D</code></td>
 </tr>
 <tr>
-    <td align="left"><code>~int</code></td>
+    <td align="left" rowspan="2"><code>~int</code></td>
+    <td align="left"><code>int64</code></td>
+    <td align="left"><code>ToJustInt64</code></td>
+    <td align="left"><code>ToJustInt64_{}D</code></td>
+    <td align="left"><code>ToJustInt64Strict{}D</code></td>
+</tr>
+<tr>
     <td align="left"><code>integer</code></td>
     <td align="left"><code>ToJustInt</code></td>
     <td align="left"><code>ToJustInt{}D</code></td>

--- a/optype/numpy/_to.py
+++ b/optype/numpy/_to.py
@@ -37,6 +37,12 @@ __all__ = [  # noqa: RUF022
     "ToInt3D", "ToJustInt3D", "ToIntStrict3D", "ToJustIntStrict3D",
     "ToIntND", "ToJustIntND",
 
+    "ToJustInt64",
+    "ToJustInt64_1D", "ToJustInt64Strict1D",
+    "ToJustInt64_2D", "ToJustInt64Strict2D",
+    "ToJustInt64_3D", "ToJustInt64Strict3D",
+    "ToJustInt64_ND",
+
     "ToFloat64", "ToJustFloat64",
     "ToFloat64_1D", "ToJustFloat64_1D", "ToFloat64Strict1D", "ToJustFloat64Strict1D",
     "ToFloat64_2D", "ToJustFloat64_2D", "ToFloat64Strict2D", "ToJustFloat64Strict2D",
@@ -78,7 +84,7 @@ _PyScalar: TypeAlias = complex | bytes | str  # `complex` equivs `complex | floa
 
 T = TypeVar("T", default=_PyScalar)
 
-# https://github.com/KotlinIsland/basedmypy/issues/861
+# TODO(jorenham): changge default to `Any`
 SCT = TypeVar("SCT", bound=np.generic, default=np.generic)
 
 _To0D = TypeAliasType("_To0D", T | SCT | CanArray0D[SCT], type_params=(T, SCT))
@@ -209,6 +215,12 @@ ToJustBool2D: TypeAlias = _To2D[bool, np.bool_]
 ToJustBool3D: TypeAlias = _To3D[bool, np.bool_]
 ToJustBoolND: TypeAlias = _ToND[bool, np.bool_]
 
+ToJustInt64: TypeAlias = JustInt | np.intp
+ToJustInt64_1D: TypeAlias = _To1D[JustInt, np.intp]
+ToJustInt64_2D: TypeAlias = _To2D[JustInt, np.intp]
+ToJustInt64_3D: TypeAlias = _To3D[JustInt, np.intp]
+ToJustInt64_ND: TypeAlias = _ToND[JustInt, np.intp]
+
 ToJustInt: TypeAlias = JustInt | npc.integer
 ToJustInt1D: TypeAlias = _To1D[JustInt, npc.integer]
 ToJustInt2D: TypeAlias = _To2D[JustInt, npc.integer]
@@ -274,6 +286,10 @@ ToComplexStrict3D: TypeAlias = _ToStrict3D[complex, complexfloating_co]
 ToJustBoolStrict1D: TypeAlias = _ToStrict1D[bool, np.bool_]
 ToJustBoolStrict2D: TypeAlias = _ToStrict2D[bool, np.bool_]
 ToJustBoolStrict3D: TypeAlias = _ToStrict3D[bool, np.bool_]
+
+ToJustInt64Strict1D: TypeAlias = _ToStrict1D[JustInt, np.int64]
+ToJustInt64Strict2D: TypeAlias = _ToStrict2D[JustInt, np.int64]
+ToJustInt64Strict3D: TypeAlias = _ToStrict3D[JustInt, np.int64]
 
 ToJustIntStrict1D: TypeAlias = _ToStrict1D[JustInt, npc.integer]
 ToJustIntStrict2D: TypeAlias = _ToStrict2D[JustInt, npc.integer]


### PR DESCRIPTION
This adds the following `np.intt64` array-like type aliases to `optype.numpy`:

- `ToJustInt64`
- `ToJustInt64_1D`
- `ToJustInt64_2D`
- `ToJustInt64_3D`
- `ToJustInt64_ND`
- `ToJustInt64Strict1D`
- `ToJustInt64Strict2D`
- `ToJustInt64Strict3D`