### PR TITLE
Add structured `dtype` support for `AnyVoidArray`

### DIFF
--- a/optype/numpy/_any_dtype.py
+++ b/optype/numpy/_any_dtype.py
@@ -4,9 +4,17 @@ The names are analogous to those in `numpy.dtypes`.
 """
 
 from collections.abc import Sequence
-from typing import Any, Protocol
+from typing import Any, Never, Protocol, TypeAlias, TypedDict
+
+if sys.version_info >= (3, 13):
+    from typing import NotRequired, TypeAliasType
+else:
+    from typing import NotRequired
+    from typing_extensions import TypeAliasType
+
 
 import numpy as np
+import numpy.typing as npt
 import numpy_typing_compat
 
 import optype.numpy._dtype_attr as a
@@ -158,19 +166,47 @@ type AnyBytesDType = S_cls | To[np.bytes_] | a.S0_code
 type AnyBytes8DType = a.S1_code
 type AnyStrDType = S_cls | To[np.str_] | a.U0_code
 
-type _ToShape = tuple[int, ...] | int
-type _ToName = str | tuple[str, str]
-type _ToDType = To[Any] | str
-type _ToStructured = (
-    tuple[_ToDType, _ToShape]
-    | Sequence[tuple[_ToName, _ToDType] | tuple[_ToName, _ToDType, _ToShape]]
+# Structured dtype specifiers for np.void: covers all 4 NumPy forms.
+# See: https://numpy.org/doc/stable/user/basics.rec.html
+_StructuredDTypeField: TypeAlias = (
+    tuple[str, npt.DTypeLike]
+    | tuple[str, npt.DTypeLike, int]
+    | tuple[str, npt.DTypeLike, tuple[int, ...]]
+    | tuple[tuple[Any, str], npt.DTypeLike]
+    | tuple[tuple[Any, str], npt.DTypeLike, int]
+    | tuple[tuple[Any, str], npt.DTypeLike, tuple[int, ...]]
 )
-type AnyVoidDType = V_cls | To[np.void] | a.V0_code | _ToStructured
+_StructuredDTypeListForm: TypeAlias = Sequence[_StructuredDTypeField]
+_ToDType: TypeAlias = To[Any] | str
+
+
+class _StructuredDTypeDictForm1(TypedDict, total=True):
+    names: Sequence[str]
+    formats: Sequence[npt.DTypeLike]
+    offsets: NotRequired[Sequence[int]]
+    itemsize: NotRequired[int]
+    aligned: NotRequired[bool]
+    titles: NotRequired[Sequence[Any]]
+
+
+_StructuredDTypeDictForm2: TypeAlias = dict[
+    str,
+    tuple[npt.DTypeLike, int] | tuple[npt.DTypeLike, int, Any],
+]
+
+_StructuredDTypeLike: TypeAlias = (
+    _StructuredDTypeListForm | _StructuredDTypeDictForm1 | _StructuredDTypeDictForm2
+)
+
+AnyVoidDType = TypeAliasType(
+    "AnyVoidDType",
+    V_cls | To[np.void] | a.V0_code | _StructuredDTypeLike,
+)
 
 # object
 
-type AnyObjectDType = O_cls | To[np.object_] | a.O_code
-type AnyDType = _ToDType | _ToStructured
+AnyObjectDType = TypeAliasType("AnyObjectDType", O_cls | To[np.object_] | a.O_code)
+AnyDType = TypeAliasType("AnyDType", _ToDType | _StructuredDTypeLike)
 
 # abstract
 

--- a/optype/numpy/_any_dtype.py
+++ b/optype/numpy/_any_dtype.py
@@ -4,17 +4,15 @@ The names are analogous to those in `numpy.dtypes`.
 """
 
 from collections.abc import Sequence
-from typing import Any, Never, Protocol, TypeAlias, TypedDict
+from typing import Any, Never, NotRequired, Protocol, TypeAlias, TypedDict
 
 if sys.version_info >= (3, 13):
-    from typing import NotRequired, TypeAliasType
+    from typing import TypeAliasType
 else:
-    from typing import NotRequired
     from typing_extensions import TypeAliasType
 
 
 import numpy as np
-import numpy.typing as npt
 import numpy_typing_compat
 
 import optype.numpy._dtype_attr as a
@@ -168,21 +166,20 @@ type AnyStrDType = S_cls | To[np.str_] | a.U0_code
 
 # Structured dtype specifiers for np.void: covers all 4 NumPy forms.
 # See: https://numpy.org/doc/stable/user/basics.rec.html
