### PR TITLE
Dataclass improvements

### DIFF
--- a/optype/dataclasses.py
+++ b/optype/dataclasses.py
@@ -8,6 +8,11 @@ import sys
 from collections.abc import Mapping
 from typing import Any, Protocol, TypeAlias
 
+if sys.version_info >= (3, 12):
+    from typing import override
+else:
+    from typing_extensions import override
+
 if sys.version_info >= (3, 13):
     from typing import TypeVar, runtime_checkable
 else:
@@ -34,3 +39,11 @@ class HasDataclassFields(Protocol[_FieldsT]):
     """Can be used to check whether a type or instance is a dataclass."""
 
     __dataclass_fields__: _FieldsT
+
+    # Because of https://github.com/python/mypy/issues/3939 just having
+    # `__dataclass_fields__` is insufficient for `issubclass` checks.
+    @override
+    @classmethod
+    def __subclasshook__(cls, c: type, /) -> bool:
+        """Customize the subclass check."""
+        return hasattr(c, "__dataclass_fields__")

--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -1,9 +1,7 @@
 """Test module for optype.dataclasses protocols."""
 
 import dataclasses
-from typing import cast
-
-import pytest
+from typing import Any, cast
 
 import optype as op
 from optype.inspect import is_runtime_protocol
@@ -33,29 +31,39 @@ class ImmutablePoint:
 class FakeDataclass:
     """A class with __dataclass_fields__ attribute but not a real dataclass."""
 
-    __dataclass_fields__: dict[str, object] = {}
+    __dataclass_fields__: dict[str, Any] = {}  # noqa: RUF012
 
 
 class NotADataclass:
     """A regular class without __dataclass_fields__."""
 
-    pass
-
 
 def test_has_dataclass_fields_issubclass_real_dataclass() -> None:
     """Test issubclass with real dataclasses."""
-    assert issubclass(Point, op.dataclasses.HasDataclassFields)
-    assert issubclass(ImmutablePoint, op.dataclasses.HasDataclassFields)
+    assert issubclass(  # type: ignore[misc]
+        Point,
+        op.dataclasses.HasDataclassFields,  # pyright: ignore[reportGeneralTypeIssues]  # pyrefly: ignore[invalid-argument]
+    )
+    assert issubclass(  # type: ignore[misc]
+        ImmutablePoint,
+        op.dataclasses.HasDataclassFields,  # pyright: ignore[reportGeneralTypeIssues]  # pyrefly: ignore[invalid-argument]
+    )
 
 
 def test_has_dataclass_fields_issubclass_fake_dataclass() -> None:
     """Test issubclass with a fake dataclass that has __dataclass_fields__."""
-    assert issubclass(FakeDataclass, op.dataclasses.HasDataclassFields)
+    assert issubclass(  # type: ignore[misc]
+        FakeDataclass,
+        op.dataclasses.HasDataclassFields,  # pyright: ignore[reportGeneralTypeIssues]  # pyrefly: ignore[invalid-argument]
+    )
 
 
 def test_has_dataclass_fields_issubclass_not_dataclass() -> None:
     """Test issubclass with a regular class without __dataclass_fields__."""
-    assert not issubclass(NotADataclass, op.dataclasses.HasDataclassFields)
+    assert not issubclass(  # type: ignore[misc]
+        NotADataclass,
+        op.dataclasses.HasDataclassFields,  # pyright: ignore[reportGeneralTypeIssues]  # pyrefly: ignore[invalid-argument]
+    )
 
 
 def test_has_dataclass_fields_isinstance_real_dataclass() -> None:
@@ -96,5 +104,8 @@ def test_has_dataclass_fields_generic_type_parameter() -> None:
     assert isinstance(Point, op.dataclasses.HasDataclassFields)
 
     # This should type check correctly with the generic parameter
-    protocol_type = cast(type[op.dataclasses.HasDataclassFields], Point)
-    assert issubclass(protocol_type, op.dataclasses.HasDataclassFields)
+    protocol_type = cast("type[op.dataclasses.HasDataclassFields]", Point)
+    assert issubclass(  # type: ignore[misc]
+        protocol_type,
+        op.dataclasses.HasDataclassFields,  # pyright: ignore[reportGeneralTypeIssues]  # pyrefly: ignore[invalid-argument]
+    )


### PR DESCRIPTION
I would like to replace https://github.com/GalacticDynamics/dataclassish/blob/c1bbc41163ba1af7bb327d813cce41f0b092b9b6/src/dataclassish/_src/types.py#L11 with optype's HasDataclassFields, but can't as of yet. This PR should enable the migration.

Not sure how you want the tests structured.