### PR TITLE
`Can` binop return type param defaults to input param

### DIFF
--- a/README.md
+++ b/README.md
@@ -622,7 +622,7 @@ Classifying them "arithmetic" is, at the very least, a bit of a stretch.
         <td><code>DoesAdd</code></td>
         <td><code>__add__</code></td>
         <td>
-            <code>CanAdd[-T, +R]</code><br>
+            <code>CanAdd[-T, +R=T]</code><br>
             <code>CanAddSelf[-T]</code>
         </td>
     </tr>
@@ -632,7 +632,7 @@ Classifying them "arithmetic" is, at the very least, a bit of a stretch.
         <td><code>DoesSub</code></td>
         <td><code>__sub__</code></td>
         <td>
-            <code>CanSub[-T, +R]</code><br>
+            <code>CanSub[-T, +R=T]</code><br>
             <code>CanSubSelf[-T]</code>
         </td>
     </tr>
@@ -642,7 +642,7 @@ Classifying them "arithmetic" is, at the very least, a bit of a stretch.
         <td><code>DoesMul</code></td>
         <td><code>__mul__</code></td>
         <td>
-            <code>CanMul[-T, +R]</code><br>
+            <code>CanMul[-T, +R=T]</code><br>
             <code>CanMulSelf[-T]</code>
         </td>
     </tr>
@@ -652,7 +652,7 @@ Classifying them "arithmetic" is, at the very least, a bit of a stretch.
         <td><code>DoesMatmul</code></td>
         <td><code>__matmul__</code></td>
         <td>
-            <code>CanMatmul[-T, +R]</code><br>
+            <code>CanMatmul[-T, +R=T]</code><br>
             <code>CanMatmulSelf[-T]</code>
         </td>
     </tr>
@@ -662,7 +662,7 @@ Classifying them "arithmetic" is, at the very least, a bit of a stretch.
         <td><code>DoesTruediv</code></td>
         <td><code>__truediv__</code></td>
         <td>
-            <code>CanTruediv[-T, +R]</code><br>
+            <code>CanTruediv[-T, +R=T]</code><br>
             <code>CanTruedivSelf[-T]</code>
         </td>
     </tr>
@@ -672,7 +672,7 @@ Classifying them "arithmetic" is, at the very least, a bit of a stretch.
         <td><code>DoesFloordiv</code></td>
         <td><code>__floordiv__</code></td>
         <td>
-            <code>CanFloordiv[-T, +R]</code><br>
+            <code>CanFloordiv[-T, +R=T]</code><br>
             <code>CanFloordivSelf[-T]</code>
         </td>
     </tr>
@@ -682,7 +682,7 @@ Classifying them "arithmetic" is, at the very least, a bit of a stretch.
         <td><code>DoesMod</code></td>
         <td><code>__mod__</code></td>
         <td>
-            <code>CanMod[-T, +R]</code><br>
+            <code>CanMod[-T, +R=T]</code><br>
             <code>CanModSelf[-T]</code>
         </td>
     </tr>
@@ -702,7 +702,7 @@ Classifying them "arithmetic" is, at the very least, a bit of a stretch.
         <td><code>DoesPow</code></td>
         <td><code>__pow__</code></td>
         <td>
-            <code>CanPow2[-T, +R]</code><br>
+            <code>CanPow2[-T, +R=T]</code><br>
             <code>CanPowSelf[-T]</code><br>
             <code>CanPow[-T, None, +R, Never]</code>
         </td>
@@ -713,7 +713,7 @@ Classifying them "arithmetic" is, at the very least, a bit of a stretch.
         <td><code>DoesPow</code></td>
         <td><code>__pow__</code></td>
         <td>
-            <code>CanPow3[-T, -M, +R]</code><br>
+            <code>CanPow3[-T, -M, +R=int]</code><br>
             <code>CanPow[-T, -M, Never, +R]</code>
         </td>
     </tr>
@@ -723,7 +723,7 @@ Classifying them "arithmetic" is, at the very least, a bit of a stretch.
         <td><code>DoesLshift</code></td>
         <td><code>__lshift__</code></td>
         <td>
