### PR TITLE
`optype.numpy.CanArrayND`: remove scalar type parameter default

### DIFF
--- a/optype/numpy/_array.py
+++ b/optype/numpy/_array.py
@@ -35,6 +35,7 @@ _DTT = TypeVar("_DTT", bound=np.dtype[Any], default=np.dtype[Any])
 _DTT_co = TypeVar("_DTT_co", bound=np.dtype[Any], default=np.dtype[Any], covariant=True)
 _SCT = TypeVar("_SCT", bound=np.generic, default=Any)
 _SCT_co = TypeVar("_SCT_co", bound=np.generic, default=Any, covariant=True)
+_SCT0_co = TypeVar("_SCT0_co", bound=np.generic, covariant=True)
 
 
 Matrix = TypeAliasType(
@@ -115,14 +116,14 @@ class CanArray(Protocol[_NDT_co, _DTT_co]):
 
 @runtime_checkable
 @set_module("optype.numpy")
-class CanArrayND(Protocol[_SCT_co, _NDT_co]):
+class CanArrayND(Protocol[_SCT0_co, _NDT_co]):
     """
     Similar to `onp.CanArray`, but must be sized (i.e. excludes scalars), and is
     parameterized by only the scalar type (instead of the shape and dtype).
     """
 
     def __len__(self, /) -> int: ...
-    def __array__(self, /) -> np.ndarray[_NDT_co, np.dtype[_SCT_co]]: ...
+    def __array__(self, /) -> np.ndarray[_NDT_co, np.dtype[_SCT0_co]]: ...
 
 
 Array0D = TypeAliasType(


### PR DESCRIPTION
This removes the PEP 696 default of the first `optype.numpy.CanArrayND` generic type parameter (covariant and bound to `np.generic`). This is technically a breaking change, but given its absence from the docs, I don't expect it to be likely that this will cuase issues for optype users.

This works around a path-dependent bug in Pyright (<=1.1.403) that has recently been causing a lot of issues in scipy-stubs.

See scipy/scipy-stubs#745, scipy/scipy-stubs#742, and scipy/scipy-stubs#741 for more info about this pyright bug.