-_StructuredDTypeField: TypeAlias = (
-    tuple[str, npt.DTypeLike]
-    | tuple[str, npt.DTypeLike, int]
-    | tuple[str, npt.DTypeLike, tuple[int, ...]]
-    | tuple[tuple[Any, str], npt.DTypeLike]
-    | tuple[tuple[Any, str], npt.DTypeLike, int]
-    | tuple[tuple[Any, str], npt.DTypeLike, tuple[int, ...]]
+_StructuredDTypeField = TypeAliasType(
+    "_StructuredDTypeField",
+    tuple[str, "AnyDType"]
+    | tuple[str, "AnyDType", int | tuple[int, ...]]
+    | tuple[tuple[Any, str], "AnyDType"]
+    | tuple[tuple[Any, str], "AnyDType", int | tuple[int, ...]],
 )
 _StructuredDTypeListForm: TypeAlias = Sequence[_StructuredDTypeField]
 _ToDType: TypeAlias = To[Any] | str
 
 
-class _StructuredDTypeDictForm1(TypedDict, total=True):
+class _StructuredDTypeDictForm1(TypedDict):
     names: Sequence[str]
-    formats: Sequence[npt.DTypeLike]
+    formats: Sequence["AnyDType"]
     offsets: NotRequired[Sequence[int]]
     itemsize: NotRequired[int]
     aligned: NotRequired[bool]
@@ -191,7 +188,7 @@ class _StructuredDTypeDictForm1(TypedDict, total=True):
 
 _StructuredDTypeDictForm2: TypeAlias = dict[
     str,
-    tuple[npt.DTypeLike, int] | tuple[npt.DTypeLike, int, Any],
+    tuple["AnyDType", int] | tuple["AnyDType", int, Any],
 ]
 
 _StructuredDTypeLike: TypeAlias = (

--- a/optype/numpy/_any_dtype.py
+++ b/optype/numpy/_any_dtype.py
@@ -4,13 +4,7 @@ The names are analogous to those in `numpy.dtypes`.
 """
 
 from collections.abc import Sequence
-from typing import Any, Never, NotRequired, Protocol, TypeAlias, TypedDict
-
-if sys.version_info >= (3, 13):
-    from typing import TypeAliasType
-else:
-    from typing_extensions import TypeAliasType
-
+from typing import Any, NotRequired, Protocol, TypedDict
 
 import numpy as np
 import numpy_typing_compat
@@ -166,15 +160,14 @@ type AnyStrDType = S_cls | To[np.str_] | a.U0_code
 
 # Structured dtype specifiers for np.void: covers all 4 NumPy forms.
 # See: https://numpy.org/doc/stable/user/basics.rec.html
-_StructuredDTypeField = TypeAliasType(
-    "_StructuredDTypeField",
-    tuple[str, "AnyDType"]
-    | tuple[str, "AnyDType", int | tuple[int, ...]]
-    | tuple[tuple[Any, str], "AnyDType"]
-    | tuple[tuple[Any, str], "AnyDType", int | tuple[int, ...]],
+type _StructuredDTypeField = (
+    tuple[str, AnyDType]
+    | tuple[str, AnyDType, int | tuple[int, ...]]
+    | tuple[tuple[Any, str], AnyDType]
+    | tuple[tuple[Any, str], AnyDType, int | tuple[int, ...]]
 )
-_StructuredDTypeListForm: TypeAlias = Sequence[_StructuredDTypeField]
-_ToDType: TypeAlias = To[Any] | str
+type _StructuredDTypeListForm = Sequence[_StructuredDTypeField]
+type _ToDType = To[Any] | str
 
 
 class _StructuredDTypeDictForm1(TypedDict):
@@ -186,24 +179,21 @@ class _StructuredDTypeDictForm1(TypedDict):
     titles: NotRequired[Sequence[Any]]
 
 
-_StructuredDTypeDictForm2: TypeAlias = dict[
+type _StructuredDTypeDictForm2 = dict[
     str,
-    tuple["AnyDType", int] | tuple["AnyDType", int, Any],
+    tuple[AnyDType, int] | tuple[AnyDType, int, Any],
 ]
 
-_StructuredDTypeLike: TypeAlias = (
+type _StructuredDTypeLike = (
     _StructuredDTypeListForm | _StructuredDTypeDictForm1 | _StructuredDTypeDictForm2
 )
 
-AnyVoidDType = TypeAliasType(
-    "AnyVoidDType",
-    V_cls | To[np.void] | a.V0_code | _StructuredDTypeLike,
-)
+type AnyVoidDType = V_cls | To[np.void] | a.V0_code | _StructuredDTypeLike
 
 # object
 
-AnyObjectDType = TypeAliasType("AnyObjectDType", O_cls | To[np.object_] | a.O_code)
-AnyDType = TypeAliasType("AnyDType", _ToDType | _StructuredDTypeLike)
+type AnyObjectDType = O_cls | To[np.object_] | a.O_code
+type AnyDType = _ToDType | _StructuredDTypeLike
 
 # abstract
 

--- a/tests/numpy/test_any_array.py
+++ b/tests/numpy/test_any_array.py
@@ -1,5 +1,6 @@
 import ctypes as ct
 import datetime as dt
+import math
 from collections import deque
 from typing import Final
 
@@ -234,3 +235,47 @@ def test_any_object_array(sctype: type[np.object_ | _ct.Object]) -> None:
     x = np.array(sctype())
     x_any: onp.AnyObjectArray = x
     assert np.issubdtype(x.dtype, np.object_)
+
+
+def test_any_void_array_structured_forms() -> None:
+    """Verify AnyVoidArray accepts all 4 NumPy structured dtype forms plus raw void."""
+
+    dt1 = [("x", "f4"), ("y", "i4", 2), ((42, "z"), "f4", (2, 2))]
+    arr1: onp.AnyVoidArray = np.array(
+        [(1.0, [2, 3], [[4.0, 5.0], [6.0, 7.0]])],
+        dtype=dt1,
+    )
+    fields1 = arr1.dtype.fields
+    assert fields1 is not None
+    assert fields1["y"][0] == np.dtype(("i4", (2,)))
+    assert fields1["z"][0] == np.dtype(("f4", (2, 2)))
+    assert fields1["z"][2] == 42  # type: ignore[misc]  # stubs type fields as 2-tuple
+
+    arr2: onp.AnyVoidArray = np.array([(1, 2.0)], dtype="i4, f4")
+    assert arr2.dtype.names == ("f0", "f1")
+
+    arr3: onp.AnyVoidArray = np.array(
+        [(1, 2.0)],
+        dtype={
+            "names": ["a", "b"],
+            "formats": ["i4", "f4"],
+            "offsets": [0, 8],
+            "itemsize": 16,
+            "titles": ["A", None],
+        },
+    )
+    fields3 = arr3.dtype.fields
+    assert fields3 is not None
+    assert fields3["b"][1] == 8
+    assert arr3.dtype.itemsize == 16
+    assert fields3["a"][2] == "A"  # type: ignore[misc]  # stubs type fields as 2-tuple
+
+    dt4 = np.dtype({"x": ("i4", 0), "y": ("f4", 4, math.pi)})  # type: ignore[arg-type]
+    arr4: onp.AnyVoidArray = np.array([(1, 2.0)], dtype=dt4)
+    fields4 = arr4.dtype.fields
+    assert fields4 is not None
+    assert fields4["y"][2] == math.pi  # type: ignore[misc]  # stubs type fields as 2-tuple
+
+    arr5: onp.AnyVoidArray = np.empty(3, dtype="V8")
+    assert arr5.dtype == np.dtype("V8")
+    assert arr5.dtype.fields is None

--- a/tests/numpy/test_any_array.py
+++ b/tests/numpy/test_any_array.py
@@ -2,7 +2,7 @@ import ctypes as ct
 import datetime as dt
 import math
 from collections import deque
-from typing import Final
+from typing import Final, cast
 
 import numpy as np
 import pytest
@@ -250,7 +250,7 @@ def test_any_void_array_structured_forms() -> None:
     assert fields1 is not None
     assert fields1["y"][0] == np.dtype(("i4", (2,)))
     assert fields1["z"][0] == np.dtype(("f4", (2, 2)))
-    assert fields1["z"][2] == 42  # type: ignore[misc]  # stubs type fields as 2-tuple
+    assert fields1["z"][2] == 42  # type: ignore[misc]  # pyright: ignore[reportGeneralTypeIssues]
 
     arr2 = np.array([(1, 2.0)], dtype="i4, f4")
     arr2_any: onp.AnyVoidArray = arr2
@@ -271,14 +271,14 @@ def test_any_void_array_structured_forms() -> None:
     assert fields3 is not None
     assert fields3["b"][1] == 8
     assert arr3.dtype.itemsize == 16
-    assert fields3["a"][2] == "A"  # type: ignore[misc]  # stubs type fields as 2-tuple
+    assert fields3["a"][2] == "A"  # type: ignore[misc]  # pyright: ignore[reportGeneralTypeIssues]
 
-    dt4 = np.dtype({"x": ("i4", 0), "y": ("f4", 4, math.pi)})  # type: ignore[arg-type]
+    dt4 = cast("np.dtype[np.void]", np.dtype({"x": ("i4", 0), "y": ("f4", 4, math.pi)}))  # type: ignore[call-overload]
     arr4 = np.array([(1, 2.0)], dtype=dt4)
     arr4_any: onp.AnyVoidArray = arr4
     fields4 = arr4.dtype.fields
     assert fields4 is not None
-    assert fields4["y"][2] == math.pi  # type: ignore[misc]  # stubs type fields as 2-tuple
+    assert fields4["y"][2] == math.pi  # type: ignore[misc]  # pyright: ignore[reportGeneralTypeIssues]
 
     arr5 = np.empty(3, dtype="V8")
     arr5_any: onp.AnyVoidArray = arr5

--- a/tests/numpy/test_any_array.py
+++ b/tests/numpy/test_any_array.py
@@ -1,6 +1,5 @@
 import ctypes as ct
 import datetime as dt
-import math
 from collections import deque
 from typing import Final
 
@@ -235,56 +234,3 @@ def test_any_object_array(sctype: type[np.object_ | _ct.Object]) -> None:
     x = np.array(sctype())
     x_any: onp.AnyObjectArray = x
     assert np.issubdtype(x.dtype, np.object_)
-
-
-def test_any_void_array_structured_forms() -> None:
-    """Verify AnyVoidArray accepts all 4 NumPy structured dtype forms plus raw void."""
-
-    dt1 = [("x", "f4"), ("y", "i4", 2), ((42, "z"), "f4", (2, 2))]
-    arr1 = np.array(
-        [(1.0, [2, 3], [[4.0, 5.0], [6.0, 7.0]])],
-        dtype=dt1,
-    )
-    arr1_any: onp.AnyVoidArray = arr1
-    fields1 = arr1.dtype.fields
-    assert fields1 is not None
-    assert fields1["y"][0] == np.dtype(("i4", (2,)))
-    assert fields1["z"][0] == np.dtype(("f4", (2, 2)))
-    assert fields1["z"][2] == 42  # type: ignore[misc]  # pyright: ignore[reportGeneralTypeIssues]
-
-    arr2 = np.array([(1, 2.0)], dtype="i4, f4")
-    arr2_any: onp.AnyVoidArray = arr2
-    assert arr2.dtype.names == ("f0", "f1")
-
-    arr3 = np.array(
-        [(1, 2.0)],
-        dtype={
-            "names": ["a", "b"],
-            "formats": ["i4", "f4"],
-            "offsets": [0, 8],
-            "itemsize": 16,
-            "titles": ["A", None],
-        },
-    )
-    arr3_any: onp.AnyVoidArray = arr3
-    fields3 = arr3.dtype.fields
-    assert fields3 is not None
-    assert fields3["b"][1] == 8
-    assert arr3.dtype.itemsize == 16
-    assert fields3["a"][2] == "A"  # type: ignore[misc]  # pyright: ignore[reportGeneralTypeIssues]
-
-    dt4_spec: dict[str, tuple[str, int] | tuple[str, int, float]] = {
-        "x": ("i4", 0),
-        "y": ("f4", 4, math.pi),
-    }
-    dt4 = np.dtype(dt4_spec)  # type: ignore[call-overload]  # pyright: ignore[reportCallIssue, reportArgumentType]
-    arr4 = np.array([(1, 2.0)], dtype=dt4)
-    arr4_any: onp.AnyVoidArray = arr4
-    fields4 = arr4.dtype.fields
-    assert fields4 is not None
-    assert fields4["y"][2] == math.pi  # type: ignore[misc]  # pyright: ignore[reportGeneralTypeIssues]
-
-    arr5 = np.empty(3, dtype="V8")
-    arr5_any: onp.AnyVoidArray = arr5
-    assert arr5.dtype == np.dtype("V8")
-    assert arr5.dtype.fields is None

--- a/tests/numpy/test_any_array.py
+++ b/tests/numpy/test_any_array.py
@@ -2,7 +2,7 @@ import ctypes as ct
 import datetime as dt
 import math
 from collections import deque
-from typing import Final, cast
+from typing import Final
 
 import numpy as np
 import pytest
@@ -273,7 +273,11 @@ def test_any_void_array_structured_forms() -> None:
     assert arr3.dtype.itemsize == 16
     assert fields3["a"][2] == "A"  # type: ignore[misc]  # pyright: ignore[reportGeneralTypeIssues]
 
-    dt4 = cast("np.dtype[np.void]", np.dtype({"x": ("i4", 0), "y": ("f4", 4, math.pi)}))  # type: ignore[call-overload]
+    dt4_spec: dict[str, tuple[str, int] | tuple[str, int, float]] = {
+        "x": ("i4", 0),
+        "y": ("f4", 4, math.pi),
+    }
+    dt4 = np.dtype(dt4_spec)  # type: ignore[call-overload]  # pyright: ignore[reportCallIssue, reportArgumentType]
     arr4 = np.array([(1, 2.0)], dtype=dt4)
     arr4_any: onp.AnyVoidArray = arr4
     fields4 = arr4.dtype.fields

--- a/tests/numpy/test_any_array.py
+++ b/tests/numpy/test_any_array.py
@@ -241,20 +241,22 @@ def test_any_void_array_structured_forms() -> None:
     """Verify AnyVoidArray accepts all 4 NumPy structured dtype forms plus raw void."""
 
     dt1 = [("x", "f4"), ("y", "i4", 2), ((42, "z"), "f4", (2, 2))]
-    arr1: onp.AnyVoidArray = np.array(
+    arr1 = np.array(
         [(1.0, [2, 3], [[4.0, 5.0], [6.0, 7.0]])],
         dtype=dt1,
     )
+    arr1_any: onp.AnyVoidArray = arr1
     fields1 = arr1.dtype.fields
     assert fields1 is not None
     assert fields1["y"][0] == np.dtype(("i4", (2,)))
     assert fields1["z"][0] == np.dtype(("f4", (2, 2)))
     assert fields1["z"][2] == 42  # type: ignore[misc]  # stubs type fields as 2-tuple
 
-    arr2: onp.AnyVoidArray = np.array([(1, 2.0)], dtype="i4, f4")
+    arr2 = np.array([(1, 2.0)], dtype="i4, f4")
+    arr2_any: onp.AnyVoidArray = arr2
     assert arr2.dtype.names == ("f0", "f1")
 
-    arr3: onp.AnyVoidArray = np.array(
+    arr3 = np.array(
         [(1, 2.0)],
         dtype={
             "names": ["a", "b"],
@@ -264,6 +266,7 @@ def test_any_void_array_structured_forms() -> None:
             "titles": ["A", None],
         },
     )
+    arr3_any: onp.AnyVoidArray = arr3
     fields3 = arr3.dtype.fields
     assert fields3 is not None
     assert fields3["b"][1] == 8
@@ -271,11 +274,13 @@ def test_any_void_array_structured_forms() -> None:
     assert fields3["a"][2] == "A"  # type: ignore[misc]  # stubs type fields as 2-tuple
 
     dt4 = np.dtype({"x": ("i4", 0), "y": ("f4", 4, math.pi)})  # type: ignore[arg-type]
-    arr4: onp.AnyVoidArray = np.array([(1, 2.0)], dtype=dt4)
+    arr4 = np.array([(1, 2.0)], dtype=dt4)
+    arr4_any: onp.AnyVoidArray = arr4
     fields4 = arr4.dtype.fields
     assert fields4 is not None
     assert fields4["y"][2] == math.pi  # type: ignore[misc]  # stubs type fields as 2-tuple
 
-    arr5: onp.AnyVoidArray = np.empty(3, dtype="V8")
+    arr5 = np.empty(3, dtype="V8")
+    arr5_any: onp.AnyVoidArray = arr5
     assert arr5.dtype == np.dtype("V8")
     assert arr5.dtype.fields is None

--- a/tests/numpy/test_any_dtype.py
+++ b/tests/numpy/test_any_dtype.py
@@ -4,6 +4,7 @@ from typing import Final, Never, cast
 import numpy as np
 import pytest
 
+import optype.numpy as onp  # noqa: TC001
 from optype.numpy import _dtype_attr
 
 _DTYPES: Final = (
@@ -111,3 +112,23 @@ def test_time_units(
 
     assert name in names, (name, names)
     assert str_ in chars, (str_, chars)
+
+
+def test_any_void_dtype_list_form() -> None:
+    dt: onp.AnyVoidDType = [("x", "f4"), ("y", "i4")]
+    assert np.dtype(dt)
+
+
+def test_any_void_dtype_dict_form1() -> None:
+    dt: onp.AnyVoidDType = {"names": ["x", "y"], "formats": ["f4", "i4"]}
+    assert np.dtype(dt)
+
+
+def test_any_void_dtype_dict_form2() -> None:
+    dt: onp.AnyVoidDType = {"x": ("i4", 0), "y": ("f4", 4)}
+    assert np.dtype(dt)
+
+
+def test_any_void_dtype_string_form() -> None:
+    dt: onp.AnyVoidDType = "V8"
+    assert np.dtype(dt)


### PR DESCRIPTION
fixes #371 