-            <code>CanLshift[-T, +R]</code><br>
+            <code>CanLshift[-T, +R=T]</code><br>
             <code>CanLshiftSelf[-T]</code>
         </td>
     </tr>
@@ -733,7 +733,7 @@ Classifying them "arithmetic" is, at the very least, a bit of a stretch.
         <td><code>DoesRshift</code></td>
         <td><code>__rshift__</code></td>
         <td>
-            <code>CanRshift[-T, +R]</code><br>
+            <code>CanRshift[-T, +R=T]</code><br>
             <code>CanRshiftSelf[-T]</code>
         </td>
     </tr>
@@ -743,7 +743,7 @@ Classifying them "arithmetic" is, at the very least, a bit of a stretch.
         <td><code>DoesAnd</code></td>
         <td><code>__and__</code></td>
         <td>
-            <code>CanAnd[-T, +R]</code><br>
+            <code>CanAnd[-T, +R=T]</code><br>
             <code>CanAndSelf[-T]</code>
         </td>
     </tr>
@@ -753,7 +753,7 @@ Classifying them "arithmetic" is, at the very least, a bit of a stretch.
         <td><code>DoesXor</code></td>
         <td><code>__xor__</code></td>
         <td>
-            <code>CanXor[-T, +R]</code><br>
+            <code>CanXor[-T, +R=T]</code><br>
             <code>CanXorSelf[-T]</code>
         </td>
     </tr>
@@ -763,7 +763,7 @@ Classifying them "arithmetic" is, at the very least, a bit of a stretch.
         <td><code>DoesOr</code></td>
         <td><code>__or__</code></td>
         <td>
-            <code>CanOr[-T, +R]</code><br>
+            <code>CanOr[-T, +R=T]</code><br>
             <code>CanOrSelf[-T]</code>
         </td>
     </tr>
@@ -802,7 +802,7 @@ They are named like the original, but prefixed with `CanR` prefix, i.e.
         <td><code>DoesRAdd</code></td>
         <td><code>__radd__</code></td>
         <td>
-            <code>CanRAdd[-T, +R]</code><br>
+            <code>CanRAdd[-T, +R=T]</code><br>
             <code>CanRAddSelf[-T]</code>
         </td>
     </tr>
@@ -812,7 +812,7 @@ They are named like the original, but prefixed with `CanR` prefix, i.e.
         <td><code>DoesRSub</code></td>
         <td><code>__rsub__</code></td>
         <td>
-            <code>CanRSub[-T, +R]</code><br>
+            <code>CanRSub[-T, +R=T]</code><br>
             <code>CanRSubSelf[-T]</code>
         </td>
     </tr>
@@ -822,7 +822,7 @@ They are named like the original, but prefixed with `CanR` prefix, i.e.
         <td><code>DoesRMul</code></td>
         <td><code>__rmul__</code></td>
         <td>
-            <code>CanRMul[-T, +R]</code><br>
+            <code>CanRMul[-T, +R=T]</code><br>
             <code>CanRMulSelf[-T]</code>
         </td>
     </tr>
@@ -832,7 +832,7 @@ They are named like the original, but prefixed with `CanR` prefix, i.e.
         <td><code>DoesRMatmul</code></td>
         <td><code>__rmatmul__</code></td>
         <td>
-            <code>CanRMatmul[-T, +R]</code><br>
+            <code>CanRMatmul[-T, +R=T]</code><br>
             <code>CanRMatmulSelf[-T]</code>
         </td>
     </tr>
@@ -842,7 +842,7 @@ They are named like the original, but prefixed with `CanR` prefix, i.e.
         <td><code>DoesRTruediv</code></td>
         <td><code>__rtruediv__</code></td>
         <td>
-            <code>CanRTruediv[-T, +R]</code><br>
+            <code>CanRTruediv[-T, +R=T]</code><br>
             <code>CanRTruedivSelf[-T]</code>
         </td>
     </tr>
@@ -852,7 +852,7 @@ They are named like the original, but prefixed with `CanR` prefix, i.e.
         <td><code>DoesRFloordiv</code></td>
         <td><code>__rfloordiv__</code></td>
         <td>
-            <code>CanRFloordiv[-T, +R]</code><br>
+            <code>CanRFloordiv[-T, +R=T]</code><br>
             <code>CanRFloordivSelf[-T]</code>
         </td>
     </tr>
