### PR TITLE
make `AnyLongDouble*` compatible with `numpy<2.2`

### DIFF
--- a/optype/numpy/_any_array.py
+++ b/optype/numpy/_any_array.py
@@ -8,9 +8,8 @@ else:
     from typing_extensions import TypeAliasType, TypeVar
 
 import numpy as np
-from numpy_typing_compat import NUMPY_GE_2_0, NUMPY_GE_2_1
+from numpy_typing_compat import NUMPY_GE_2_0, NUMPY_GE_2_1, long, ulong
 
-import optype.numpy._compat as _x
 import optype.numpy._scalar as _sc
 from ._shape import AnyShape
 from optype._core import CanBuffer, JustComplex, JustFloat, JustInt, JustObject
@@ -120,7 +119,7 @@ AnyUInt32Array: TypeAlias = _AnyArray[np.uint32]
 AnyUInt64Array: TypeAlias = _AnyArray[np.uint64]
 AnyUIntCArray: TypeAlias = _AnyArray[np.uintc]
 AnyULongLongArray: TypeAlias = _AnyArray[np.ulonglong]
-AnyULongArray: TypeAlias = _AnyArray[_x.ULong]
+AnyULongArray: TypeAlias = _AnyArray[ulong]
 AnyUIntPArray: TypeAlias = _AnyArray[np.uintp]
 AnyUIntArray: TypeAlias = _AnyArray[np.uint]
 
@@ -132,7 +131,7 @@ AnyInt32Array: TypeAlias = _AnyArray[np.int32]
 AnyInt64Array: TypeAlias = _AnyArray[np.int64]
 AnyIntCArray: TypeAlias = _AnyArray[np.intc]
 AnyLongLongArray: TypeAlias = _AnyArray[np.longlong]
-AnyLongArray: TypeAlias = _AnyArray[_x.Long]  # no int (numpy<=1)
+AnyLongArray: TypeAlias = _AnyArray[long]  # no int (numpy<=1)
 AnyIntPArray: TypeAlias = _AnyArray[np.intp]  # no int (numpy>=2)
 AnyIntArray: TypeAlias = _AnyArray[np.int_, np.int_ | JustInt]
 
@@ -140,7 +139,7 @@ AnyFloatingArray: TypeAlias = _AnyArray[_sc.floating, _sc.floating | JustFloat]
 AnyFloat16Array: TypeAlias = _AnyArray[np.float16]
 AnyFloat32Array: TypeAlias = _AnyArray[np.float32]
 AnyFloat64Array: TypeAlias = _AnyArray[_sc.floating64, _sc.floating64 | JustFloat]
