### PR TITLE
generic `Can*Self` arithmetic unop protocols

### DIFF
--- a/README.md
+++ b/README.md
@@ -1143,7 +1143,7 @@ suffix, e.g. `optype.CanIAddSelf[T]`.
         <td><code>__pos__</code></td>
         <td>
             <code>CanPos[+R]</code><br>
-            <code>CanPosSelf</code>
+            <code>CanPosSelf[+R?]</code>
         </td>
     </tr>
     <tr>
@@ -1153,7 +1153,7 @@ suffix, e.g. `optype.CanIAddSelf[T]`.
         <td><code>__neg__</code></td>
         <td>
             <code>CanNeg[+R]</code><br>
-            <code>CanNegSelf</code>
+            <code>CanNegSelf[+R?]</code>
         </td>
     </tr>
     <tr>
@@ -1163,7 +1163,7 @@ suffix, e.g. `optype.CanIAddSelf[T]`.
         <td><code>__invert__</code></td>
         <td>
             <code>CanInvert[+R]</code><br>
-            <code>CanInvertSelf</code>
+            <code>CanInvertSelf[+R?]</code>
         </td>
     </tr>
     <tr>
@@ -1173,10 +1173,14 @@ suffix, e.g. `optype.CanIAddSelf[T]`.
         <td><code>__abs__</code></td>
         <td>
             <code>CanAbs[+R]</code><br>
-            <code>CanAbsSelf</code>
+            <code>CanAbsSelf[+R?]</code>
         </td>
     </tr>
 </table>
+
+The `Can*Self` variants return `-> Self` instead of `R`. Since optype 0.12.1 these
+also accept an optional `R` type parameter (with a default of `Never`), which, when
+provided, will result in a return type of `-> Self | R`.
 
 #### Rounding
 

--- a/optype/_core/_can.py
+++ b/optype/_core/_can.py
@@ -1429,10 +1429,10 @@ class CanNeg(Protocol[_T_co]):
 
 
 @runtime_checkable
-class CanNegSelf(Protocol):
-    """CanNegSelf = CanNeg[Self]"""
+class CanNegSelf(Protocol[_T_Never_co]):
+    """CanNegSelf[+T = Never] = CanNeg[Self | T]"""
 
-    def __neg__(self, /) -> Self: ...
+    def __neg__(self, /) -> Self | _T_Never_co: ...
 
 
 # __pos__
@@ -1444,10 +1444,10 @@ class CanPos(Protocol[_T_co]):
 
 
 @runtime_checkable
-class CanPosSelf(Protocol):
-    """CanPosSelf = CanPos[Self]"""
+class CanPosSelf(Protocol[_T_Never_co]):
+    """CanPosSelf[+T = Never] = CanPos[Self | T]"""
 
-    def __pos__(self, /) -> Self: ...
+    def __pos__(self, /) -> Self | _T_Never_co: ...
 
 
 # __abs__
@@ -1459,10 +1459,10 @@ class CanAbs(Protocol[_T_co]):
 
 
 @runtime_checkable
-class CanAbsSelf(Protocol):
-    """CanAbsSelf = CanAbs[Self]"""
+class CanAbsSelf(Protocol[_T_Never_co]):
+    """CanAbsSelf[+T = Never] = CanAbs[Self | T]"""
 
-    def __abs__(self, /) -> Self: ...
+    def __abs__(self, /) -> Self | _T_Never_co: ...
 
 
 # __invert__
@@ -1474,10 +1474,10 @@ class CanInvert(Protocol[_T_co]):
 
 
 @runtime_checkable
-class CanInvertSelf(Protocol):
-    """CanInvertSelf = CanInvert[Self]"""
+class CanInvertSelf(Protocol[_T_Never_co]):
+    """CanInvertSelf[+T = Never] = CanInvert[Self | T]"""
 
-    def __invert__(self, /) -> Self: ...
+    def __invert__(self, /) -> Self | _T_Never_co: ...
 
 
 ###


### PR DESCRIPTION
Isomorphic to #379, but for the unary `Can*Self` protocols:

- `CanNegSelf[+R?]`
- `CanPosSelf[+R?]`
- `CanAbsSelf[+R?]`
- `CanInvertSelf[+R?]`

So just to clear: These protocols already existed before this. This just adds an optional generic covariant type parameter that defaults to `Never`, making it a fully backwards compatible change.

---

Closes #380