### PR TITLE
fix `float <: CanRound2[int, float]`

### DIFF
--- a/optype/_core/_can.py
+++ b/optype/_core/_can.py
@@ -1459,7 +1459,7 @@ class CanRound1(Protocol[_T_int_co]):
 
 @runtime_checkable
 class CanRound2(Protocol[_T_int_contra, _T_float_co]):
-    def __round__(self, /, ndigits: _T_int_contra) -> _T_float_co: ...
+    def __round__(self, ndigits: _T_int_contra, /) -> _T_float_co: ...
 
 
 @runtime_checkable
@@ -1472,7 +1472,7 @@ class CanRound(
     @override
     def __round__(self, /) -> _T_int_co: ...
     @overload
-    def __round__(self, /, ndigits: _T_int_contra) -> _T_float_co: ...
+    def __round__(self, ndigits: _T_int_contra, /) -> _T_float_co: ...
 
 
 @runtime_checkable

--- a/tests/core/test_can.py
+++ b/tests/core/test_can.py
@@ -352,3 +352,18 @@ def test_can_same_self(cls: type) -> None:
 
     assert members_same == members_self
     assert members_same == members_base
+
+
+def test_can_round_float() -> None:
+    # https://github.com/jorenham/optype/issues/596
+
+    x: float = 1 / 137
+
+    r1: op.CanRound1[int] = x
+    assert isinstance(r1, op.CanRound1)
+
+    r2: op.CanRound2[int, float] = x
+    assert isinstance(r2, op.CanRound2)
+
+    r: op.CanRound[int, int, float] = x
+    assert isinstance(r, op.CanRound)


### PR DESCRIPTION
fixes #596