@@ -862,7 +862,7 @@ They are named like the original, but prefixed with `CanR` prefix, i.e.
         <td><code>DoesRMod</code></td>
         <td><code>__rmod__</code></td>
         <td>
-            <code>CanRMod[-T, +R]</code><br>
+            <code>CanRMod[-T, +R=T]</code><br>
             <code>CanRModSelf[-T]</code>
         </td>
     </tr>
@@ -882,7 +882,7 @@ They are named like the original, but prefixed with `CanR` prefix, i.e.
         <td><code>DoesRPow</code></td>
         <td><code>__rpow__</code></td>
         <td>
-            <code>CanRPow[-T, +R]</code><br>
+            <code>CanRPow[-T, +R=T]</code><br>
             <code>CanRPowSelf[-T]</code>
         </td>
     </tr>
@@ -892,7 +892,7 @@ They are named like the original, but prefixed with `CanR` prefix, i.e.
         <td><code>DoesRLshift</code></td>
         <td><code>__rlshift__</code></td>
         <td>
-            <code>CanRLshift[-T, +R]</code><br>
+            <code>CanRLshift[-T, +R=T]</code><br>
             <code>CanRLshiftSelf[-T]</code>
         </td>
     </tr>
@@ -902,7 +902,7 @@ They are named like the original, but prefixed with `CanR` prefix, i.e.
         <td><code>DoesRRshift</code></td>
         <td><code>__rrshift__</code></td>
         <td>
-            <code>CanRRshift[-T, +R]</code><br>
+            <code>CanRRshift[-T, +R=T]</code><br>
             <code>CanRRshiftSelf[-T]</code>
         </td>
     </tr>
@@ -912,7 +912,7 @@ They are named like the original, but prefixed with `CanR` prefix, i.e.
         <td><code>DoesRAnd</code></td>
         <td><code>__rand__</code></td>
         <td>
-            <code>CanRAnd[-T, +R]</code><br>
+            <code>CanRAnd[-T, +R=T]</code><br>
             <code>CanRAndSelf[-T]</code>
         </td>
     </tr>
@@ -922,7 +922,7 @@ They are named like the original, but prefixed with `CanR` prefix, i.e.
         <td><code>DoesRXor</code></td>
         <td><code>__rxor__</code></td>
         <td>
-            <code>CanRXor[-T, +R]</code><br>
+            <code>CanRXor[-T, +R=T]</code><br>
             <code>CanRXorSelf[-T]</code>
         </td>
     </tr>
@@ -932,7 +932,7 @@ They are named like the original, but prefixed with `CanR` prefix, i.e.
         <td><code>DoesROr</code></td>
         <td><code>__ror__</code></td>
         <td>
-            <code>CanROr[-T, +R]</code><br>
+            <code>CanROr[-T, +R=T]</code><br>
             <code>CanROrSelf[-T]</code>
         </td>
     </tr>

--- a/optype/_core/_can.py
+++ b/optype/_core/_can.py
@@ -176,6 +176,7 @@ _Tss = ParamSpec("_Tss", default=...)
 _T = TypeVar("_T")
 _T_contra = TypeVar("_T_contra", contravariant=True)
 _T_co = TypeVar("_T_co", covariant=True)
+_TT_co = TypeVar("_TT_co", covariant=True, default=_T_contra)
 
 _K_contra = TypeVar("_K_contra", contravariant=True)
 _V_contra = TypeVar("_V_contra", contravariant=True)