-AnyLongDoubleArray: TypeAlias = _AnyArray[np.longdouble]
+AnyLongDoubleArray: TypeAlias = _AnyArray[_sc.floating80]
 
 AnyComplexFloatingArray: TypeAlias = _AnyArray[
     _sc.cfloating,
@@ -151,7 +150,7 @@ AnyComplex128Array: TypeAlias = _AnyArray[
     _sc.cfloating64,
     _sc.cfloating64 | JustComplex,
 ]
-AnyCLongDoubleArray: TypeAlias = _AnyArray[np.clongdouble]
+AnyCLongDoubleArray: TypeAlias = _AnyArray[_sc.cfloating80]
 
 AnyCharacterArray: TypeAlias = _AnyArray[np.character, np.character | bytes | str]
 AnyBytesArray: TypeAlias = _AnyArray[np.bytes_, np.bytes_ | bytes]

--- a/optype/numpy/_any_dtype.py
+++ b/optype/numpy/_any_dtype.py
@@ -160,7 +160,7 @@ AnyFloat64DType = TypeAliasType(
     type[JustFloat] | To[_sc.floating64] | a.f8_code,
 )
 # f12 | f16
-AnyLongDoubleDType = TypeAliasType("AnyLongDoubleDType", To[np.longdouble] | a.g_code)
+AnyLongDoubleDType = TypeAliasType("AnyLongDoubleDType", To[_sc.floating80] | a.g_code)
 
 # c8
 AnyComplex64DType = TypeAliasType("AnyComplex64DType", To[_sc.cfloating32] | a.c8_code)
@@ -172,7 +172,7 @@ AnyComplex128DType = TypeAliasType(
 # c24 | c32
 AnyCLongDoubleDType = TypeAliasType(
     "AnyCLongDoubleDType",
-    To[np.clongdouble] | a.G_code,
+    To[_sc.cfloating80] | a.G_code,
 )
 
 # M / N8

--- a/optype/numpy/_compat.py
+++ b/optype/numpy/_compat.py
@@ -1,4 +1,0 @@
-from numpy import bool_ as Bool  # noqa: N812
-from numpy_typing_compat import long as Long, ulong as ULong  # noqa: N812
-
-__all__ = ["Bool", "Long", "ULong"]

--- a/optype/numpy/compat.py
+++ b/optype/numpy/compat.py
@@ -8,8 +8,8 @@ from numpy.exceptions import (
     TooHardError,
     VisibleDeprecationWarning,
 )
+from numpy_typing_compat import long, ulong
 
-from ._compat import Long as long, ULong as ulong  # noqa: N813
 from ._scalar import (
     cfloating as complexfloating,
     cfloating32 as complexfloating64,

--- a/tests/numpy/test_any_array.py
+++ b/tests/numpy/test_any_array.py
@@ -5,16 +5,17 @@ from typing import Final
 
 import numpy as np
 import pytest
+from numpy_typing_compat import long, ulong
 
 import optype.numpy as onp  # noqa: TC001
-from optype.numpy import _compat as _x, _scalar as _sc, ctypeslib as _ct
+from optype.numpy import _scalar as _sc, ctypeslib as _ct
 
 # All allowed arguments that when passed to `np.array`, will result in an
 # array of the specified scalar type(s).
 
 _UNSIGNED_INTEGER_NP: Final = (
     np.uint8, np.uint16, np.uint32, np.uint64, np.uintp,
-    np.ubyte, np.ushort, np.uintc, _x.ULong, np.ulonglong,
+    np.ubyte, np.ushort, np.uintc, ulong, np.ulonglong,
 )  # fmt: skip
 _UNSIGNED_INTEGER_CT: Final = (
     ct.c_uint8, ct.c_uint16, ct.c_uint32, ct.c_uint64, ct.c_size_t,
@@ -23,7 +24,7 @@ _UNSIGNED_INTEGER_CT: Final = (
 UNSIGNED_INTEGER: Final = *_UNSIGNED_INTEGER_NP, *_UNSIGNED_INTEGER_CT
 _SIGNED_INTEGER_NP: Final = (
     np.int8, np.int16, np.int32, np.int64, np.intp,
-    np.byte, np.short, np.intc, _x.Long, np.longlong,
+    np.byte, np.short, np.intc, long, np.longlong,
 )  # fmt: skip
 _SIGNED_INTEGER_CT: Final = (
     ct.c_int8, ct.c_int16, ct.c_int32, ct.c_int64, ct.c_ssize_t,
@@ -50,7 +51,7 @@ CHARACTER: Final = *STR, *BYTES
 # https://github.com/jorenham/optype/issues/371
 VOID: Final = (np.void,)
 FLEXIBLE: Final = *VOID, *CHARACTER
-BOOL: Final = _x.Bool, ct.c_bool, bool
+BOOL: Final = np.bool_, ct.c_bool, bool
 OBJECT: Final = np.object_, ct.py_object
 
 


### PR DESCRIPTION
So that's `AnyLongDoubleArray` and `AnyLongDoubleDType` from `optype.numpy` we're talking about here.

Oh yea I also got rid of an unused `_compat` module in `optype.numpy`.