### PR TITLE
`CanGetSelf[-T, +V]` alias for `CanGet[T, V, Self]`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1654,11 +1654,19 @@ Interfaces for [descriptors](https://docs.python.org/3/howto/descriptor.html).
     </tr>
     <tr>
         <td>
-            <code>v: V = T().d</code><br/>
+            <code>v: V = T().d</code><br>
             <code>vt: VT = T.d</code>
         </td>
         <td><code>__get__</code></td>
-        <td><code>CanGet[-T, +V, +VT = V]</code></td>
+        <td><code>CanGet[-T, +V, +VT=V]</code></td>
+    </tr>
+    <tr>
+        <td>
+            <code>v: V = T().d</code><br>
+            <code>vt: Self = T.d</code>
+        </td>
+        <td><code>__get__</code></td>
+        <td><code>CanGetSelf[-T, +V]</code></td>
     </tr>
     <tr>
         <td><code>T().k = v</code></td>

--- a/optype/_core/_can.py
+++ b/optype/_core/_can.py
@@ -477,6 +477,16 @@ class CanGet(Protocol[_T_contra, _V_co, _VV_co]):
 
 
 @runtime_checkable
+class CanGetSelf(Protocol[_T_contra, _V_co]):
+    """CanGetSelf[-T, +V] = CanGet[T, V, Self]"""
+
+    @overload
+    def __get__(self, obj: _T_contra, cls: type | None = ..., /) -> _V_co: ...
+    @overload
+    def __get__(self, obj: None, cls: type[_T_contra], /) -> Self: ...
+
+
+@runtime_checkable
 class CanSet(Protocol[_T_contra, _V_contra]):
     def __set__(self, owner: _T_contra, value: _V_contra, /) -> _Ignored: ...
 


### PR DESCRIPTION
closes #355