### PR TITLE
fix `do_round: (float, int) -> float`

### DIFF
--- a/optype/_core/_does.py
+++ b/optype/_core/_does.py
@@ -1,6 +1,6 @@
 import sys
 from collections.abc import AsyncIterator, Callable, Iterable, Iterator
-from typing import Protocol, overload
+from typing import Protocol, SupportsIndex, overload
 
 if sys.version_info >= (3, 13):
     from typing import ParamSpec, TypeVar
@@ -774,15 +774,25 @@ class DoesHash(Protocol):
 
 class DoesRound(Protocol):
     @overload
-    def __call__(self, obj: _c.CanRound1[_OutT], /) -> _OutT: ...
-    @overload
-    def __call__(self, obj: _c.CanRound1[_OutT], /, ndigits: None = None) -> _OutT: ...
-    @overload
     def __call__(
         self,
-        obj: _c.CanRound2[_NDigitsT, _OutT],
+        number: _c.CanRound1[_OutT],
+        ndigits: None = None,
         /,
+    ) -> _OutT: ...
+    @overload  # this unnecessary overload works around the issue described below
+    def __call__(
+        self,
+        number: _c.CanRound2[SupportsIndex, _OutT],
+        ndigits: SupportsIndex,
+        /,
+    ) -> _OutT: ...
+    @overload  # all type-checkers except ty fail to correctly resolve this overload
+    def __call__(
+        self,
+        number: _c.CanRound2[_NDigitsT, _OutT],
         ndigits: _NDigitsT,
+        /,
     ) -> _OutT: ...
 
 

--- a/tests/core/test_does.py
+++ b/tests/core/test_does.py
@@ -1,6 +1,6 @@
 from typing import assert_type, final
 
-from optype import do_iadd
+import optype as op
 
 
 def test_iadd_iadd() -> None:
@@ -14,7 +14,7 @@ def test_iadd_iadd() -> None:
             return self.x
 
     lhs = IntIAdd(1)
-    out = do_iadd(lhs, 2)
+    out = op.do_iadd(lhs, 2)
 
     assert_type(out, int)
     assert out == 3
@@ -30,7 +30,7 @@ def test_iadd_add() -> None:
             return self.x + y
 
     lhs = IntAdd(1)
-    out = do_iadd(lhs, 2)
+    out = op.do_iadd(lhs, 2)
 
     assert_type(out, int)
     assert out == 3
@@ -46,7 +46,7 @@ def test_iadd_radd() -> None:
             return self.x + y
 
     rhs = IntRAdd(1)
-    out = do_iadd(2, rhs)
+    out = op.do_iadd(2, rhs)
 
     assert_type(out, int)
     assert out == 3
@@ -54,3 +54,21 @@ def test_iadd_radd() -> None:
 
 # the analogous tests for the other inplace binary ops are omitted, because
 # the interface implementations are structurally equivalent, and I'm lazy
+
+
+def test_round() -> None:
+    x = 1.45
+
+    r = op.do_round(x)
+    assert_type(r, int)
+    assert isinstance(r, int)
+    assert r == 1
+
+    r_none = op.do_round(x, None)
+    assert_type(r_none, int)
+    assert isinstance(r_none, int)
+    assert r == 1
+
+    r_1 = op.do_round(x, 1)
+    assert_type(r_1, float)
+    assert isinstance(r_1, float)


### PR DESCRIPTION
A workaround is required for mypy, pyright, and pyrefly (ty works correctly), because they all fail to resolve the overload of the `ndigits` type parameter for some reason. I'm guessing it has something to do with the contravariant position and the required bidirectional inference.