### PR TITLE
`optype.numpy` array-like types for `float16`, `float32`, and `complex64`

### DIFF
--- a/README.md
+++ b/README.md
@@ -2878,7 +2878,7 @@ matrix-likes, and cuboid-likes, and the `To{}` aliases for "bare" scalar types.
     <td align="left"><code>ToIntStrict{}D</code></td>
 </tr>
 <tr>
-    <td align="left"><code></code></td>
+    <td align="left"></td>
     <td align="left"><code>float16</code></td>
     <td align="left"><code>ToJustFloat16</code></td>
     <td align="left"><code>ToJustFloat16_{}D</code></td>
@@ -2897,7 +2897,7 @@ matrix-likes, and cuboid-likes, and the `To{}` aliases for "bare" scalar types.
     <td align="left"><code>ToFloat32Strict{}D</code></td>
 </tr>
 <tr>
-    <td align="left"><code></code></td>
+    <td align="left"></td>
     <td align="left"><code>float32</code></td>
     <td align="left"><code>ToJustFloat32</code></td>
     <td align="left"><code>ToJustFloat32_{}D</code></td>
@@ -2965,7 +2965,7 @@ matrix-likes, and cuboid-likes, and the `To{}` aliases for "bare" scalar types.
     <td align="left"><code>ToFloatStrict{}D</code></td>
 </tr>
 <tr>
-    <td align="left"><code></code></td>
+    <td align="left"></td>
     <td align="left"><code>complex64</code></td>
     <td align="left"><code>ToJustComplex64</code></td>
     <td align="left"><code>ToJustComplex64_{}D</code></td>

--- a/README.md
+++ b/README.md
@@ -3077,11 +3077,16 @@ matrix-likes, and cuboid-likes, and the `To{}` aliases for "bare" scalar types.
 > wasn't generic, making it impossible to distinguish between `np.False_` and `np.True_`
 > using static typing.
 
-Source code: [`optype/numpy/_to.py`][CODE-NP-TO]
+<!-- markdownlint want this here -->
 
 > [!NOTE]
 > The `ToArrayStrict{1,2,3}D` types are generic since `optype 0.9.1`, analogous to
 > their non-strict dual type, `ToArray{1,2,3}D`.
+
+<!-- markdownlint want this here -->
+
+> [!NOTE]
+> The `To[Just]{Float16,Float32,Complex64}*` type aliases were added in `optype 0.12.0`.
 
 Source code: [`optype/numpy/_to.py`][CODE-NP-TO]
 

--- a/README.md
+++ b/README.md
@@ -3038,12 +3038,12 @@ matrix-likes, and cuboid-likes, and the `To{}` aliases for "bare" scalar types.
 </tr>
 <tr>
     <td align="left">
-        <code>bytes</code><br>
-        <code>| str</code><br>
-        <code>| complex</code><br>
+        <code>complex</code><br>
         <code>| float</code><br>
         <code>| int</code><br>
         <code>| bool</code>
+        <code>| bytes</code><br>
+        <code>| str</code><br>
     </td>
     <td align="left"><code>generic</code></td>
     <td align="left"><code>ToScalar</code></td>

--- a/README.md
+++ b/README.md
@@ -2878,6 +2878,47 @@ matrix-likes, and cuboid-likes, and the `To{}` aliases for "bare" scalar types.
     <td align="left"><code>ToIntStrict{}D</code></td>
 </tr>
 <tr>
+    <td align="left"><code></code></td>
+    <td align="left"><code>float16</code></td>
+    <td align="left"><code>ToJustFloat16</code></td>
+    <td align="left"><code>ToJustFloat16_{}D</code></td>
+    <td align="left"><code>ToJustFloat16Strict{}D</code></td>
+</tr>
+<tr>
+    <td align="left"></td>
+    <td align="left">
+        <code>| float16</code><br>
+        <code>| int8</code><br>
+        <code>| uint8</code><br>
+        <code>| bool_</code>
+    </td>
+    <td align="left"><code>ToFloat32</code></td>
+    <td align="left"><code>ToFloat32_{}D</code></td>
+    <td align="left"><code>ToFloat32Strict{}D</code></td>
+</tr>
+<tr>
+    <td align="left"><code></code></td>
+    <td align="left"><code>float32</code></td>
+    <td align="left"><code>ToJustFloat32</code></td>
+    <td align="left"><code>ToJustFloat32_{}D</code></td>
+    <td align="left"><code>ToJustFloat32Strict{}D</code></td>
+</tr>
+<tr>
+    <td align="left"></td>
+    <td align="left">
+        <code>| float32</code><br>
+        <code>| float16</code><br>
+        <code>| int16</code><br>
+        <code>| uint16</code><br>
+        <code>| int8</code><br>
+        <code>| uint8</code><br>
+        <code>| bool_</code>
+    </td>
+    <td align="left"><code>ToFloat32</code></td>
+    <td align="left"><code>ToFloat32_{}D</code></td>
+    <td align="left"><code>ToFloat32Strict{}D</code></td>
+</tr>
+<tr>
     <td align="left"><code>~float</code></td>
     <td align="left"><code>float64</code></td>
     <td align="left"><code>ToJustFloat64</code></td>