@@ -567,8 +568,8 @@ class CanSequence(
 
 
 @runtime_checkable
-class CanAdd(Protocol[_T_contra, _T_co]):
-    def __add__(self, rhs: _T_contra, /) -> _T_co: ...
+class CanAdd(Protocol[_T_contra, _TT_co]):
+    def __add__(self, rhs: _T_contra, /) -> _TT_co: ...
 
 
 @runtime_checkable
@@ -582,8 +583,8 @@ class CanAddSelf(Protocol[_T_contra]):
 
 
 @runtime_checkable
-class CanSub(Protocol[_T_contra, _T_co]):
-    def __sub__(self, rhs: _T_contra, /) -> _T_co: ...
+class CanSub(Protocol[_T_contra, _TT_co]):
+    def __sub__(self, rhs: _T_contra, /) -> _TT_co: ...
 
 
 @runtime_checkable
@@ -597,8 +598,8 @@ class CanSubSelf(Protocol[_T_contra]):
 
 
 @runtime_checkable
-class CanMul(Protocol[_T_contra, _T_co]):
-    def __mul__(self, rhs: _T_contra, /) -> _T_co: ...
+class CanMul(Protocol[_T_contra, _TT_co]):
+    def __mul__(self, rhs: _T_contra, /) -> _TT_co: ...
 
 
 @runtime_checkable
@@ -612,8 +613,8 @@ class CanMulSelf(Protocol[_T_contra]):
 
 
 @runtime_checkable
-class CanMatmul(Protocol[_T_contra, _T_co]):
-    def __matmul__(self, rhs: _T_contra, /) -> _T_co: ...
+class CanMatmul(Protocol[_T_contra, _TT_co]):
+    def __matmul__(self, rhs: _T_contra, /) -> _TT_co: ...
 
 
 @runtime_checkable
@@ -627,8 +628,8 @@ class CanMatmulSelf(Protocol[_T_contra]):
 
 
 @runtime_checkable
-class CanTruediv(Protocol[_T_contra, _T_co]):
-    def __truediv__(self, rhs: _T_contra, /) -> _T_co: ...
+class CanTruediv(Protocol[_T_contra, _TT_co]):
+    def __truediv__(self, rhs: _T_contra, /) -> _TT_co: ...
 
 
 @runtime_checkable
@@ -642,8 +643,8 @@ class CanTruedivSelf(Protocol[_T_contra]):
 
 
 @runtime_checkable
-class CanFloordiv(Protocol[_T_contra, _T_co]):
-    def __floordiv__(self, rhs: _T_contra, /) -> _T_co: ...
+class CanFloordiv(Protocol[_T_contra, _TT_co]):
+    def __floordiv__(self, rhs: _T_contra, /) -> _TT_co: ...
 
 
 @runtime_checkable
@@ -657,8 +658,8 @@ class CanFloordivSelf(Protocol[_T_contra]):
 
 
 @runtime_checkable
-class CanMod(Protocol[_T_contra, _T_co]):
-    def __mod__(self, rhs: _T_contra, /) -> _T_co: ...
+class CanMod(Protocol[_T_contra, _TT_co]):
+    def __mod__(self, rhs: _T_contra, /) -> _TT_co: ...
 
 
 @runtime_checkable
@@ -680,8 +681,8 @@ class CanDivmod(Protocol[_T_contra, _T_co]):
 
 
 @runtime_checkable
-class CanPow2(Protocol[_T_contra, _T_co]):
-    def __pow__(self, rhs: _T_contra, /) -> _T_co: ...
+class CanPow2(Protocol[_T_contra, _TT_co]):
+    def __pow__(self, rhs: _T_contra, /) -> _TT_co: ...
 
 
 @runtime_checkable
@@ -691,13 +692,13 @@ class CanPow3(Protocol[_T_contra, _V_contra, _AnyIntT_co]):
 
 @runtime_checkable
 class CanPow(
-    CanPow2[_T_contra, _T_co],
+    CanPow2[_T_contra, _TT_co],
     CanPow3[_T_contra, _V_contra, _AnyIntT_co],
-    Protocol[_T_contra, _V_contra, _T_co, _AnyIntT_co],
+    Protocol[_T_contra, _V_contra, _TT_co, _AnyIntT_co],
 ):
     @overload
     @override
-    def __pow__(self, exp: _T_contra, /) -> _T_co: ...
+    def __pow__(self, exp: _T_contra, /) -> _TT_co: ...
     @overload
     def __pow__(self, exp: _T_contra, mod: _V_contra, /) -> _AnyIntT_co: ...
 
@@ -713,8 +714,8 @@ class CanPowSelf(Protocol[_T_contra]):
 
 
 @runtime_checkable
-class CanLshift(Protocol[_T_contra, _T_co]):
-    def __lshift__(self, rhs: _T_contra, /) -> _T_co: ...
+class CanLshift(Protocol[_T_contra, _TT_co]):
+    def __lshift__(self, rhs: _T_contra, /) -> _TT_co: ...
 
 
 @runtime_checkable
@@ -728,8 +729,8 @@ class CanLshiftSelf(Protocol[_T_contra]):
 
 
 @runtime_checkable
-class CanRshift(Protocol[_T_contra, _T_co]):
-    def __rshift__(self, rhs: _T_contra, /) -> _T_co: ...
+class CanRshift(Protocol[_T_contra, _TT_co]):
+    def __rshift__(self, rhs: _T_contra, /) -> _TT_co: ...
 
 
 @runtime_checkable
@@ -743,8 +744,8 @@ class CanRshiftSelf(Protocol[_T_contra]):
 
 
 @runtime_checkable
-class CanAnd(Protocol[_T_contra, _T_co]):
-    def __and__(self, rhs: _T_contra, /) -> _T_co: ...
+class CanAnd(Protocol[_T_contra, _TT_co]):
+    def __and__(self, rhs: _T_contra, /) -> _TT_co: ...
 
 
 @runtime_checkable
@@ -758,8 +759,8 @@ class CanAndSelf(Protocol[_T_contra]):
 
 
 @runtime_checkable
-class CanXor(Protocol[_T_contra, _T_co]):
-    def __xor__(self, rhs: _T_contra, /) -> _T_co: ...
+class CanXor(Protocol[_T_contra, _TT_co]):
+    def __xor__(self, rhs: _T_contra, /) -> _TT_co: ...
 
 
 @runtime_checkable
@@ -773,8 +774,8 @@ class CanXorSelf(Protocol[_T_contra]):
 
 
 @runtime_checkable
-class CanOr(Protocol[_T_contra, _T_co]):
-    def __or__(self, rhs: _T_contra, /) -> _T_co: ...
+class CanOr(Protocol[_T_contra, _TT_co]):
+    def __or__(self, rhs: _T_contra, /) -> _TT_co: ...
 
 
 @runtime_checkable
@@ -791,8 +792,8 @@ class CanOrSelf(Protocol[_T_contra]):
 
 
 @runtime_checkable
-class CanRAdd(Protocol[_T_contra, _T_co]):
-    def __radd__(self, lhs: _T_contra, /) -> _T_co: ...
+class CanRAdd(Protocol[_T_contra, _TT_co]):
+    def __radd__(self, lhs: _T_contra, /) -> _TT_co: ...
 
 
 @runtime_checkable
@@ -806,8 +807,8 @@ class CanRAddSelf(Protocol[_T_contra]):
 
 
 @runtime_checkable
-class CanRSub(Protocol[_T_contra, _T_co]):
-    def __rsub__(self, lhs: _T_contra, /) -> _T_co: ...
+class CanRSub(Protocol[_T_contra, _TT_co]):
+    def __rsub__(self, lhs: _T_contra, /) -> _TT_co: ...
 
 
 @runtime_checkable
@@ -821,8 +822,8 @@ class CanRSubSelf(Protocol[_T_contra]):
 
 
 @runtime_checkable
-class CanRMul(Protocol[_T_contra, _T_co]):
-    def __rmul__(self, lhs: _T_contra, /) -> _T_co: ...
+class CanRMul(Protocol[_T_contra, _TT_co]):
+    def __rmul__(self, lhs: _T_contra, /) -> _TT_co: ...
 
 
 @runtime_checkable
@@ -836,8 +837,8 @@ class CanRMulSelf(Protocol[_T_contra]):
 
 
 @runtime_checkable
-class CanRMatmul(Protocol[_T_contra, _T_co]):
-    def __rmatmul__(self, lhs: _T_contra, /) -> _T_co: ...
+class CanRMatmul(Protocol[_T_contra, _TT_co]):
+    def __rmatmul__(self, lhs: _T_contra, /) -> _TT_co: ...
 
 
 @runtime_checkable
@@ -851,8 +852,8 @@ class CanRMatmulSelf(Protocol[_T_contra]):
 
 
 @runtime_checkable
-class CanRTruediv(Protocol[_T_contra, _T_co]):
-    def __rtruediv__(self, lhs: _T_contra, /) -> _T_co: ...
+class CanRTruediv(Protocol[_T_contra, _TT_co]):
+    def __rtruediv__(self, lhs: _T_contra, /) -> _TT_co: ...
 
 
 @runtime_checkable
@@ -866,8 +867,8 @@ class CanRTruedivSelf(Protocol[_T_contra]):
 
 
 @runtime_checkable
-class CanRFloordiv(Protocol[_T_contra, _T_co]):
-    def __rfloordiv__(self, lhs: _T_contra, /) -> _T_co: ...
+class CanRFloordiv(Protocol[_T_contra, _TT_co]):
+    def __rfloordiv__(self, lhs: _T_contra, /) -> _TT_co: ...
 
 
 @runtime_checkable
@@ -881,8 +882,8 @@ class CanRFloordivSelf(Protocol[_T_contra]):
 
 
 @runtime_checkable
-class CanRMod(Protocol[_T_contra, _T_co]):
-    def __rmod__(self, lhs: _T_contra, /) -> _T_co: ...
+class CanRMod(Protocol[_T_contra, _TT_co]):
+    def __rmod__(self, lhs: _T_contra, /) -> _TT_co: ...
 
 
 @runtime_checkable
@@ -905,8 +906,8 @@ class CanRDivmod(Protocol[_T_contra, _T_co]):
 
 
 @runtime_checkable
-class CanRPow(Protocol[_T_contra, _T_co]):
-    def __rpow__(self, lhs: _T_contra, /) -> _T_co: ...
+class CanRPow(Protocol[_T_contra, _TT_co]):
+    def __rpow__(self, lhs: _T_contra, /) -> _TT_co: ...
 
 
 @runtime_checkable
@@ -920,8 +921,8 @@ class CanRPowSelf(Protocol[_T_contra]):
 
 
 @runtime_checkable
-class CanRLshift(Protocol[_T_contra, _T_co]):
-    def __rlshift__(self, lhs: _T_contra, /) -> _T_co: ...
+class CanRLshift(Protocol[_T_contra, _TT_co]):
+    def __rlshift__(self, lhs: _T_contra, /) -> _TT_co: ...
 
 
 @runtime_checkable
@@ -935,8 +936,8 @@ class CanRLshiftSelf(Protocol[_T_contra]):
 
 
 @runtime_checkable
-class CanRRshift(Protocol[_T_contra, _T_co]):
-    def __rrshift__(self, lhs: _T_contra, /) -> _T_co: ...
+class CanRRshift(Protocol[_T_contra, _TT_co]):
+    def __rrshift__(self, lhs: _T_contra, /) -> _TT_co: ...
 
 
 @runtime_checkable
@@ -950,8 +951,8 @@ class CanRRshiftSelf(Protocol[_T_contra]):
 
 
 @runtime_checkable
-class CanRAnd(Protocol[_T_contra, _T_co]):
-    def __rand__(self, lhs: _T_contra, /) -> _T_co: ...
+class CanRAnd(Protocol[_T_contra, _TT_co]):
+    def __rand__(self, lhs: _T_contra, /) -> _TT_co: ...
 
 
 @runtime_checkable
@@ -965,8 +966,8 @@ class CanRAndSelf(Protocol[_T_contra]):
 
 
 @runtime_checkable
-class CanRXor(Protocol[_T_contra, _T_co]):
-    def __rxor__(self, lhs: _T_contra, /) -> _T_co: ...
+class CanRXor(Protocol[_T_contra, _TT_co]):
+    def __rxor__(self, lhs: _T_contra, /) -> _TT_co: ...
 
 
 @runtime_checkable
@@ -980,8 +981,8 @@ class CanRXorSelf(Protocol[_T_contra]):
 
 
 @runtime_checkable
-class CanROr(Protocol[_T_contra, _T_co]):
-    def __ror__(self, lhs: _T_contra, /) -> _T_co: ...
+class CanROr(Protocol[_T_contra, _TT_co]):
+    def __ror__(self, lhs: _T_contra, /) -> _TT_co: ...
 
 
 @runtime_checkable


### PR DESCRIPTION
For example, one can now write `CanMul[int]` instead of `CanMul[int, int]`.