### PR TITLE
prepare for numpy 2.4

### DIFF
--- a/optype/numpy/_compat.py
+++ b/optype/numpy/_compat.py
@@ -14,6 +14,8 @@ NP21: Final = NP20 and not np.__version__.startswith("2.0.")
 NP22: Final = NP21 and not np.__version__.startswith("2.1.")
 # >=2.3
 NP23: Final = NP22 and not np.__version__.startswith("2.2.")
+# >=2.4
+NP24: Final = NP23 and not np.__version__.startswith("2.3.")
 
 
 if NP20:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,6 +125,7 @@ reportUnusedVariable = false              # dupe of F841
     NP21 = true
     NP22 = true
     NP23 = true
+    NP24 = false
 
 
 [tool.pytest.ini_options]

--- a/scripts/config/bpr-np-2.4.json
+++ b/scripts/config/bpr-np-2.4.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./bpr-np-2.3.json",
+  "defineConstant": { "NP24": true }
+}

--- a/scripts/my.py
+++ b/scripts/my.py
@@ -13,7 +13,7 @@ _Version: TypeAlias = tuple[int, int]
 _NP1_MIN: Final = 1, 25
 _NP1_MAX: Final = 1, 26
 _NP2_MIN: Final = 2, 0
-_NP2_MAX: Final = 2, 3
+_NP2_MAX: Final = 2, 4
 _NP_SKIP: Final = frozenset({(1, 26)})
 
 


### PR DESCRIPTION
Note that the NumPy 2.4 release is still 5 or so months off.

And don't worry; numpy is still an optional dependency :)