@@ -2924,6 +2965,29 @@ matrix-likes, and cuboid-likes, and the `To{}` aliases for "bare" scalar types.
     <td align="left"><code>ToFloatStrict{}D</code></td>
 </tr>
 <tr>
+    <td align="left"><code></code></td>
+    <td align="left"><code>complex64</code></td>
+    <td align="left"><code>ToJustComplex64</code></td>
+    <td align="left"><code>ToJustComplex64_{}D</code></td>
+    <td align="left"><code>ToJustComplex64Strict{}D</code></td>
+</tr>
+<tr>
+    <td align="left"></td>
+    <td align="left">
+        <code>| complex64</code><br>
+        <code>| float32</code><br>
+        <code>| float16</code><br>
+        <code>| int16</code><br>
+        <code>| uint16</code><br>
+        <code>| int8</code><br>
+        <code>| uint8</code><br>
+        <code>| bool_</code>
+    </td>
+    <td align="left"><code>ToComplex64</code></td>
+    <td align="left"><code>ToComplex64_{}D</code></td>
+    <td align="left"><code>ToComplex64Strict{}D</code></td>
+</tr>
+<tr>
     <td align="left"><code>~complex</code></td>
     <td align="left"><code>complex128</code></td>
     <td align="left"><code>ToJustComplex128</code></td>
@@ -2940,7 +3004,6 @@ matrix-likes, and cuboid-likes, and the `To{}` aliases for "bare" scalar types.
     <td align="left">
         <code>complex128</code><br>
         <code>| complex64</code><br>
-        <code>| float64</code><br>
         <code>| float64</code><br>
         <code>| float32</code><br>
         <code>| float16</code><br>

