### PR TITLE
fix docs deploy branch

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,7 +2,7 @@ name: deploy docs
 
 on:
   push:
-    branches: [$default-branch]
+    branches: [master]
     paths:
       - "docs/**"
       - ".github/workflows/docs.yml"


### PR DESCRIPTION
because apparently `$default-branch` only works in workflow templates for some reason