### PR TITLE
use `github.ref` instead of `github.sha` in the `concurrency.group` of `CI`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 env:


### PR DESCRIPTION
ref: https://github.com/data-apis/array-api-typing/pull/18/files#r2134923886