### PR TITLE
fix `CanArrayStrict{1,2,3}D`

### DIFF
--- a/optype/numpy/_to.py
+++ b/optype/numpy/_to.py
@@ -126,17 +126,17 @@ SCT_co = TypeVar("SCT_co", bound=np.generic, covariant=True)
 
 _CanArrayStrict1D = TypeAliasType(
     "_CanArrayStrict1D",
-    "nptc.CanArray[tuple[int], np.dtype[SCT]]",
+    nptc.CanArray[tuple[int], np.dtype[SCT]],
     type_params=(SCT,),
 )
 _CanArrayStrict2D = TypeAliasType(
     "_CanArrayStrict2D",
-    "nptc.CanArray[tuple[int, int], np.dtype[SCT]]",
+    nptc.CanArray[tuple[int, int], np.dtype[SCT]],
     type_params=(SCT,),
 )
 _CanArrayStrict3D = TypeAliasType(
     "_CanArrayStrict3D",
-    "nptc.CanArray[tuple[int, int, int], np.dtype[SCT]]",
+    nptc.CanArray[tuple[int, int, int], np.dtype[SCT]],
     type_params=(SCT,),
 )
 


### PR DESCRIPTION
Apparently stringified annotations in `TypeAliasType` will silently be inferred as `Unknown`....