### PR TITLE
set an upper version bound for `numpy-typing-compat`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = ["typing-extensions>=4.10; python_version<'3.13'"]
 
 [project.optional-dependencies]
 numpy = [
-  "numpy-typing-compat >=1.25.20250814",
+  "numpy-typing-compat >=1.25.20250814,<3",
 ]
 
 [project.urls]

--- a/uv.lock
+++ b/uv.lock
@@ -295,7 +295,7 @@ type = [
 
 [package.metadata]
 requires-dist = [
-    { name = "numpy-typing-compat", marker = "extra == 'numpy'", specifier = ">=1.25.20250814" },
+    { name = "numpy-typing-compat", marker = "extra == 'numpy'", specifier = ">=1.25.20250814,<3" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'", specifier = ">=4.10" },
 ]
 provides-extras = ["numpy"]


### PR DESCRIPTION
x-ref: https://github.com/jorenham/numpy-typing-compat/issues/45