### PR TITLE
preliminary support for python 3.14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,9 @@ jobs:
         os: [ubuntu-latest, windows-latest]
         py: ["3.11", "3.13"]
         np: ["1.25", "2.3"]
+        include:
+          - py: "3.14"
+            np: "2.3"
         exclude:
           - py: "3.13"
             np: "1.25"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,13 +85,12 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        py: ["3.11", "3.13"]
+        py: ["3.11", "3.13", "3.14"]
         np: ["1.25", "2.3"]
-        include:
-          - py: "3.14"
-            np: "2.3"
         exclude:
           - py: "3.13"
+            np: "1.25"
+          - py: "3.14"
             np: "1.25"
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,8 @@ jobs:
             np: "1.25"
           - py: "3.14"
             np: "1.25"
+          - os: windows-latest
+            py: "3.14"
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
       - name: install deps
         run: |
           uv sync --no-editable
-          uv pip install numpy==${{ matrix.np }}
+          uv pip install numpy==${{ matrix.np }}.*
 
       # NOTE: mypy ignores `uv run --with=...` (and `--isolated` does not help)
       - name: mypy
@@ -100,4 +100,4 @@ jobs:
           python-version: ${{ matrix.py }}
 
       - name: pytest
-        run: uv run --with="numpy==${{ matrix.np }}" pytest
+        run: uv run --with="numpy==${{ matrix.np }}.*" pytest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
           basedpyright -p scripts/config/bpr-np-${{ matrix.np }}.json
 
   test:
-    timeout-minutes: 5
+    timeout-minutes: 10
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,8 +51,9 @@ test = [
 type = [
   { include-group = "extra" },
   { include-group = "test" },
-  "mypy[faster-cache]>=1.17.0",
   "basedpyright>=1.31.0",
+  "mypy>=1.17.0",
+  "orjson>=3.11.0; python_version<'3.14'", # used by mypy, but no 3.14 wheels yet
 ]
 dev = [
   { include-group = "extra" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "Typing :: Typed",
 ]
 requires-python = ">=3.11"
@@ -227,6 +228,7 @@ env_list = [
   "3.11",
   "3.12",
   "3.13",
+  "3.14",
   "dprint",
   "ruff",
   "mypy",

--- a/uv.lock
+++ b/uv.lock
@@ -118,11 +118,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/e3/fc/ee058cc4316f219078464555873e99d170bde1d9569abd833300dbeb484a/mypy-1.17.0-py3-none-any.whl", hash = "sha256:15d9d0018237ab058e5de3d8fce61b6fa72cc59cc78fd91f1b474bce12abf496", size = 2283195, upload-time = "2025-07-14T20:31:54.753Z" },
 ]
 
-[package.optional-dependencies]
-faster-cache = [
-    { name = "orjson" },
-]
-
 [[package]]
 name = "mypy-extensions"
 version = "1.1.0"
@@ -224,8 +219,9 @@ dev = [
     { name = "basedpyright" },
     { name = "beartype" },
     { name = "dprint-py" },
-    { name = "mypy", extra = ["faster-cache"] },
+    { name = "mypy" },
     { name = "optype", extra = ["numpy"] },
+    { name = "orjson", marker = "python_full_version < '3.14'" },
     { name = "pytest" },
     { name = "ruff" },
     { name = "sp-repo-review", extra = ["cli"] },
@@ -248,8 +244,9 @@ test = [
 type = [
     { name = "basedpyright" },
     { name = "beartype" },
-    { name = "mypy", extra = ["faster-cache"] },
+    { name = "mypy" },
     { name = "optype", extra = ["numpy"] },
+    { name = "orjson", marker = "python_full_version < '3.14'" },
     { name = "pytest" },
     { name = "typing-extensions" },
 ]
@@ -266,8 +263,9 @@ dev = [
     { name = "basedpyright", specifier = ">=1.31.0" },
     { name = "beartype", specifier = ">=0.21.0" },
     { name = "dprint-py", specifier = ">=0.50.0.0" },
-    { name = "mypy", extras = ["faster-cache"], specifier = ">=1.17.0" },
+    { name = "mypy", specifier = ">=1.17.0" },
     { name = "optype", extras = ["numpy"] },
+    { name = "orjson", marker = "python_full_version < '3.14'", specifier = ">=3.11.0" },
     { name = "pytest", specifier = ">=8.4.1" },
     { name = "ruff", specifier = ">=0.12.4" },
     { name = "sp-repo-review", extras = ["cli"], specifier = ">=2025.5.2" },
@@ -288,8 +286,9 @@ test = [
 type = [
     { name = "basedpyright", specifier = ">=1.31.0" },
     { name = "beartype", specifier = ">=0.21.0" },
-    { name = "mypy", extras = ["faster-cache"], specifier = ">=1.17.0" },
+    { name = "mypy", specifier = ">=1.17.0" },
     { name = "optype", extras = ["numpy"] },
+    { name = "orjson", marker = "python_full_version < '3.14'", specifier = ">=3.11.0" },
     { name = "pytest", specifier = ">=8.4.1" },
     { name = "typing-extensions", specifier = ">=4.14.1" },
 ]


### PR DESCRIPTION
Next week `3.14.0rc1` will released, and the final release is expected for 2025-10-07 (see [PEP 745](https://peps.python.org/pep-0745/)).