### PR TITLE
numpy version agnostic gradual shape type defaults

### DIFF
--- a/optype/numpy/_any_array.py
+++ b/optype/numpy/_any_array.py
@@ -11,6 +11,7 @@ import numpy as np
 
 import optype.numpy._compat as _x
 import optype.numpy._scalar as _sc
+from ._shape import AnyShape
 from optype._core import CanBuffer, JustComplex, JustFloat, JustInt, JustObject
 from optype._utils import set_module
 
@@ -75,14 +76,7 @@ _ST_co = TypeVar("_ST_co", bound=np.generic, covariant=True)
 # NOTE: Does not include scalar types
 class _AnyArrayNP(Protocol[_ST_co]):
     def __len__(self, /) -> int: ...
-
-    if _x.NP21:
-
-        def __array__(self, /) -> np.ndarray[tuple[int, ...], np.dtype[_ST_co]]: ...
-
-    else:
-
-        def __array__(self, /) -> np.ndarray[Any, np.dtype[_ST_co]]: ...
+    def __array__(self, /) -> np.ndarray[AnyShape, np.dtype[_ST_co]]: ...
 
 
 # NOTE: does not include tuple
@@ -176,16 +170,7 @@ if _x.NP20:
     @set_module("optype.numpy")
     class AnyStringArray(Protocol):
         def __len__(self, /) -> int: ...
-
-        if _x.NP21:
-            # `numpy>=2.1`
-            def __array__(
-                self, /
-            ) -> np.ndarray[tuple[int, ...], np.dtypes.StringDType]: ...
-
-        elif _x.NP20:
-            # `numpy>=2,<2.1`
-            def __array__(self, /) -> np.ndarray[Any, np.dtype[Never]]: ...
+        def __array__(self, /) -> np.ndarray[AnyShape, np.dtypes.StringDType]: ...
 
 else:  # `numpy<2`
     AnyStringArray: TypeAlias = Never

--- a/optype/numpy/_any_array.py
+++ b/optype/numpy/_any_array.py
@@ -165,12 +165,19 @@ AnyTimeDelta64Array: TypeAlias = _AnyArray[np.timedelta64]
 AnyObjectArray: TypeAlias = _AnyArray[np.object_, np.object_ | JustObject]
 
 
-if _x.NP20:
+if _x.NP20:  # `numpy>=2.0`
 
     @set_module("optype.numpy")
     class AnyStringArray(Protocol):
         def __len__(self, /) -> int: ...
-        def __array__(self, /) -> np.ndarray[AnyShape, np.dtypes.StringDType]: ...
 
-else:  # `numpy<2`
+        if _x.NP21:  # numpy>=2.1
+
+            def __array__(self, /) -> np.ndarray[AnyShape, np.dtypes.StringDType]: ...
+
+        else:  # numpy==2.0.*
+
+            def __array__(self, /) -> np.ndarray[AnyShape, np.dtype[Never]]: ...
+
+else:  # `numpy<2.0`
     AnyStringArray: TypeAlias = Never

--- a/optype/numpy/_is.py
+++ b/optype/numpy/_is.py
@@ -1,5 +1,5 @@
 import sys
-from typing import Any, TypeAlias
+from typing import Any
 
 if sys.version_info >= (3, 13):
     from typing import TypeIs, TypeVar
@@ -10,6 +10,7 @@ import numpy as np
 
 from ._array import Array0D, Array1D, Array2D, Array3D, ArrayND
 from ._dtype import ToDType
+from ._shape import AnyShape, Shape
 
 __all__ = [
     "is_array_0d",
@@ -24,10 +25,6 @@ __all__ = [
 
 def __dir__() -> list[str]:
     return __all__
-
-
-Shape: TypeAlias = tuple[int, ...]
-AnyShape: TypeAlias = tuple[Any, ...]
 
 
 ShapeT = TypeVar("ShapeT", bound=Shape, default=AnyShape)

--- a/optype/numpy/_shape.py
+++ b/optype/numpy/_shape.py
@@ -26,6 +26,11 @@ def __dir__() -> list[str]:
 
 
 ###
+Shape: TypeAlias = tuple[int, ...]  # undocumented
+AnyShape: TypeAlias = tuple[Any, ...]  # undocumented
+
+
+###
 
 AxT = TypeVar("AxT", int, Any, default=int)
 

--- a/optype/numpy/ctypeslib.py
+++ b/optype/numpy/ctypeslib.py
@@ -44,7 +44,7 @@ from ctypes import (
 )
 from typing import TYPE_CHECKING, Final, Literal, Never, TypeAlias, cast
 
-if sys.version_info >= (3, 12):
+if sys.version_info >= (3, 13):
     from typing import TypeAliasType, TypeVar
 else:
     from typing_extensions import TypeAliasType, TypeVar

--- a/optype/numpy/random.py
+++ b/optype/numpy/random.py
@@ -6,7 +6,7 @@ import sys
 from collections.abc import Sequence
 from typing import Any, TypeAlias
 
-if sys.version_info >= (3, 12):
+if sys.version_info >= (3, 13):
     from typing import TypeAliasType
 else:
     from typing_extensions import TypeAliasType


### PR DESCRIPTION
this unifies `Any` and `tuple[int, ...]` as shape-types using the "gradual tuple" `tuple[Any, ...]` for numpy `><2.1` and `>=2.1`.