### PR TITLE
Preliminary Pyrefly support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,9 @@ jobs:
           numpy==${{ matrix.np }}.*
           numpy-typing-compat==${{ env.NPTC_BUILD }}.${{ matrix.np }}
 
+      - name: pyrefly
+        run: pyrefly check
+
       - name: basedpyright
         run: basedpyright
 

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -3,6 +3,7 @@
     "charliermarsh.ruff",
     "detachhead.basedpyright",
     "dprint.dprint",
+    "meta.pyrefly",
     "ms-python.mypy-type-checker",
     "ms-python.python",
   ],

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -232,8 +232,8 @@ uvx tox p
 ```
 
 This will run `pytest` in parallel on all supported Python versions, as well as the
-linters (`dprint`, `ruff`, and `repo-review`) and the type-checkers (`mypy` and
-`basedpyright`).
+linters (`dprint`, `ruff`, and `repo-review`) and the type-checkers (`mypy`,
+`basedpyright`, and `pyrefly`).
 
 ### Improving The Documentation
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -32,6 +32,10 @@ pre-commit:
       glob: "*.{py,pyi}"
       run: uv {run} basedpyright --threads 3 {staged_files}
 
+    - name: pyrefly
+      glob: "*.{py,pyi}"
+      run: uv {run} pyrefly check {staged_files}
+
     - name: mypy
       glob: "*.{py,pyi}"
       # passing staged files will confuse mypy, due to there both being a

--- a/optype/_core/_can.py
+++ b/optype/_core/_can.py
@@ -233,7 +233,7 @@ _T_Never_co = TypeVar("_T_Never_co", default=Never, covariant=True)
 # we can't use `CanIndex` here, because of a recent regression in pyright 1.1.392
 _IndexT_contra = TypeVar(
     "_IndexT_contra",
-    bound=SupportsIndex | slice,
+    bound=SupportsIndex | slice,  # pyrefly: ignore[invalid-annotation]
     contravariant=True,
 )
 

--- a/optype/_core/_has.py
+++ b/optype/_core/_has.py
@@ -60,7 +60,11 @@ _DictT = TypeVar("_DictT", bound=__AnyMapping, default=__AnyDict)
 _DictT_co = TypeVar("_DictT_co", bound=__AnyMapping, default=__AnyDict, covariant=True)
 
 _NameT = TypeVar("_NameT", bound=str, default=str)
-_QualNameT = TypeVar("_QualNameT", bound=str, default=_NameT)
+_QualNameT = TypeVar(
+    "_QualNameT",
+    bound=str,
+    default=_NameT,  # pyrefly: ignore[invalid-type-var]
+)
 _StrT_co = TypeVar("_StrT_co", bound=str, default=str, covariant=True)
 
 

--- a/optype/_core/_just.py
+++ b/optype/_core/_just.py
@@ -86,7 +86,7 @@ class _JustMeta(_ProtocolMeta, Generic[_ObjectT]):
         just: type[_ObjectT],
     ) -> _TypeT:
         self = super().__new__(mcls, *args)  # type: ignore[misc]
-        self.__just_class__ = just
+        self.__just_class__ = just  # pyrefly: ignore[missing-attribute]
         return self
 
     @override

--- a/optype/inspect.py
+++ b/optype/inspect.py
@@ -9,7 +9,7 @@ else:
     from typing_extensions import (  # type: ignore[attr-defined]
         TypeAliasType,
         TypeIs,
-        _get_protocol_attrs,  # noqa: PLC2701  # pyright: ignore[reportAttributeAccessIssue, reportUnknownVariableType]
+        _get_protocol_attrs,  # noqa: PLC2701  # pyrefly: ignore[missing-module-attribute]  # pyright: ignore[reportAttributeAccessIssue, reportUnknownVariableType]
         is_protocol,
     )
 

--- a/optype/inspect.py
+++ b/optype/inspect.py
@@ -4,7 +4,12 @@ from collections.abc import Iterable
 from typing import Literal, TypeAlias, cast, get_args as _get_args, overload
 
 if sys.version_info >= (3, 13):
-    from typing import TypeAliasType, TypeIs, _get_protocol_attrs, is_protocol
+    from typing import (  # type: ignore[attr-defined]
+        TypeAliasType,
+        TypeIs,
+        _get_protocol_attrs,
+        is_protocol,
+    )
 else:
     from typing_extensions import (  # type: ignore[attr-defined]
         TypeAliasType,

--- a/optype/typing.py
+++ b/optype/typing.py
@@ -62,6 +62,7 @@ _ValueT = TypeVar("_ValueT", default=object)
     "and will be removed in optype 0.10.0",
 )
 class Just(  # type: ignore[misc]
+    # pyrefly: ignore[invalid-inheritance]
     _just.Just[_T],  # pyright: ignore[reportGeneralTypeIssues]
     Protocol[_T],
 ): ...

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -307,6 +307,17 @@ commands = [
   ],
 ]
 
+[tool.tox.env.pyrefly]
+description = "pyrefly"
+runner = "uv-venv-lock-runner"
+dependency_groups = ["type"]
+commands = [
+  [
+    "pyrefly",
+    { replace = "posargs", default = [], extend = true },
+  ],
+]
+
 [tool.tox.env.pyright]
 description = "basedpyright"
 runner = "uv-venv-lock-runner"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,7 @@ type = [
   { include-group = "test" },
   "basedpyright>=1.31.5",
   "mypy[faster-cache]>=1.18.2",
+  "pyrefly==0.34.0",
 ]
 dev = [
   { include-group = "extra" },
@@ -109,6 +110,11 @@ enable_error_code = [
 ]
 warn_return_any = false
 warn_unreachable = false # numpy-typing-compat compat
+
+# pyrefly
+
+[tool.pyrefly]
+project-includes = ["optype", "examples", "tests"]
 
 # [based]pyright
 

--- a/tests/core/test_can.py
+++ b/tests/core/test_can.py
@@ -180,12 +180,14 @@ def test_can_iadd_same_list_accept() -> None:
     # acceptance tests (true negatives)
     x: list[int] = [42]
     assert isinstance(x, op.CanIAddSame)
-    assert issubclass(list, op.CanIAddSame)
 
     a0: op.CanIAddSame = x
     a1: op.CanIAddSame[Any] = x
     a2: op.CanIAddSame[list[int]] = x
     a3: op.CanIAddSame[bytes] = x
+
+    # https://github.com/facebook/pyrefly/issues/1164
+    assert issubclass(list, op.CanIAddSame)
 
 
 def test_can_iadd_same_list_reject() -> None:

--- a/tests/core/test_has_types.pyi
+++ b/tests/core/test_has_types.pyi
@@ -37,7 +37,8 @@ assert_type(type(int_obj), type[int])
 assert_type(typeof(int_obj), type[int])
 
 int_str: int | str
-assert_type(type(int_str), type[int | str])
+# https://github.com/facebook/pyrefly/issues/1165
+assert_type(type(int_str), type[int] | type[str])
 typeof(int_str)  # type: ignore[misc]  # pyright: ignore[reportArgumentType]
 
 bool_or_int: bool | int
@@ -45,11 +46,13 @@ assert_type(type(bool_or_int), type[bool] | type[int])
 assert_type(typeof(bool_or_int), type[int])  # type: ignore[arg-type]  # mypy fail
 
 lit_str: LiteralString
-assert_type(type(lit_str), type[str])
+# https://github.com/facebook/pyrefly/issues/1166
+assert_type(type(lit_str), type[str])  # pyrefly: ignore[assert-type]
 assert_type(typeof(lit_str), type[str])
 
 class TDict(TypedDict): ...
 
 tdict: TDict
-assert_type(type(tdict), type[TDict])
-assert_type(typeof(tdict), type[TDict])  # type: ignore[arg-type]
+# https://github.com/facebook/pyrefly/issues/1167
+assert_type(type(tdict), type[TDict])  # pyrefly: ignore[assert-type]
+assert_type(typeof(tdict), type[TDict])  # type: ignore[arg-type]  # mypy fail

--- a/tests/numpy/test_array.py
+++ b/tests/numpy/test_array.py
@@ -29,6 +29,7 @@ def test_can_array() -> None:
     nd0_y: onp.CanArray[_Shape0D, np.dtype[np.int8]] = nd0_x
     assert isinstance(nd0_x, onp.CanArray)
 
+    # pyrefly: ignore[redundant-cast]
     nd1_x = cast("np.ndarray[_Shape1D, np.dtype[np.int8]]", np.empty((42,), dt))
     nd1_y: onp.CanArray[_Shape1D, np.dtype[np.int8]] = nd1_x
     assert isinstance(nd1_x, onp.CanArray)

--- a/tests/numpy/test_is.py
+++ b/tests/numpy/test_is.py
@@ -99,8 +99,13 @@ def test_is_array(
     assert onp.is_array_nd(arr[4], dtype=dtype_is)
 
     dtype_not = np.dtype("?") if dtype.char != "?" else np.dtype("B")
+    # pyrefly: ignore[bad-argument-type]
     assert not onp.is_array_0d(arr[0], dtype=dtype_not)
+    # pyrefly: ignore[bad-argument-type]
     assert not onp.is_array_1d(arr[1], dtype=dtype_not)
+    # pyrefly: ignore[bad-argument-type]
     assert not onp.is_array_2d(arr[2], dtype=dtype_not)
+    # pyrefly: ignore[bad-argument-type]
     assert not onp.is_array_3d(arr[3], dtype=dtype_not)
+    # pyrefly: ignore[bad-argument-type]
     assert not onp.is_array_nd(arr[4], dtype=dtype_not)

--- a/tests/numpy/test_to.pyi
+++ b/tests/numpy/test_to.pyi
@@ -62,44 +62,118 @@ _Arr0_c_co: TypeAlias = onp.CanArray0D[_Sca_c_co]
 _Arr0_f8_co: TypeAlias = onp.CanArray0D[_Sca_f8_co]
 _Arr0_c16_co: TypeAlias = onp.CanArray0D[_Sca_c16_co]
 
-_Arr1_x: TypeAlias = onp.Array1D[_Sca_x] | Seq[_Sca_x | _Val_x]
-_Arr1_b: TypeAlias = onp.Array1D[_Sca_b] | Seq[_Sca_b | _Val_b]
-_Arr1_i: TypeAlias = onp.Array1D[_Sca_i] | Seq[_Sca_i | _Val_i]
-_Arr1_f: TypeAlias = onp.Array1D[_Sca_f] | Seq[_Sca_f | _Val_f]
-_Arr1_c: TypeAlias = onp.Array1D[_Sca_c] | Seq[_Sca_c | _Val_c]
-_Arr1_f8: TypeAlias = onp.Array1D[_Sca_f8] | Seq[_Sca_f8 | _Val_f8]
-_Arr1_c16: TypeAlias = onp.Array1D[_Sca_c16] | Seq[_Sca_c16 | _Val_c16]
-_Arr1_i_co: TypeAlias = onp.Array1D[_Sca_i_co] | Seq[_Sca_i_co | _Val_i_co]
-_Arr1_f_co: TypeAlias = onp.Array1D[_Sca_f_co] | Seq[_Sca_f_co | _Val_f_co]
-_Arr1_c_co: TypeAlias = onp.Array1D[_Sca_c_co] | Seq[_Sca_c_co | _Val_c_co]
-_Arr1_f8_co: TypeAlias = onp.Array1D[_Sca_f8_co] | Seq[_Sca_f8_co | _Val_f8_co]
-_Arr1_c16_co: TypeAlias = onp.Array1D[_Sca_c16_co] | Seq[_Sca_c16_co | _Val_c16_co]
+_Arr1_x: TypeAlias = onp.Array1D[_Sca_x] | Seq[_Val_x]
+_Arr1_b: TypeAlias = onp.Array1D[_Sca_b] | Seq[_Val_b]
+_Arr1_i: TypeAlias = onp.Array1D[_Sca_i] | Seq[_Val_i]
+_Arr1_f: TypeAlias = onp.Array1D[_Sca_f] | Seq[_Val_f]
+_Arr1_c: TypeAlias = onp.Array1D[_Sca_c] | Seq[_Val_c]
+_Arr1_f8: TypeAlias = onp.Array1D[_Sca_f8] | Seq[_Val_f8]
+_Arr1_c16: TypeAlias = onp.Array1D[_Sca_c16] | Seq[_Val_c16]
+_Arr1_i_co: TypeAlias = onp.Array1D[_Sca_i_co] | Seq[_Val_i_co]
+_Arr1_f_co: TypeAlias = onp.Array1D[_Sca_f_co] | Seq[_Val_f_co]
+_Arr1_c_co: TypeAlias = onp.Array1D[_Sca_c_co] | Seq[_Val_c_co]
+_Arr1_f8_co: TypeAlias = onp.Array1D[_Sca_f8_co] | Seq[_Val_f8_co]
+_Arr1_c16_co: TypeAlias = onp.Array1D[_Sca_c16_co] | Seq[_Val_c16_co]
 
-_Arr2_x: TypeAlias = onp.Array2D[_Sca_x] | Seq[_Arr1_x]
-_Arr2_b: TypeAlias = onp.Array2D[_Sca_b] | Seq[_Arr1_b]
-_Arr2_i: TypeAlias = onp.Array2D[_Sca_i] | Seq[_Arr1_i]
-_Arr2_f: TypeAlias = onp.Array2D[_Sca_f] | Seq[_Arr1_f]
-_Arr2_c: TypeAlias = onp.Array2D[_Sca_c] | Seq[_Arr1_c]
-_Arr2_f8: TypeAlias = onp.Array2D[_Sca_f8] | Seq[_Arr1_f8]
-_Arr2_c16: TypeAlias = onp.Array2D[_Sca_c16] | Seq[_Arr1_c16]
-_Arr2_i_co: TypeAlias = onp.Array2D[_Sca_i_co] | Seq[_Arr1_i_co]
-_Arr2_f_co: TypeAlias = onp.Array2D[_Sca_f_co] | Seq[_Arr1_f_co]
-_Arr2_c_co: TypeAlias = onp.Array2D[_Sca_c_co] | Seq[_Arr1_c_co]
-_Arr2_f8_co: TypeAlias = onp.Array2D[_Sca_f8_co] | Seq[_Arr1_f8_co]
-_Arr2_c16_co: TypeAlias = onp.Array2D[_Sca_c16_co] | Seq[_Arr1_c16_co]
+_Arr2_x: TypeAlias = onp.Array2D[_Sca_x] | Seq[onp.Array1D[_Sca_x]] | Seq[Seq[_Val_x]]
+_Arr2_b: TypeAlias = onp.Array2D[_Sca_b] | Seq[onp.Array1D[_Sca_b]] | Seq[Seq[_Val_b]]
+_Arr2_i: TypeAlias = onp.Array2D[_Sca_i] | Seq[onp.Array1D[_Sca_i]] | Seq[Seq[_Val_i]]
+_Arr2_f: TypeAlias = onp.Array2D[_Sca_f] | Seq[onp.Array1D[_Sca_f]] | Seq[Seq[_Val_f]]
+_Arr2_c: TypeAlias = onp.Array2D[_Sca_c] | Seq[onp.Array1D[_Sca_c]] | Seq[Seq[_Val_c]]
+_Arr2_f8: TypeAlias = (
+    onp.Array2D[_Sca_f8] | Seq[onp.Array1D[_Sca_f8]] | Seq[Seq[_Val_f8]]
+)
+_Arr2_c16: TypeAlias = (
+    onp.Array2D[_Sca_c16] | Seq[onp.Array1D[_Sca_c16]] | Seq[Seq[_Val_c16]]
+)
+_Arr2_i_co: TypeAlias = (
+    onp.Array2D[_Sca_i_co] | Seq[onp.Array1D[_Sca_i_co]] | Seq[Seq[_Val_i_co]]
+)
+_Arr2_f_co: TypeAlias = (
+    onp.Array2D[_Sca_f_co] | Seq[onp.Array1D[_Sca_f_co]] | Seq[Seq[_Val_f_co]]
+)
+_Arr2_c_co: TypeAlias = (
+    onp.Array2D[_Sca_c_co] | Seq[onp.Array1D[_Sca_c_co]] | Seq[Seq[_Val_c_co]]
+)
+_Arr2_f8_co: TypeAlias = (
+    onp.Array2D[_Sca_f8_co] | Seq[onp.Array1D[_Sca_f8_co]] | Seq[Seq[_Val_f8_co]]
+)
+_Arr2_c16_co: TypeAlias = (
+    onp.Array2D[_Sca_c16_co] | Seq[onp.Array1D[_Sca_c16_co]] | Seq[Seq[_Val_c16_co]]
+)
 
-_Arr3_x: TypeAlias = onp.Array3D[_Sca_x] | Seq[_Arr2_x]
-_Arr3_b: TypeAlias = onp.Array3D[_Sca_b] | Seq[_Arr2_b]
-_Arr3_i: TypeAlias = onp.Array3D[_Sca_i] | Seq[_Arr2_i]
-_Arr3_f: TypeAlias = onp.Array3D[_Sca_f] | Seq[_Arr2_f]
-_Arr3_c: TypeAlias = onp.Array3D[_Sca_c] | Seq[_Arr2_c]
-_Arr3_f8: TypeAlias = onp.Array3D[_Sca_f8] | Seq[_Arr2_f8]
-_Arr3_c16: TypeAlias = onp.Array3D[_Sca_c16] | Seq[_Arr2_c16]
-_Arr3_i_co: TypeAlias = onp.Array3D[_Sca_i_co] | Seq[_Arr2_i_co]
-_Arr3_f_co: TypeAlias = onp.Array3D[_Sca_f_co] | Seq[_Arr2_f_co]
-_Arr3_c_co: TypeAlias = onp.Array3D[_Sca_c_co] | Seq[_Arr2_c_co]
-_Arr3_f8_co: TypeAlias = onp.Array3D[_Sca_f8_co] | Seq[_Arr2_f8_co]
-_Arr3_c16_co: TypeAlias = onp.Array3D[_Sca_c16_co] | Seq[_Arr2_c16_co]
+_Arr3_x: TypeAlias = (
+    onp.Array3D[_Sca_x]
+    | Seq[onp.Array2D[_Sca_x]]
+    | Seq[Seq[onp.Array1D[_Sca_x]]]
+    | Seq[Seq[Seq[_Val_x]]]
+)
+_Arr3_b: TypeAlias = (
+    onp.Array3D[_Sca_b]
+    | Seq[onp.Array2D[_Sca_b]]
+    | Seq[Seq[onp.Array1D[_Sca_b]]]
+    | Seq[Seq[Seq[_Val_b]]]
+)
+_Arr3_i: TypeAlias = (
+    onp.Array3D[_Sca_i]
+    | Seq[onp.Array2D[_Sca_i]]
+    | Seq[Seq[onp.Array1D[_Sca_i]]]
+    | Seq[Seq[Seq[_Val_i]]]
+)
+_Arr3_f: TypeAlias = (
+    onp.Array3D[_Sca_f]
+    | Seq[onp.Array2D[_Sca_f]]
+    | Seq[Seq[onp.Array1D[_Sca_f]]]
+    | Seq[Seq[Seq[_Val_f]]]
+)
+_Arr3_c: TypeAlias = (
+    onp.Array3D[_Sca_c]
+    | Seq[onp.Array2D[_Sca_c]]
+    | Seq[Seq[onp.Array1D[_Sca_c]]]
+    | Seq[Seq[Seq[_Val_c]]]
+)
+_Arr3_f8: TypeAlias = (
+    onp.Array3D[_Sca_f8]
+    | Seq[onp.Array2D[_Sca_f8]]
+    | Seq[Seq[onp.Array1D[_Sca_f8]]]
+    | Seq[Seq[Seq[_Val_f8]]]
+)
+_Arr3_c16: TypeAlias = (
+    onp.Array3D[_Sca_c16]
+    | Seq[onp.Array2D[_Sca_c16]]
+    | Seq[Seq[onp.Array1D[_Sca_c16]]]
+    | Seq[Seq[Seq[_Val_c16]]]
+)
+_Arr3_i_co: TypeAlias = (
+    onp.Array3D[_Sca_i_co]
+    | Seq[onp.Array2D[_Sca_i_co]]
+    | Seq[Seq[onp.Array1D[_Sca_i_co]]]
+    | Seq[Seq[Seq[_Val_i_co]]]
+)
+_Arr3_f_co: TypeAlias = (
+    onp.Array3D[_Sca_f_co]
+    | Seq[onp.Array2D[_Sca_f_co]]
+    | Seq[Seq[onp.Array1D[_Sca_f_co]]]
+    | Seq[Seq[Seq[_Val_f_co]]]
+)
+_Arr3_c_co: TypeAlias = (
+    onp.Array3D[_Sca_c_co]
+    | Seq[onp.Array2D[_Sca_c_co]]
+    | Seq[Seq[onp.Array1D[_Sca_c_co]]]
+    | Seq[Seq[Seq[_Val_c_co]]]
+)
+_Arr3_f8_co: TypeAlias = (
+    onp.Array3D[_Sca_f8_co]
+    | Seq[onp.Array2D[_Sca_f8_co]]
+    | Seq[Seq[onp.Array1D[_Sca_f8_co]]]
+    | Seq[Seq[Seq[_Val_f8_co]]]
+)
+_Arr3_c16_co: TypeAlias = (
+    onp.Array3D[_Sca_c16_co]
+    | Seq[onp.Array2D[_Sca_c16_co]]
+    | Seq[Seq[onp.Array1D[_Sca_c16_co]]]
+    | Seq[Seq[Seq[_Val_c16_co]]]
+)
 
 x_: _Val_x
 b_: _Val_b
@@ -374,20 +448,20 @@ def nd_sca() -> None:
     f8_co__f8_co: onp.ToFloat64_ND = f8_co  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
     c16_co__c16_co: onp.ToComplex128_ND = c16_co  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
 
-def nd_1d() -> None:
-    to_x_1d: onp.ToArray1D
-    to_b_1d: onp.ToBool1D
-    to_i_1d: onp.ToJustInt1D
-    to_f_1d: onp.ToJustFloat1D
-    to_c_1d: onp.ToJustComplex1D
-    to_f8_1d: onp.ToJustFloat64_1D
-    to_c16_1d: onp.ToJustComplex128_1D
-    to_i_co_1d: onp.ToInt1D
-    to_f_co_1d: onp.ToFloat1D
-    to_c_co_1d: onp.ToComplex1D
-    to_f8_co_1d: onp.ToFloat64_1D
-    to_c16_co_1d: onp.ToComplex128_1D
-
+def nd_1d(
+    to_x_1d: onp.ToArray1D,
+    to_b_1d: onp.ToBool1D,
+    to_i_1d: onp.ToJustInt1D,
+    to_f_1d: onp.ToJustFloat1D,
+    to_c_1d: onp.ToJustComplex1D,
+    to_f8_1d: onp.ToJustFloat64_1D,
+    to_c16_1d: onp.ToJustComplex128_1D,
+    to_i_co_1d: onp.ToInt1D,
+    to_f_co_1d: onp.ToFloat1D,
+    to_c_co_1d: onp.ToComplex1D,
+    to_f8_co_1d: onp.ToFloat64_1D,
+    to_c16_co_1d: onp.ToComplex128_1D,
+) -> None:
     x__x: onp.ToArrayND = to_x_1d
     b__b: onp.ToBoolND = to_b_1d
     i__i: onp.ToJustIntND = to_i_1d
@@ -401,20 +475,20 @@ def nd_1d() -> None:
     f8_co__f8: onp.ToFloat64_ND = to_f8_co_1d
     c16_co__c16: onp.ToComplex128_ND = to_c16_co_1d
 
-def nd_2d() -> None:
-    to_x_2d: onp.ToArray2D
-    to_b_2d: onp.ToBool2D
-    to_i_2d: onp.ToJustInt2D
-    to_f_2d: onp.ToJustFloat2D
-    to_c_2d: onp.ToJustComplex2D
-    to_f8_2d: onp.ToJustFloat64_2D
-    to_c16_2d: onp.ToJustComplex128_2D
-    to_i_co_2d: onp.ToInt2D
-    to_f_co_2d: onp.ToFloat2D
-    to_c_co_2d: onp.ToComplex2D
-    to_f8_co_2d: onp.ToFloat64_2D
-    to_c16_co_2d: onp.ToComplex128_2D
-
+def nd_2d(
+    to_x_2d: onp.ToArray2D,
+    to_b_2d: onp.ToBool2D,
+    to_i_2d: onp.ToJustInt2D,
+    to_f_2d: onp.ToJustFloat2D,
+    to_c_2d: onp.ToJustComplex2D,
+    to_f8_2d: onp.ToJustFloat64_2D,
+    to_c16_2d: onp.ToJustComplex128_2D,
+    to_i_co_2d: onp.ToInt2D,
+    to_f_co_2d: onp.ToFloat2D,
+    to_c_co_2d: onp.ToComplex2D,
+    to_f8_co_2d: onp.ToFloat64_2D,
+    to_c16_co_2d: onp.ToComplex128_2D,
+) -> None:
     x__x: onp.ToArrayND = to_x_2d
     b__b: onp.ToBoolND = to_b_2d
     i__i: onp.ToJustIntND = to_i_2d
@@ -428,29 +502,32 @@ def nd_2d() -> None:
     f8_co__f8: onp.ToFloat64_ND = to_f8_co_2d
     c16_co__c16: onp.ToComplex128_ND = to_c16_co_2d
 
-def nd_3d() -> None:
-    to_x_3d: onp.ToArray3D
-    to_b_3d: onp.ToBool3D
-    to_i_3d: onp.ToJustInt3D
-    to_f_3d: onp.ToJustFloat3D
-    to_c_3d: onp.ToJustComplex3D
-    to_f8_3d: onp.ToJustFloat64_3D
-    to_c16_3d: onp.ToJustComplex128_3D
-    to_i_co_3d: onp.ToInt3D
-    to_f_co_3d: onp.ToFloat3D
-    to_c_co_3d: onp.ToComplex3D
-    to_f8_co_3d: onp.ToFloat64_3D
-    to_c16_co_3d: onp.ToComplex128_3D
-
+def nd_3d(
+    to_x_3d: onp.ToArray3D,
+    to_b_3d: onp.ToBool3D,
+    to_i_3d: onp.ToJustInt3D,
+    to_f_3d: onp.ToJustFloat3D,
+    to_c_3d: onp.ToJustComplex3D,
+    to_f8_3d: onp.ToJustFloat64_3D,
+    to_c16_3d: onp.ToJustComplex128_3D,
+    to_i_co_3d: onp.ToInt3D,
+    to_f_co_3d: onp.ToFloat3D,
+    to_c_co_3d: onp.ToComplex3D,
+    to_f8_co_3d: onp.ToFloat64_3D,
+    to_c16_co_3d: onp.ToComplex128_3D,
+) -> None:
     x__x: onp.ToArrayND = to_x_3d
-    b__b: onp.ToBoolND = to_b_3d
-    i__i: onp.ToJustIntND = to_i_3d
-    f__f: onp.ToJustFloatND = to_f_3d
-    c__c: onp.ToJustComplexND = to_c_3d
-    f8__f8: onp.ToJustFloat64_ND = to_f8_3d
-    c16__c16: onp.ToJustComplex128_ND = to_c16_3d
-    i_co__i: onp.ToIntND = to_i_co_3d
-    f_co__f: onp.ToFloatND = to_f_co_3d
-    c_co__c: onp.ToComplexND = to_c_co_3d
-    f8_co__f8: onp.ToFloat64_ND = to_f8_co_3d
-    c16_co__c16: onp.ToComplex128_ND = to_c16_co_3d
+    # J: I'm not sure what's going on here with pyrefly, and why it only occurs here.
+    # It might be related facebook/pyrefly#778, so let's hope it'll resolve itself,
+    # since writing a minimal reproducer for this seems like a lot of effort.
+    b__b: onp.ToBoolND = to_b_3d  # pyrefly: ignore[bad-assignment]
+    i__i: onp.ToJustIntND = to_i_3d  # pyrefly: ignore[bad-assignment]
+    f__f: onp.ToJustFloatND = to_f_3d  # pyrefly: ignore[bad-assignment]
+    c__c: onp.ToJustComplexND = to_c_3d  # pyrefly: ignore[bad-assignment]
+    f8__f8: onp.ToJustFloat64_ND = to_f8_3d  # pyrefly: ignore[bad-assignment]
+    c16__c16: onp.ToJustComplex128_ND = to_c16_3d  # pyrefly: ignore[bad-assignment]
+    i_co__i: onp.ToIntND = to_i_co_3d  # pyrefly: ignore[bad-assignment]
+    f_co__f: onp.ToFloatND = to_f_co_3d  # pyrefly: ignore[bad-assignment]
+    c_co__c: onp.ToComplexND = to_c_co_3d  # pyrefly: ignore[bad-assignment]
+    f8_co__f8: onp.ToFloat64_ND = to_f8_co_3d  # pyrefly: ignore[bad-assignment]
+    c16_co__c16: onp.ToComplex128_ND = to_c16_co_3d  # pyrefly: ignore[bad-assignment]

--- a/uv.lock
+++ b/uv.lock
@@ -268,6 +268,7 @@ dev = [
     { name = "dprint-py" },
     { name = "mypy", extra = ["faster-cache"] },
     { name = "optype", extra = ["numpy"] },
+    { name = "pyrefly" },
     { name = "pytest" },
     { name = "ruff" },
     { name = "sp-repo-review", extra = ["cli"] },
@@ -292,6 +293,7 @@ type = [
     { name = "beartype" },
     { name = "mypy", extra = ["faster-cache"] },
     { name = "optype", extra = ["numpy"] },
+    { name = "pyrefly" },
     { name = "pytest" },
     { name = "typing-extensions" },
 ]
@@ -311,6 +313,7 @@ dev = [
     { name = "dprint-py", specifier = ">=0.50.2.0" },
     { name = "mypy", extras = ["faster-cache"], specifier = ">=1.18.2" },
     { name = "optype", extras = ["numpy"] },
+    { name = "pyrefly", specifier = "==0.34.0" },
     { name = "pytest", specifier = ">=8.4.2" },
     { name = "ruff", specifier = ">=0.13.2" },
     { name = "sp-repo-review", extras = ["cli"], specifier = ">=2025.5.2" },
@@ -333,6 +336,7 @@ type = [
     { name = "beartype", specifier = ">=0.21.0" },
     { name = "mypy", extras = ["faster-cache"], specifier = ">=1.18.2" },
     { name = "optype", extras = ["numpy"] },
+    { name = "pyrefly", specifier = "==0.34.0" },
     { name = "pytest", specifier = ">=8.4.2" },
     { name = "typing-extensions", specifier = ">=4.15.0" },
 ]
@@ -435,6 +439,22 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+]
+
+[[package]]
+name = "pyrefly"
+version = "0.34.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cb/db/b9bdb8c2f538cfa3338d368927b98cd573131804e6d57857ea9c7d0dbc56/pyrefly-0.34.0.tar.gz", hash = "sha256:eb18f4ec341105d5463b5c5844b25a2d520d36d5294302fcb3fd1de2868246e1", size = 1461134, upload-time = "2025-09-22T17:46:56.579Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7d/8c/decdf3c66207f21f71ca0a2919650499aa2afcb3f22e0f2fbffb002e3754/pyrefly-0.34.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:c5b212f557c19bbc9f02377d25c0380ea9987e320a1ed69f625fe817a1163774", size = 6722736, upload-time = "2025-09-22T17:46:41.432Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/80/4262da89aef2b14fde6bf0346fe63dc710742e2854b26a929f78160d594a/pyrefly-0.34.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:87181abe763ed19fd9e107a9ae5982f852f18f93de2957a731c9b40048174552", size = 6267483, upload-time = "2025-09-22T17:46:43.533Z" },
+    { url = "https://files.pythonhosted.org/packages/53/64/36db94740c2a413a1255540da6103d82bd2c451d526a1c405d341a75a50f/pyrefly-0.34.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1085c186cde52c79f42b8c654aa0840c1028601fbd9c35d981d60453008498ec", size = 6505495, upload-time = "2025-09-22T17:46:45.041Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/2b/6606fcb784770cd36c5cafc5c940c796753772d5c64be82bed1bf5cce9aa/pyrefly-0.34.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:dcb92520e4dac3967744f44bd3145e8d029d313076b06277f15b693869f4eb4a", size = 7334795, upload-time = "2025-09-22T17:46:47.472Z" },
+    { url = "https://files.pythonhosted.org/packages/69/b3/4353e744e29fa95c0e9f70ababe15fd019df252f8e90ecd2d15620adcfc8/pyrefly-0.34.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1f840afa73371aa56f8e6666f2733b4b8a85620329aa385d7a39bb226983b43b", size = 6999090, upload-time = "2025-09-22T17:46:49.376Z" },
+    { url = "https://files.pythonhosted.org/packages/60/1e/7d13a42f680c98ed0365295d3bb09d7e11c97aab563154dcfa62a7448a25/pyrefly-0.34.0-py3-none-win32.whl", hash = "sha256:a22f1fd6f03c6fe11c6b491c12a70bb07b3025cd316faa9f98729d42e410bbcd", size = 6500766, upload-time = "2025-09-22T17:46:51.194Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/16/e2285197587d125473237f9daf3878edeab9d03918985db89f294bdebc86/pyrefly-0.34.0-py3-none-win_amd64.whl", hash = "sha256:ac6e33b6a2f90aea9bdf54c7f78ff29b9f71ffcf55f2636b7da513df74bd4b56", size = 6938350, upload-time = "2025-09-22T17:46:53.08Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/34/0653bf969bd3f0dbb86083ff73f0a381e46239aac21b7d6dfec403959832/pyrefly-0.34.0-py3-none-win_arm64.whl", hash = "sha256:34517123a61caef9d19a73ebb04b5bb8bde6efe999daf89fd7a200bb755e3e73", size = 6527162, upload-time = "2025-09-22T17:46:54.954Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This adds [pyrefly](https://github.com/facebook/pyrefly) as a static type-checker. This makes optype officially compatible with mypy, [based]pyright, and pyrefly.

Note, however, that there are still some problematic open issues, that could lead to incorrect inference of optype types. In praticular, facebook/pyrefly#1162 is problematic for most of the `optype.numpy.ToArray*` type aliases.