--- a/optype/numpy/_to.py
+++ b/optype/numpy/_to.py
@@ -43,6 +43,18 @@ __all__ = [  # noqa: RUF022
     "ToJustInt64_3D", "ToJustInt64Strict3D",
     "ToJustInt64_ND",
 
+    "ToFloat16", "ToJustFloat16",
+    "ToFloat16_1D", "ToJustFloat16_1D", "ToFloat16Strict1D", "ToJustFloat16Strict1D",
+    "ToFloat16_2D", "ToJustFloat16_2D", "ToFloat16Strict2D", "ToJustFloat16Strict2D",
+    "ToFloat16_3D", "ToJustFloat16_3D", "ToFloat16Strict3D", "ToJustFloat16Strict3D",
+    "ToFloat16_ND", "ToJustFloat16_ND",
+
+    "ToFloat32", "ToJustFloat32",
+    "ToFloat32_1D", "ToJustFloat32_1D", "ToFloat32Strict1D", "ToJustFloat32Strict1D",
+    "ToFloat32_2D", "ToJustFloat32_2D", "ToFloat32Strict2D", "ToJustFloat32Strict2D",
+    "ToFloat32_3D", "ToJustFloat32_3D", "ToFloat32Strict3D", "ToJustFloat32Strict3D",
+    "ToFloat32_ND", "ToJustFloat32_ND",
+
     "ToFloat64", "ToJustFloat64",
     "ToFloat64_1D", "ToJustFloat64_1D", "ToFloat64Strict1D", "ToJustFloat64Strict1D",
     "ToFloat64_2D", "ToJustFloat64_2D", "ToFloat64Strict2D", "ToJustFloat64Strict2D",
@@ -54,6 +66,15 @@ __all__ = [  # noqa: RUF022
     "ToFloat2D", "ToJustFloat2D", "ToFloatStrict2D", "ToJustFloatStrict2D",
     "ToFloat3D", "ToJustFloat3D", "ToFloatStrict3D", "ToJustFloatStrict3D",
     "ToFloatND", "ToJustFloatND",
+
+    "ToComplex64", "ToJustComplex64",
+    "ToComplex64_1D", "ToJustComplex64_1D",
+    "ToComplex64_2D", "ToJustComplex64_2D",
+    "ToComplex64_3D", "ToJustComplex64_3D",
+    "ToComplex64_ND", "ToJustComplex64_ND",
+    "ToComplex64Strict1D", "ToJustComplex64Strict1D",
+    "ToComplex64Strict2D", "ToJustComplex64Strict2D",
+    "ToComplex64Strict3D", "ToJustComplex64Strict3D",
 
     "ToComplex128", "ToJustComplex128",
     "ToComplex128_1D", "ToJustComplex128_1D",
@@ -100,41 +121,80 @@ class _CanArrayND(Protocol[SCT_co]):
     def __array__(self, /) -> np.ndarray[Any, np.dtype[SCT_co]]: ...
 
 
-_To0D = TypeAliasType("_To0D", T | _CanArray0D[SCT], type_params=(T, SCT))
-_To1D = TypeAliasType(
-    "_To1D",
+_To1D1 = TypeAliasType(
+    "_To1D1",
+    CanArrayND[SCT] | Seq[_CanArray0D[SCT]],
+    type_params=(SCT,),
+)
+_To1D2 = TypeAliasType(
+    "_To1D2",
     CanArrayND[SCT] | Seq[T | _CanArray0D[SCT]],
     type_params=(T, SCT),
 )
-_To2D = TypeAliasType(
-    "_To2D",
-    CanArrayND[SCT] | Seq[_To1D[T, SCT]],
+
+_To2D1 = TypeAliasType(
+    "_To2D1",
+    CanArrayND[SCT] | Seq[_To1D1[SCT]],
+    type_params=(SCT,),
+)
+_To2D2 = TypeAliasType(
+    "_To2D2",
+    CanArrayND[SCT] | Seq[_To1D2[T, SCT]],
     type_params=(T, SCT),
 )
-_To3D = TypeAliasType(
-    "_To3D",
-    CanArrayND[SCT] | Seq[_To2D[T, SCT]],
+
+_To3D1 = TypeAliasType(
+    "_To3D1",
+    CanArrayND[SCT] | Seq[_To2D1[SCT]],
+    type_params=(SCT,),
+)
+_To3D2 = TypeAliasType(
+    "_To3D2",
+    CanArrayND[SCT] | Seq[_To2D2[T, SCT]],
     type_params=(T, SCT),
 )
-_ToND = TypeAliasType(
-    "_ToND",
+
+_ToND1 = TypeAliasType(
+    "_ToND1",
+    CanArrayND[SCT] | SeqND[_CanArrayND[SCT]],
+    type_params=(SCT,),
+)
+_ToND2 = TypeAliasType(
+    "_ToND2",
     CanArrayND[SCT] | SeqND[T | _CanArrayND[SCT]],
     type_params=(T, SCT),
 )
 
-_ToStrict1D = TypeAliasType(
-    "_ToStrict1D",
+_ToStrict1D1 = TypeAliasType(
+    "_ToStrict1D1",
+    CanArray1D[SCT] | Seq[_CanArray0D[SCT]],
+    type_params=(SCT,),
+)
+_ToStrict1D2 = TypeAliasType(
+    "_ToStrict1D2",
     CanArray1D[SCT] | Seq[T | _CanArray0D[SCT]],
     type_params=(T, SCT),
 )
-_ToStrict2D = TypeAliasType(
-    "_ToStrict2D",
-    CanArray2D[SCT] | Seq[_ToStrict1D[T, SCT]],
+
+_ToStrict2D1 = TypeAliasType(
+    "_ToStrict2D1",
+    CanArray2D[SCT] | Seq[_ToStrict1D1[SCT]],
+    type_params=(SCT,),
+)
+_ToStrict2D2 = TypeAliasType(
+    "_ToStrict2D2",
+    CanArray2D[SCT] | Seq[_ToStrict1D2[T, SCT]],
     type_params=(T, SCT),
 )
-_ToStrict3D = TypeAliasType(
-    "_ToStrict3D",
-    CanArray3D[SCT] | Seq[_ToStrict2D[T, SCT]],
+
+_ToStrict3D1 = TypeAliasType(
+    "_ToStrict3D1",
+    CanArray3D[SCT] | Seq[_ToStrict2D1[SCT]],
+    type_params=(SCT,),
+)
+_ToStrict3D2 = TypeAliasType(
+    "_ToStrict3D2",
+    CanArray3D[SCT] | Seq[_ToStrict2D2[T, SCT]],
     type_params=(T, SCT),
 )
 
@@ -147,12 +207,26 @@ _ToStrict3D = TypeAliasType(
 integer_co = TypeAliasType("integer_co", npc.integer | np.bool_)
 floating_co = TypeAliasType("floating_co", npc.floating | integer_co)
 complexfloating_co = TypeAliasType("complexfloating_co", npc.number | np.bool_)
-float64_co = TypeAliasType(
-    "float64_co",
+
+# promotion rules with safe casting mode
+f16_co = TypeAliasType(
+    "f16_co",
+    npc.floating16 | npc.integer8 | np.bool_,
+)
+f32_co = TypeAliasType(
+    "f32_co",
+    npc.floating32 | npc.floating16 | npc.integer16 | npc.integer8 | np.bool_,
+)
+c64_co = TypeAliasType(
+    "c64_co",
+    npc.inexact32 | npc.number16 | npc.integer8 | np.bool_,
+)
+f64_co = TypeAliasType(
+    "f64_co",
     npc.floating64 | npc.floating32 | npc.floating16 | integer_co,
 )
-complex128_co = TypeAliasType(
-    "complex128_co",
+c128_co = TypeAliasType(
+    "c128_co",
     npc.number64 | npc.number32 | npc.number16 | integer_co,
 )
 
@@ -163,10 +237,10 @@ complex128_co = TypeAliasType(
 # scalar- and array-likes, with "coercible" shape-types
 
 ToScalar: TypeAlias = _PyScalar | np.generic
-ToArray1D: TypeAlias = _To1D[T, SCT]
-ToArray2D: TypeAlias = _To2D[T, SCT]
-ToArray3D: TypeAlias = _To3D[T, SCT]
-ToArrayND: TypeAlias = _ToND[T, SCT]
+ToArray1D: TypeAlias = _To1D2[T, SCT]
+ToArray2D: TypeAlias = _To2D2[T, SCT]
+ToArray3D: TypeAlias = _To3D2[T, SCT]
+ToArrayND: TypeAlias = _ToND2[T, SCT]
 
 if NP22:
     ToFalse = TypeAliasType("ToFalse", "Literal[False, 0] | np.bool[Literal[False]]")
@@ -185,141 +259,201 @@ else:
     ToJustTrue = TypeAliasType("ToJustTrue", Literal[True])
 
 ToBool: TypeAlias = _PyBool | np.bool_
-ToBool1D: TypeAlias = _To1D[_PyBool, np.bool_]
-ToBool2D: TypeAlias = _To2D[_PyBool, np.bool_]
-ToBool3D: TypeAlias = _To3D[_PyBool, np.bool_]
-ToBoolND: TypeAlias = _ToND[_PyBool, np.bool_]
+ToBool1D: TypeAlias = _To1D2[_PyBool, np.bool_]
+ToBool2D: TypeAlias = _To2D2[_PyBool, np.bool_]
+ToBool3D: TypeAlias = _To3D2[_PyBool, np.bool_]
+ToBoolND: TypeAlias = _ToND2[_PyBool, np.bool_]
 
 ToInt: TypeAlias = int | integer_co
-ToInt1D: TypeAlias = _To1D[int, integer_co]
-ToInt2D: TypeAlias = _To2D[int, integer_co]
-ToInt3D: TypeAlias = _To3D[int, integer_co]
-ToIntND: TypeAlias = _ToND[int, integer_co]
+ToInt1D: TypeAlias = _To1D2[int, integer_co]
+ToInt2D: TypeAlias = _To2D2[int, integer_co]
+ToInt3D: TypeAlias = _To3D2[int, integer_co]
+ToIntND: TypeAlias = _ToND2[int, integer_co]
 
-ToFloat64: TypeAlias = float | float64_co
-ToFloat64_1D: TypeAlias = _To1D[float, float64_co]
-ToFloat64_2D: TypeAlias = _To2D[float, float64_co]
-ToFloat64_3D: TypeAlias = _To3D[float, float64_co]
-ToFloat64_ND: TypeAlias = _ToND[float, float64_co]
+ToFloat16: TypeAlias = f16_co
+ToFloat16_1D: TypeAlias = _To1D1[f16_co]
+ToFloat16_2D: TypeAlias = _To2D1[f16_co]
+ToFloat16_3D: TypeAlias = _To3D1[f16_co]
+ToFloat16_ND: TypeAlias = _ToND1[f16_co]
+
+ToFloat32: TypeAlias = f32_co
+ToFloat32_1D: TypeAlias = _To1D1[f32_co]
+ToFloat32_2D: TypeAlias = _To2D1[f32_co]
+ToFloat32_3D: TypeAlias = _To3D1[f32_co]
+ToFloat32_ND: TypeAlias = _ToND1[f32_co]
+
+ToFloat64: TypeAlias = float | f64_co
+ToFloat64_1D: TypeAlias = _To1D2[float, f64_co]
+ToFloat64_2D: TypeAlias = _To2D2[float, f64_co]
+ToFloat64_3D: TypeAlias = _To3D2[float, f64_co]
+ToFloat64_ND: TypeAlias = _ToND2[float, f64_co]
 
 ToFloat: TypeAlias = float | floating_co
-ToFloat1D: TypeAlias = _To1D[float, floating_co]
-ToFloat2D: TypeAlias = _To2D[float, floating_co]
-ToFloat3D: TypeAlias = _To3D[float, floating_co]
-ToFloatND: TypeAlias = _ToND[float, floating_co]
+ToFloat1D: TypeAlias = _To1D2[float, floating_co]
+ToFloat2D: TypeAlias = _To2D2[float, floating_co]
+ToFloat3D: TypeAlias = _To3D2[float, floating_co]
+ToFloatND: TypeAlias = _ToND2[float, floating_co]
+
+ToComplex64: TypeAlias = c64_co
+ToComplex64_1D: TypeAlias = _To1D1[c64_co]
+ToComplex64_2D: TypeAlias = _To2D1[c64_co]
+ToComplex64_3D: TypeAlias = _To3D1[c64_co]
+ToComplex64_ND: TypeAlias = _ToND1[c64_co]
+
+ToComplex128: TypeAlias = complex | c128_co
+ToComplex128_1D: TypeAlias = _To1D2[complex, c128_co]
+ToComplex128_2D: TypeAlias = _To2D2[complex, c128_co]
+ToComplex128_3D: TypeAlias = _To3D2[complex, c128_co]
+ToComplex128_ND: TypeAlias = _ToND2[complex, c128_co]
 
 ToComplex: TypeAlias = complex | complexfloating_co
-ToComplex1D: TypeAlias = _To1D[complex, complexfloating_co]
-ToComplex2D: TypeAlias = _To2D[complex, complexfloating_co]
-ToComplex3D: TypeAlias = _To3D[complex, complexfloating_co]
-ToComplexND: TypeAlias = _ToND[complex, complexfloating_co]
-
-ToComplex128: TypeAlias = complex | complex128_co
-ToComplex128_1D: TypeAlias = _To1D[complex, complex128_co]
-ToComplex128_2D: TypeAlias = _To2D[complex, complex128_co]
-ToComplex128_3D: TypeAlias = _To3D[complex, complex128_co]
-ToComplex128_ND: TypeAlias = _ToND[complex, complex128_co]
+ToComplex1D: TypeAlias = _To1D2[complex, complexfloating_co]
+ToComplex2D: TypeAlias = _To2D2[complex, complexfloating_co]
+ToComplex3D: TypeAlias = _To3D2[complex, complexfloating_co]
+ToComplexND: TypeAlias = _ToND2[complex, complexfloating_co]
 
 # scalar- and array-likes, with "just" that scalar type
 
 ToJustBool: TypeAlias = bool | np.bool_
-ToJustBool1D: TypeAlias = _To1D[bool, np.bool_]
-ToJustBool2D: TypeAlias = _To2D[bool, np.bool_]
-ToJustBool3D: TypeAlias = _To3D[bool, np.bool_]
-ToJustBoolND: TypeAlias = _ToND[bool, np.bool_]
+ToJustBool1D: TypeAlias = _To1D2[bool, np.bool_]
+ToJustBool2D: TypeAlias = _To2D2[bool, np.bool_]
+ToJustBool3D: TypeAlias = _To3D2[bool, np.bool_]
+ToJustBoolND: TypeAlias = _ToND2[bool, np.bool_]
 
 ToJustInt64: TypeAlias = JustInt | np.intp
-ToJustInt64_1D: TypeAlias = _To1D[JustInt, np.intp]
-ToJustInt64_2D: TypeAlias = _To2D[JustInt, np.intp]
-ToJustInt64_3D: TypeAlias = _To3D[JustInt, np.intp]
-ToJustInt64_ND: TypeAlias = _ToND[JustInt, np.intp]
+ToJustInt64_1D: TypeAlias = _To1D2[JustInt, np.intp]
+ToJustInt64_2D: TypeAlias = _To2D2[JustInt, np.intp]
+ToJustInt64_3D: TypeAlias = _To3D2[JustInt, np.intp]
+ToJustInt64_ND: TypeAlias = _ToND2[JustInt, np.intp]
 
 ToJustInt: TypeAlias = JustInt | npc.integer
-ToJustInt1D: TypeAlias = _To1D[JustInt, npc.integer]
-ToJustInt2D: TypeAlias = _To2D[JustInt, npc.integer]
-ToJustInt3D: TypeAlias = _To3D[JustInt, npc.integer]
-ToJustIntND: TypeAlias = _ToND[JustInt, npc.integer]
+ToJustInt1D: TypeAlias = _To1D2[JustInt, npc.integer]
+ToJustInt2D: TypeAlias = _To2D2[JustInt, npc.integer]
+ToJustInt3D: TypeAlias = _To3D2[JustInt, npc.integer]
+ToJustIntND: TypeAlias = _ToND2[JustInt, npc.integer]
+
+ToJustFloat16: TypeAlias = npc.floating16
+ToJustFloat16_1D: TypeAlias = _To1D1[npc.floating16]
+ToJustFloat16_2D: TypeAlias = _To2D1[npc.floating16]
+ToJustFloat16_3D: TypeAlias = _To3D1[npc.floating16]
+ToJustFloat16_ND: TypeAlias = _ToND1[npc.floating16]
+
+ToJustFloat32: TypeAlias = npc.floating32
+ToJustFloat32_1D: TypeAlias = _To1D1[npc.floating32]
+ToJustFloat32_2D: TypeAlias = _To2D1[npc.floating32]
+ToJustFloat32_3D: TypeAlias = _To3D1[npc.floating32]
+ToJustFloat32_ND: TypeAlias = _ToND1[npc.floating32]
 
 ToJustFloat64: TypeAlias = JustFloat | npc.floating64
-ToJustFloat64_1D: TypeAlias = _To1D[JustFloat, npc.floating64]
-ToJustFloat64_2D: TypeAlias = _To2D[JustFloat, npc.floating64]
-ToJustFloat64_3D: TypeAlias = _To3D[JustFloat, npc.floating64]
-ToJustFloat64_ND: TypeAlias = _ToND[JustFloat, npc.floating64]
+ToJustFloat64_1D: TypeAlias = _To1D2[JustFloat, npc.floating64]
+ToJustFloat64_2D: TypeAlias = _To2D2[JustFloat, npc.floating64]
+ToJustFloat64_3D: TypeAlias = _To3D2[JustFloat, npc.floating64]
+ToJustFloat64_ND: TypeAlias = _ToND2[JustFloat, npc.floating64]
 
 ToJustFloat: TypeAlias = JustFloat | npc.floating
-ToJustFloat1D: TypeAlias = _To1D[JustFloat, npc.floating]
-ToJustFloat2D: TypeAlias = _To2D[JustFloat, npc.floating]
-ToJustFloat3D: TypeAlias = _To3D[JustFloat, npc.floating]
-ToJustFloatND: TypeAlias = _ToND[JustFloat, npc.floating]
+ToJustFloat1D: TypeAlias = _To1D2[JustFloat, npc.floating]
+ToJustFloat2D: TypeAlias = _To2D2[JustFloat, npc.floating]
+ToJustFloat3D: TypeAlias = _To3D2[JustFloat, npc.floating]
+ToJustFloatND: TypeAlias = _ToND2[JustFloat, npc.floating]
 
-ToJustComplex: TypeAlias = JustComplex | npc.complexfloating
-ToJustComplex1D: TypeAlias = _To1D[JustComplex, npc.complexfloating]
-ToJustComplex2D: TypeAlias = _To2D[JustComplex, npc.complexfloating]
-ToJustComplex3D: TypeAlias = _To3D[JustComplex, npc.complexfloating]
-ToJustComplexND: TypeAlias = _ToND[JustComplex, npc.complexfloating]
+ToJustComplex64: TypeAlias = npc.complexfloating64
+ToJustComplex64_1D: TypeAlias = _To1D1[npc.complexfloating64]
+ToJustComplex64_2D: TypeAlias = _To2D1[npc.complexfloating64]
+ToJustComplex64_3D: TypeAlias = _To3D1[npc.complexfloating64]
+ToJustComplex64_ND: TypeAlias = _ToND1[npc.complexfloating64]
 
 ToJustComplex128: TypeAlias = JustComplex | npc.complexfloating128
-ToJustComplex128_1D: TypeAlias = _To1D[JustComplex, npc.complexfloating128]
-ToJustComplex128_2D: TypeAlias = _To2D[JustComplex, npc.complexfloating128]
-ToJustComplex128_3D: TypeAlias = _To3D[JustComplex, npc.complexfloating128]
-ToJustComplex128_ND: TypeAlias = _ToND[JustComplex, npc.complexfloating128]
+ToJustComplex128_1D: TypeAlias = _To1D2[JustComplex, npc.complexfloating128]
+ToJustComplex128_2D: TypeAlias = _To2D2[JustComplex, npc.complexfloating128]
+ToJustComplex128_3D: TypeAlias = _To3D2[JustComplex, npc.complexfloating128]
+ToJustComplex128_ND: TypeAlias = _ToND2[JustComplex, npc.complexfloating128]
+
+ToJustComplex: TypeAlias = JustComplex | npc.complexfloating
+ToJustComplex1D: TypeAlias = _To1D2[JustComplex, npc.complexfloating]
+ToJustComplex2D: TypeAlias = _To2D2[JustComplex, npc.complexfloating]
+ToJustComplex3D: TypeAlias = _To3D2[JustComplex, npc.complexfloating]
+ToJustComplexND: TypeAlias = _ToND2[JustComplex, npc.complexfloating]
 
 # array-likes, with "coercible" shape-types, and "strict" shape-types
 
-ToArrayStrict1D: TypeAlias = _ToStrict1D[T, SCT]
-ToArrayStrict2D: TypeAlias = _ToStrict2D[T, SCT]
-ToArrayStrict3D: TypeAlias = _ToStrict3D[T, SCT]
+ToArrayStrict1D: TypeAlias = _ToStrict1D2[T, SCT]
+ToArrayStrict2D: TypeAlias = _ToStrict2D2[T, SCT]
+ToArrayStrict3D: TypeAlias = _ToStrict3D2[T, SCT]
 
-ToBoolStrict1D: TypeAlias = _ToStrict1D[_PyBool, np.bool_]
-ToBoolStrict2D: TypeAlias = _ToStrict2D[_PyBool, np.bool_]
-ToBoolStrict3D: TypeAlias = _ToStrict3D[_PyBool, np.bool_]
+ToBoolStrict1D: TypeAlias = _ToStrict1D2[_PyBool, np.bool_]
+ToBoolStrict2D: TypeAlias = _ToStrict2D2[_PyBool, np.bool_]
+ToBoolStrict3D: TypeAlias = _ToStrict3D2[_PyBool, np.bool_]
 
-ToIntStrict1D: TypeAlias = _ToStrict1D[int, integer_co]
-ToIntStrict2D: TypeAlias = _ToStrict2D[int, integer_co]
-ToIntStrict3D: TypeAlias = _ToStrict3D[int, integer_co]
+ToIntStrict1D: TypeAlias = _ToStrict1D2[int, integer_co]
+ToIntStrict2D: TypeAlias = _ToStrict2D2[int, integer_co]
+ToIntStrict3D: TypeAlias = _ToStrict3D2[int, integer_co]
 
-ToFloat64Strict1D: TypeAlias = _ToStrict1D[float, float64_co]
-ToFloat64Strict2D: TypeAlias = _ToStrict2D[float, float64_co]
-ToFloat64Strict3D: TypeAlias = _ToStrict3D[float, float64_co]
+ToFloat16Strict1D: TypeAlias = _ToStrict1D1[f16_co]
+ToFloat16Strict2D: TypeAlias = _ToStrict2D1[f16_co]
+ToFloat16Strict3D: TypeAlias = _ToStrict3D1[f16_co]
 
-ToFloatStrict1D: TypeAlias = _ToStrict1D[float, floating_co]
-ToFloatStrict2D: TypeAlias = _ToStrict2D[float, floating_co]
-ToFloatStrict3D: TypeAlias = _ToStrict3D[float, floating_co]
+ToFloat32Strict1D: TypeAlias = _ToStrict1D1[f32_co]
+ToFloat32Strict2D: TypeAlias = _ToStrict2D1[f32_co]
+ToFloat32Strict3D: TypeAlias = _ToStrict3D1[f32_co]
 
-ToComplex128Strict1D: TypeAlias = _ToStrict1D[complex, complex128_co]
-ToComplex128Strict2D: TypeAlias = _ToStrict2D[complex, complex128_co]
-ToComplex128Strict3D: TypeAlias = _ToStrict3D[complex, complex128_co]
+ToFloat64Strict1D: TypeAlias = _ToStrict1D2[float, f64_co]
+ToFloat64Strict2D: TypeAlias = _ToStrict2D2[float, f64_co]
+ToFloat64Strict3D: TypeAlias = _ToStrict3D2[float, f64_co]
 
-ToComplexStrict1D: TypeAlias = _ToStrict1D[complex, complexfloating_co]
-ToComplexStrict2D: TypeAlias = _ToStrict2D[complex, complexfloating_co]
-ToComplexStrict3D: TypeAlias = _ToStrict3D[complex, complexfloating_co]
+ToFloatStrict1D: TypeAlias = _ToStrict1D2[float, floating_co]
+ToFloatStrict2D: TypeAlias = _ToStrict2D2[float, floating_co]
+ToFloatStrict3D: TypeAlias = _ToStrict3D2[float, floating_co]
+
+ToComplex64Strict1D: TypeAlias = _ToStrict1D1[c64_co]
+ToComplex64Strict2D: TypeAlias = _ToStrict2D1[c64_co]
+ToComplex64Strict3D: TypeAlias = _ToStrict3D1[c64_co]
+
+ToComplex128Strict1D: TypeAlias = _ToStrict1D2[complex, c128_co]
+ToComplex128Strict2D: TypeAlias = _ToStrict2D2[complex, c128_co]
+ToComplex128Strict3D: TypeAlias = _ToStrict3D2[complex, c128_co]
+
+ToComplexStrict1D: TypeAlias = _ToStrict1D2[complex, complexfloating_co]
+ToComplexStrict2D: TypeAlias = _ToStrict2D2[complex, complexfloating_co]
+ToComplexStrict3D: TypeAlias = _ToStrict3D2[complex, complexfloating_co]
 
 # array-likes, with "just" that scalar type, and "strict" shape-types
 
-ToJustBoolStrict1D: TypeAlias = _ToStrict1D[bool, np.bool_]
-ToJustBoolStrict2D: TypeAlias = _ToStrict2D[bool, np.bool_]
-ToJustBoolStrict3D: TypeAlias = _ToStrict3D[bool, np.bool_]
+ToJustBoolStrict1D: TypeAlias = _ToStrict1D2[bool, np.bool_]
+ToJustBoolStrict2D: TypeAlias = _ToStrict2D2[bool, np.bool_]
+ToJustBoolStrict3D: TypeAlias = _ToStrict3D2[bool, np.bool_]
 
-ToJustInt64Strict1D: TypeAlias = _ToStrict1D[JustInt, np.int64]
-ToJustInt64Strict2D: TypeAlias = _ToStrict2D[JustInt, np.int64]
-ToJustInt64Strict3D: TypeAlias = _ToStrict3D[JustInt, np.int64]
+ToJustInt64Strict1D: TypeAlias = _ToStrict1D2[JustInt, np.int64]
+ToJustInt64Strict2D: TypeAlias = _ToStrict2D2[JustInt, np.int64]
+ToJustInt64Strict3D: TypeAlias = _ToStrict3D2[JustInt, np.int64]
 
-ToJustIntStrict1D: TypeAlias = _ToStrict1D[JustInt, npc.integer]
-ToJustIntStrict2D: TypeAlias = _ToStrict2D[JustInt, npc.integer]
-ToJustIntStrict3D: TypeAlias = _ToStrict3D[JustInt, npc.integer]
+ToJustIntStrict1D: TypeAlias = _ToStrict1D2[JustInt, npc.integer]
+ToJustIntStrict2D: TypeAlias = _ToStrict2D2[JustInt, npc.integer]
+ToJustIntStrict3D: TypeAlias = _ToStrict3D2[JustInt, npc.integer]
 
-ToJustFloat64Strict1D: TypeAlias = _ToStrict1D[JustFloat, npc.floating64]
-ToJustFloat64Strict2D: TypeAlias = _ToStrict2D[JustFloat, npc.floating64]
-ToJustFloat64Strict3D: TypeAlias = _ToStrict3D[JustFloat, npc.floating64]
+ToJustFloat16Strict1D: TypeAlias = _ToStrict1D1[npc.floating16]
+ToJustFloat16Strict2D: TypeAlias = _ToStrict2D1[npc.floating16]
+ToJustFloat16Strict3D: TypeAlias = _ToStrict3D1[npc.floating16]
 
-ToJustFloatStrict1D: TypeAlias = _ToStrict1D[JustFloat, npc.floating]
-ToJustFloatStrict2D: TypeAlias = _ToStrict2D[JustFloat, npc.floating]
-ToJustFloatStrict3D: TypeAlias = _ToStrict3D[JustFloat, npc.floating]
+ToJustFloat32Strict1D: TypeAlias = _ToStrict1D1[npc.floating32]
+ToJustFloat32Strict2D: TypeAlias = _ToStrict2D1[npc.floating32]
+ToJustFloat32Strict3D: TypeAlias = _ToStrict3D1[npc.floating32]
 
-ToJustComplex128Strict1D: TypeAlias = _ToStrict1D[JustComplex, npc.complexfloating128]
-ToJustComplex128Strict2D: TypeAlias = _ToStrict2D[JustComplex, npc.complexfloating128]
-ToJustComplex128Strict3D: TypeAlias = _ToStrict3D[JustComplex, npc.complexfloating128]
+ToJustFloat64Strict1D: TypeAlias = _ToStrict1D2[JustFloat, npc.floating64]
+ToJustFloat64Strict2D: TypeAlias = _ToStrict2D2[JustFloat, npc.floating64]
+ToJustFloat64Strict3D: TypeAlias = _ToStrict3D2[JustFloat, npc.floating64]
 
-ToJustComplexStrict1D: TypeAlias = _ToStrict1D[JustComplex, npc.complexfloating]
-ToJustComplexStrict2D: TypeAlias = _ToStrict2D[JustComplex, npc.complexfloating]
-ToJustComplexStrict3D: TypeAlias = _ToStrict3D[JustComplex, npc.complexfloating]
+ToJustFloatStrict1D: TypeAlias = _ToStrict1D2[JustFloat, npc.floating]
+ToJustFloatStrict2D: TypeAlias = _ToStrict2D2[JustFloat, npc.floating]
+ToJustFloatStrict3D: TypeAlias = _ToStrict3D2[JustFloat, npc.floating]
+
+ToJustComplex64Strict1D: TypeAlias = _ToStrict1D1[npc.complexfloating64]
+ToJustComplex64Strict2D: TypeAlias = _ToStrict2D1[npc.complexfloating64]
+ToJustComplex64Strict3D: TypeAlias = _ToStrict3D1[npc.complexfloating64]
+
+ToJustComplex128Strict1D: TypeAlias = _ToStrict1D2[JustComplex, npc.complexfloating128]
+ToJustComplex128Strict2D: TypeAlias = _ToStrict2D2[JustComplex, npc.complexfloating128]
+ToJustComplex128Strict3D: TypeAlias = _ToStrict3D2[JustComplex, npc.complexfloating128]
+
+ToJustComplexStrict1D: TypeAlias = _ToStrict1D2[JustComplex, npc.complexfloating]
+ToJustComplexStrict2D: TypeAlias = _ToStrict2D2[JustComplex, npc.complexfloating]
+ToJustComplexStrict3D: TypeAlias = _ToStrict3D2[JustComplex, npc.complexfloating]


### PR DESCRIPTION
This adds array-like type aliases to `optype.numpy` for the `float16`, `float32`, and `complex64` scalar types.