### PR TITLE
some mypy_primer workflow tweaks

### DIFF
--- a/.github/workflows/mypy_primer.yml
+++ b/.github/workflows/mypy_primer.yml
@@ -58,7 +58,7 @@ jobs:
           uvx \
             --from="https://github.com/hauntsaninja/mypy_primer.git" \
             mypy_primer \
-            --project-selector "/(beartype|dedupe|efax|hydpy|jax|lmo|numpy-typing-compat|optuna|pandera|scikit-learn|scipy|scipy-stubs|static-frame|vision|xarray)/?$" \
+            --project-selector "/(colour|dedupe|efax|hydpy|jax|optuna|pandera|scikit-learn|scipy-stubs|static-frame|vision|xarray)/?$" \
             --new v${MYPY_VERSION} \
             --new-prepend-path new \
             --old v${MYPY_VERSION} \

--- a/.github/workflows/mypy_primer.yml
+++ b/.github/workflows/mypy_primer.yml
@@ -5,12 +5,7 @@ on:
   # only run on pr, since we diff between branches
   pull_request:
     paths:
-      - "optype/**/*.py"
-      - "optype/**/*.pyi"
-      - "examples/**/*.py"
-      - "tests/**/*.py"
-      - "tests/**/*.pyi"
-      - "pyproject.toml"
+      - "optype/**/*.{py,pyi}"
       - "uv.lock"
       - ".github/workflows/mypy_primer.yml"
 


### PR DESCRIPTION
It'll run less often now, and the project selector regex doesn't contain projects that aren't listed in the mypy_primer projects (and therefore not used).