### PR TITLE
`numpy.To*`: artisanal beartype support

### DIFF
--- a/optype/numpy/_scalar.py
+++ b/optype/numpy/_scalar.py
@@ -1,5 +1,5 @@
 import sys
-from typing import Any, Literal, Protocol, Self, overload
+from typing import TYPE_CHECKING, Any, Literal, Protocol, Self, overload
 
 if sys.version_info >= (3, 13):
     from types import CapsuleType
@@ -8,7 +8,6 @@ else:
     from typing_extensions import CapsuleType, TypeVar, runtime_checkable
 
 import numpy as np
-from numpy._typing import _8Bit, _16Bit, _32Bit, _64Bit, _96Bit, _128Bit
 
 from optype._utils import set_module
 
@@ -89,38 +88,79 @@ generic = np.generic
 flexible = np.flexible
 character = np.character
 
-type number = np.number[Any]  # noqa: PYI042
-type integer = np.integer[Any]  # noqa: PYI042
-type uinteger = np.unsignedinteger[Any]  # noqa: PYI042
-type sinteger = np.signedinteger[Any]  # noqa: PYI042
-type inexact = np.inexact[Any]  # noqa: PYI042
-type floating = np.floating[Any]  # noqa: PYI042
-type cfloating = np.complexfloating[Any, Any]  # noqa: PYI042
+if TYPE_CHECKING:
+    from numpy._typing import (
+        _8Bit,
+        _16Bit,
+        _32Bit,
+        _64Bit,
+        _96Bit,
+        _128Bit,
+    )
 
-type integer8 = np.integer[_8Bit]  # noqa: PYI042
-type integer16 = np.integer[_16Bit]  # noqa: PYI042
-type integer32 = np.integer[_32Bit]  # noqa: PYI042
-type integer64 = np.integer[_64Bit]  # noqa: PYI042
+    type number = np.number[Any]  # noqa: PYI042
+    type integer = np.integer[Any]  # noqa: PYI042
+    type uinteger = np.unsignedinteger[Any]  # noqa: PYI042
+    type sinteger = np.signedinteger[Any]  # noqa: PYI042
+    type inexact = np.inexact[Any]  # noqa: PYI042
+    type floating = np.floating[Any]  # noqa: PYI042
+    type cfloating = np.complexfloating[Any, Any]  # noqa: PYI042
 
-type floating16 = np.floating[_16Bit]  # noqa: PYI042
-type floating32 = np.floating[_32Bit]  # noqa: PYI042
-type floating64 = np.floating[_64Bit]  # noqa: PYI042
-# float96, float128, and longdouble
-type floating80 = np.floating[_96Bit] | np.floating[_128Bit]  # noqa: PYI042
+    type integer8 = np.integer[_8Bit]  # noqa: PYI042
+    type integer16 = np.integer[_16Bit]  # noqa: PYI042
+    type integer32 = np.integer[_32Bit]  # noqa: PYI042
+    type integer64 = np.integer[_64Bit]  # noqa: PYI042
 
-type cfloating32 = np.complexfloating[_32Bit, _32Bit]  # noqa: PYI042
-type cfloating64 = np.complexfloating[_64Bit, _64Bit]  # noqa: PYI042
-# complex192, complex256, and clongdouble
-type cfloating80 = (  # noqa: PYI042
-    np.complexfloating[_96Bit, _96Bit] | np.complexfloating[_128Bit, _128Bit]
-)
+    type floating16 = np.floating[_16Bit]  # noqa: PYI042
+    type floating32 = np.floating[_32Bit]  # noqa: PYI042
+    type floating64 = np.floating[_64Bit]  # noqa: PYI042
+    # float96, float128, and longdouble
+    type floating80 = np.floating[_96Bit] | np.floating[_128Bit]  # noqa: PYI042
 
-type inexact32 = np.inexact[_32Bit]  # noqa: PYI042
-type inexact64 = np.inexact[_64Bit]  # noqa: PYI042
-# float96, complex192, float128, complex256, longdouble, and clongdouble
-type inexact80 = np.inexact[_96Bit] | np.inexact[_128Bit]  # noqa: PYI042
+    type cfloating32 = np.complexfloating[_32Bit, _32Bit]  # noqa: PYI042
+    type cfloating64 = np.complexfloating[_64Bit, _64Bit]  # noqa: PYI042
+    # complex192, complex256, and clongdouble
+    type cfloating80 = (  # noqa: PYI042
+        np.complexfloating[_96Bit, _96Bit] | np.complexfloating[_128Bit, _128Bit]
+    )
 
-type number8 = np.number[_8Bit]  # noqa: PYI042
-type number16 = np.number[_16Bit]  # noqa: PYI042
-type number32 = np.number[_32Bit]  # noqa: PYI042
-type number64 = np.number[_64Bit]  # noqa: PYI042
+    type inexact32 = np.inexact[_32Bit]  # noqa: PYI042
+    type inexact64 = np.inexact[_64Bit]  # noqa: PYI042
+    # float96, complex192, float128, complex256, longdouble, and clongdouble
+    type inexact80 = np.inexact[_96Bit] | np.inexact[_128Bit]  # noqa: PYI042
+
+    type number8 = np.number[_8Bit]  # noqa: PYI042
+    type number16 = np.number[_16Bit]  # noqa: PYI042
+    type number32 = np.number[_32Bit]  # noqa: PYI042
+    type number64 = np.number[_64Bit]  # noqa: PYI042
+else:
+    number = np.number
+    integer = np.integer
+    uinteger = np.unsignedinteger
+    sinteger = np.signedinteger
+    inexact = np.inexact
+    floating = np.floating
+    cfloating = np.complexfloating
+
+    integer8 = np.int8 | np.uint8
+    integer16 = np.int16 | np.uint16
+    integer32 = np.int32 | np.uint32
+    integer64 = np.int64 | np.uint64
+
+    floating16 = np.float16
+    floating32 = np.float32
+    floating64 = np.float64
+    floating80 = np.longdouble
+
+    cfloating32 = np.complex64
+    cfloating64 = np.complex128
+    cfloating80 = np.clongdouble
+
+    inexact32 = floating32 | cfloating32
+    inexact64 = floating64 | cfloating64
+    inexact80 = floating80 | cfloating80
+
+    number8 = integer8
+    number16 = integer16 | np.float16
+    number32 = integer32 | inexact32
+    number64 = integer64 | inexact64

--- a/optype/numpy/_sequence_nd.py
+++ b/optype/numpy/_sequence_nd.py
@@ -1,5 +1,5 @@
 from collections.abc import Iterator
-from typing import Any, Protocol, TypeVar, final
+from typing import Any, Protocol, TypeVar, final, runtime_checkable
 
 __all__ = ["SequenceND"]
 
@@ -8,6 +8,7 @@ T_co = TypeVar("T_co", covariant=True)
 
 
 @final
+@runtime_checkable
 class SequenceND(Protocol[T_co]):  # type: ignore[misc]  # https://github.com/python/mypy/issues/17288
     """Based on `numpy._typing._NestedSequence`."""
 

--- a/optype/numpy/_to.py
+++ b/optype/numpy/_to.py
@@ -1,6 +1,14 @@
 import sys
-from collections.abc import Sequence as Seq
-from typing import Any, Literal, Protocol, TypeAliasType
+from collections.abc import Callable, Sequence as Seq
+from typing import (
+    TYPE_CHECKING,
+    Annotated as Ann,
+    Any,
+    Literal,
+    Protocol,
+    TypeAliasType,
+    runtime_checkable,
+)
 
 if sys.version_info >= (3, 13):
     from typing import TypeVar
@@ -124,21 +132,47 @@ SCT_co = TypeVar("SCT_co", bound=np.generic, covariant=True)
 # (and aren't runtime checkable)
 
 
-type _CanArrayStrict1D[SCT: np.generic] = nptc.CanArray[tuple[int], np.dtype[SCT]]
-type _CanArrayStrict2D[SCT: np.generic] = nptc.CanArray[tuple[int, int], np.dtype[SCT]]
-type _CanArrayStrict3D[SCT: np.generic] = nptc.CanArray[
-    tuple[int, int, int],
-    np.dtype[SCT],
-]
-
-
+@runtime_checkable
 class _CanArrayND(Protocol[SCT_co]):
     def __len__(self, /) -> int: ...
     def __array__(self, /) -> np.ndarray[Any, np.dtype[SCT_co]]: ...
 
 
+@runtime_checkable
 class _CanArray(Protocol[SCT_co]):
     def __array__(self, /) -> np.ndarray[Any, np.dtype[SCT_co]]: ...
+
+
+if TYPE_CHECKING:
+    _CanArrayStrict1D = TypeAliasType(  # noqa: UP040
+        "_CanArrayStrict1D",
+        nptc.CanArray[tuple[int], np.dtype[SCT]],
+        type_params=(SCT,),
+    )
+    _CanArrayStrict2D = TypeAliasType(  # noqa: UP040
+        "_CanArrayStrict2D",
+        nptc.CanArray[tuple[int, int], np.dtype[SCT]],
+        type_params=(SCT,),
+    )
+    _CanArrayStrict3D = TypeAliasType(  # noqa: UP040
+        "_CanArrayStrict3D",
+        nptc.CanArray[tuple[int, int, int], np.dtype[SCT]],
+        type_params=(SCT,),
+    )
+
+else:
+
+    @runtime_checkable
+    class _CanArrayStrict1D(Protocol[SCT_co]):
+        def __array__(self) -> np.ndarray[tuple[int], np.dtype[SCT_co]]: ...
+
+    @runtime_checkable
+    class _CanArrayStrict2D(Protocol[SCT_co]):
+        def __array__(self) -> np.ndarray[tuple[int, int], np.dtype[SCT_co]]: ...
+
+    @runtime_checkable
+    class _CanArrayStrict3D(Protocol[SCT_co]):
+        def __array__(self) -> np.ndarray[tuple[int, int, int], np.dtype[SCT_co]]: ...
 
 
 type _To1D1[SCT: np.generic] = _CanArrayND[SCT] | Seq[SCT]
@@ -183,6 +217,17 @@ type c64_co = npc.inexact32 | npc.number16 | npc.integer8 | np.bool  # noqa: PYI
 type f64_co = npc.floating64 | npc.floating32 | npc.floating16 | npc.integer | np.bool  # noqa: PYI042
 type c128_co = npc.number64 | npc.number32 | npc.number16 | npc.integer | np.bool  # noqa: PYI042
 
+###
+
+# runtime type-checking compat
+
+if TYPE_CHECKING:
+    # we don't use float | int to avoid clutter in type-checker error output
+    py_float = float
+    py_complex = complex
+else:
+    py_float = float | int
+    py_complex = complex | py_float
 
 ###
 
@@ -224,17 +269,17 @@ type ToFloat32_2D = _To2D1[f32_co]
 type ToFloat32_3D = _To3D1[f32_co]
 type ToFloat32_ND = _ToND1[f32_co]
 
-type ToFloat64 = float | f64_co
-type ToFloat64_1D = _To1D2[float, f64_co]
-type ToFloat64_2D = _To2D2[float, f64_co]
-type ToFloat64_3D = _To3D2[float, f64_co]
-type ToFloat64_ND = _ToND2[float, f64_co]
+type ToFloat64 = py_float | f64_co
+type ToFloat64_1D = _To1D2[py_float, f64_co]
+type ToFloat64_2D = _To2D2[py_float, f64_co]
+type ToFloat64_3D = _To3D2[py_float, f64_co]
+type ToFloat64_ND = _ToND2[py_float, f64_co]
 
-type ToFloat = float | floating_co
-type ToFloat1D = _To1D2[float, floating_co]
-type ToFloat2D = _To2D2[float, floating_co]
-type ToFloat3D = _To3D2[float, floating_co]
-type ToFloatND = _ToND2[float, floating_co]
+type ToFloat = py_float | floating_co
+type ToFloat1D = _To1D2[py_float, floating_co]
+type ToFloat2D = _To2D2[py_float, floating_co]
+type ToFloat3D = _To3D2[py_float, floating_co]
+type ToFloatND = _ToND2[py_float, floating_co]
 
 type ToComplex64 = c64_co
 type ToComplex64_1D = _To1D1[c64_co]
@@ -242,17 +287,17 @@ type ToComplex64_2D = _To2D1[c64_co]
 type ToComplex64_3D = _To3D1[c64_co]
 type ToComplex64_ND = _ToND1[c64_co]
 
-type ToComplex128 = complex | c128_co
-type ToComplex128_1D = _To1D2[complex, c128_co]
-type ToComplex128_2D = _To2D2[complex, c128_co]
-type ToComplex128_3D = _To3D2[complex, c128_co]
-type ToComplex128_ND = _ToND2[complex, c128_co]
+type ToComplex128 = py_complex | c128_co
+type ToComplex128_1D = _To1D2[py_complex, c128_co]
+type ToComplex128_2D = _To2D2[py_complex, c128_co]
+type ToComplex128_3D = _To3D2[py_complex, c128_co]
+type ToComplex128_ND = _ToND2[py_complex, c128_co]
 
-type ToComplex = complex | complexfloating_co
-type ToComplex1D = _To1D2[complex, complexfloating_co]
-type ToComplex2D = _To2D2[complex, complexfloating_co]
-type ToComplex3D = _To3D2[complex, complexfloating_co]
-type ToComplexND = _ToND2[complex, complexfloating_co]
+type ToComplex = py_complex | complexfloating_co
+type ToComplex1D = _To1D2[py_complex, complexfloating_co]
+type ToComplex2D = _To2D2[py_complex, complexfloating_co]
+type ToComplex3D = _To3D2[py_complex, complexfloating_co]
+type ToComplexND = _ToND2[py_complex, complexfloating_co]
 
 # scalar- and array-likes, with "just" that scalar type
 
@@ -362,25 +407,25 @@ type ToFloat32Strict1D = _ToStrict1D1[f32_co]
 type ToFloat32Strict2D = _ToStrict2D1[f32_co]
 type ToFloat32Strict3D = _ToStrict3D1[f32_co]
 
-type ToFloat64Strict1D = _ToStrict1D2[float, f64_co]
-type ToFloat64Strict2D = _ToStrict2D2[float, f64_co]
-type ToFloat64Strict3D = _ToStrict3D2[float, f64_co]
+type ToFloat64Strict1D = _ToStrict1D2[py_float, f64_co]
+type ToFloat64Strict2D = _ToStrict2D2[py_float, f64_co]
+type ToFloat64Strict3D = _ToStrict3D2[py_float, f64_co]
 
-type ToFloatStrict1D = _ToStrict1D2[float, floating_co]
-type ToFloatStrict2D = _ToStrict2D2[float, floating_co]
-type ToFloatStrict3D = _ToStrict3D2[float, floating_co]
+type ToFloatStrict1D = _ToStrict1D2[py_float, floating_co]
+type ToFloatStrict2D = _ToStrict2D2[py_float, floating_co]
+type ToFloatStrict3D = _ToStrict3D2[py_float, floating_co]
 
 type ToComplex64Strict1D = _ToStrict1D1[c64_co]
 type ToComplex64Strict2D = _ToStrict2D1[c64_co]
 type ToComplex64Strict3D = _ToStrict3D1[c64_co]
 
-type ToComplex128Strict1D = _ToStrict1D2[complex, c128_co]
-type ToComplex128Strict2D = _ToStrict2D2[complex, c128_co]
-type ToComplex128Strict3D = _ToStrict3D2[complex, c128_co]
+type ToComplex128Strict1D = _ToStrict1D2[py_complex, c128_co]
+type ToComplex128Strict2D = _ToStrict2D2[py_complex, c128_co]
+type ToComplex128Strict3D = _ToStrict3D2[py_complex, c128_co]
 
-type ToComplexStrict1D = _ToStrict1D2[complex, complexfloating_co]
-type ToComplexStrict2D = _ToStrict2D2[complex, complexfloating_co]
-type ToComplexStrict3D = _ToStrict3D2[complex, complexfloating_co]
+type ToComplexStrict1D = _ToStrict1D2[py_complex, complexfloating_co]
+type ToComplexStrict2D = _ToStrict2D2[py_complex, complexfloating_co]
+type ToComplexStrict3D = _ToStrict3D2[py_complex, complexfloating_co]
 
 # array-likes, with "just" that scalar type, and "strict" shape-types
 
@@ -420,3 +465,99 @@ type ToJustCLongDoubleStrict3D = _ToStrict3D1[npc.complexfloating160]
 type ToJustComplexStrict1D = _ToStrict1D2[JustComplex, npc.complexfloating]
 type ToJustComplexStrict2D = _ToStrict2D2[JustComplex, npc.complexfloating]
 type ToJustComplexStrict3D = _ToStrict3D2[JustComplex, npc.complexfloating]
+
+
+# if not TYPE_CHECKING:
+try:
+    from beartype.vale import Is as _BeartypeIs
+except ImportError:
+    pass
+else:
+    # `beartype.vale._core._valecore.BeartypeValidator` is private, unfortunately
+    type _BeartypeValidator = Any
+
+    def _install() -> None:
+        def build(
+            check: Callable[[np.dtype[np.generic], Any], bool],
+        ) -> Callable[[int | None, object], _BeartypeValidator]:
+            def factory(nd: int | None, target: object) -> _BeartypeValidator:
+                def predicate(x: object, /) -> bool:
+                    try:
+                        x = np.asanyarray(x)
+                    except (ValueError, TypeError):
+                        return False
+                    return (nd is None or x.ndim == nd) and check(x.dtype, target)
+
+                return _BeartypeIs[predicate]
+
+            return factory
+
+        is_cast = build(np.can_cast)
+        is_sub = build(lambda dt, t: issubclass(dt.type, t))
+
+        def wrap(key: str, ann: _BeartypeValidator) -> None:
+            if key in globals():
+                globals()[key] = Ann[globals()[key], ann]  # ty:ignore[invalid-type-form]
+
+        for name, sct in [
+            ("Bool", np.bool),
+            ("Int64", np.int64),
+            ("Float16", np.float16),
+            ("Float32", np.float32),
+            ("Float64", np.float64),
+            ("LongDouble", np.longdouble),
+            ("Complex64", np.complex64),
+            ("Complex128", np.complex128),
+            ("CLongDouble", np.clongdouble),
+        ]:
+            name_ = f"{name}_" if name[-1].isdigit() else name
+
+            wrap(f"To{name}", is_cast(0, sct))
+            wrap(f"To{name_}1D", is_cast(1, sct))
+            wrap(f"To{name_}2D", is_cast(2, sct))
+            wrap(f"To{name_}3D", is_cast(3, sct))
+            wrap(f"To{name_}ND", is_cast(None, sct))
+
+            wrap(f"ToJust{name}", is_sub(0, sct))
+            wrap(f"ToJust{name_}1D", is_sub(1, sct))
+            wrap(f"ToJust{name_}2D", is_sub(2, sct))
+            wrap(f"ToJust{name_}3D", is_sub(3, sct))
+            wrap(f"ToJust{name_}ND", is_sub(None, sct))
+
+            wrap(f"To{name}Strict1D", is_cast(1, sct))
+            wrap(f"To{name}Strict2D", is_cast(2, sct))
+            wrap(f"To{name}Strict3D", is_cast(3, sct))
+
+            wrap(f"ToJust{name}Strict1D", is_sub(1, sct))
+            wrap(f"ToJust{name}Strict2D", is_sub(2, sct))
+            wrap(f"ToJust{name}Strict3D", is_sub(3, sct))
+
+        for name, sct, co_sct in [
+            ("Int", np.integer, (np.bool,)),
+            ("Float", np.floating, (np.integer, np.bool)),
+            ("Complex", np.complexfloating, (np.integer, np.floating, np.bool)),
+        ]:
+            co_classes = (sct, *co_sct)
+
+            wrap(f"To{name}", is_sub(0, co_classes))
+            wrap(f"To{name}1D", is_sub(1, co_classes))
+            wrap(f"To{name}2D", is_sub(2, co_classes))
+            wrap(f"To{name}3D", is_sub(3, co_classes))
+            wrap(f"To{name}ND", is_sub(None, co_classes))
+
+            wrap(f"ToJust{name}", is_sub(0, sct))
+            wrap(f"ToJust{name}1D", is_sub(1, sct))
+            wrap(f"ToJust{name}2D", is_sub(2, sct))
+            wrap(f"ToJust{name}3D", is_sub(3, sct))
+            wrap(f"ToJust{name}ND", is_sub(None, sct))
+
+            wrap(f"To{name}Strict1D", is_sub(1, co_classes))
+            wrap(f"To{name}Strict2D", is_sub(2, co_classes))
+            wrap(f"To{name}Strict3D", is_sub(3, co_classes))
+
+            wrap(f"ToJust{name}Strict1D", is_sub(1, sct))
+            wrap(f"ToJust{name}Strict2D", is_sub(2, sct))
+            wrap(f"ToJust{name}Strict3D", is_sub(3, sct))
+
+    _install()
+    del _install

--- a/tests/numpy/test_to.py
+++ b/tests/numpy/test_to.py
@@ -1,0 +1,111 @@
+from typing import Annotated, get_args, get_origin
+
+import numpy as np
+import pytest
+from beartype.door import is_bearable
+
+import optype.numpy as onp
+
+_FAMILIES = [
+    ("Bool", np.bool_, np.bool_),
+    ("Int64", np.int64, np.int64),
+    ("Float16", np.float16, np.float16),
+    ("Float32", np.float32, np.float32),
+    ("Float64", np.float64, np.float64),
+    ("LongDouble", np.longdouble, np.longdouble),
+    ("Complex64", np.complex64, np.complex64),
+    ("Complex128", np.complex128, np.complex128),
+    ("CLongDouble", np.clongdouble, np.clongdouble),
+    ("Int", np.integer, (np.integer, np.bool_)),
+    ("Float", np.floating, (np.floating, np.integer, np.bool_)),
+    ("Complex", np.complexfloating, (np.number, np.bool_)),
+]
+
+_NDIMS = [0, 1, 2, 3, None]
+
+_NO_COERCIBLE = {"Int64", "LongDouble", "CLongDouble"}
+
+_VALUES = [
+    True,
+    1,
+    0.5,
+    1j,
+    "",
+    object(),
+    np.int8(1),
+    np.float16(1),
+    np.float64(1),
+    np.longdouble(1),
+    np.complex128(1 + 1j),
+    np.timedelta64(1, "s"),
+    np.array([True, False]),
+    np.array([1.0, 2.0], dtype=np.float32),
+    [[1, 2]],
+    np.array([[[1.0]]], dtype=np.float16),
+]
+
+
+def _alias_name(family: str, nd: int | None, just: bool) -> str:
+    prefix = "Just" if just else ""
+    if nd == 0:
+        return f"To{prefix}{family}"
+    base = f"{family}_" if family[-1].isdigit() else family
+    return f"To{prefix}{base}{'ND' if nd is None else f'{nd}D'}"
+
+
+_ALL_NAMES = [
+    _alias_name(f, nd, j)
+    for f, _, _ in _FAMILIES
+    for nd in _NDIMS
+    for j in (False, True)
+    if j or f not in _NO_COERCIBLE
+] + [
+    f"To{'Just' if j else ''}{f}Strict{nd}D"
+    for f, _, _ in _FAMILIES
+    for nd in (1, 2, 3)
+    for j in (False, True)
+    if j or f not in _NO_COERCIBLE
+]
+
+
+@pytest.mark.parametrize("name", _ALL_NAMES)
+def test_annotated(name: str) -> None:
+    assert get_origin(getattr(onp, name)) is Annotated
+
+
+@pytest.mark.parametrize("just", [False, True], ids=["co", "just"])
+@pytest.mark.parametrize("nd", _NDIMS)
+@pytest.mark.parametrize("value", _VALUES, ids=lambda v: repr(v)[:30])
+@pytest.mark.parametrize(
+    ("family", "just_sct", "co_target"),
+    _FAMILIES,
+    ids=[f[0] for f in _FAMILIES],
+)
+def test_to(  # noqa: PLR0913, PLR0917
+    family: str,
+    just_sct: type[np.generic],
+    co_target: type[np.generic] | tuple[type, ...],
+    value: object,
+    nd: int | None,
+    just: bool,
+) -> None:
+    if not just and family in _NO_COERCIBLE:
+        pytest.skip(f"No coercible To{family}")
+
+    alias = getattr(onp, _alias_name(family, nd, just))
+
+    try:
+        arr = np.asanyarray(value)
+    except (ValueError, TypeError):
+        predicate = False
+    else:
+        target = just_sct if just else co_target
+        if nd is not None and arr.ndim != nd:
+            predicate = False
+        elif just or isinstance(target, tuple):
+            predicate = issubclass(arr.dtype.type, target)
+        else:
+            predicate = bool(np.can_cast(arr.dtype, target))
+
+    plain = get_args(alias)[0]
+    assert is_bearable(value, alias) is (is_bearable(value, plain) and predicate)

--- a/tests/numpy/test_to.py
+++ b/tests/numpy/test_to.py
@@ -73,9 +73,13 @@ def test_annotated(name: str) -> None:
     assert get_origin(getattr(onp, name)) is Annotated
 
 
+def _id(v: object) -> str:
+    return f"np.{type(v).__name__}" if isinstance(v, np.generic) else repr(v)[:30]
+
+
 @pytest.mark.parametrize("just", [False, True], ids=["co", "just"])
 @pytest.mark.parametrize("nd", _NDIMS)
-@pytest.mark.parametrize("value", _VALUES, ids=lambda v: repr(v)[:30])
+@pytest.mark.parametrize("value", _VALUES, ids=_id)
 @pytest.mark.parametrize(
     ("family", "just_sct", "co_target"),
     _FAMILIES,

--- a/tests/numpy/test_to.py
+++ b/tests/numpy/test_to.py
@@ -7,7 +7,7 @@ from beartype.door import is_bearable
 import optype.numpy as onp
 
 _FAMILIES = [
-    ("Bool", np.bool_, np.bool_),
+    ("Bool", np.bool, np.bool),
     ("Int64", np.int64, np.int64),
     ("Float16", np.float16, np.float16),
     ("Float32", np.float32, np.float32),
@@ -16,9 +16,9 @@ _FAMILIES = [
     ("Complex64", np.complex64, np.complex64),
     ("Complex128", np.complex128, np.complex128),
     ("CLongDouble", np.clongdouble, np.clongdouble),
-    ("Int", np.integer, (np.integer, np.bool_)),
-    ("Float", np.floating, (np.floating, np.integer, np.bool_)),
-    ("Complex", np.complexfloating, (np.number, np.bool_)),
+    ("Int", np.integer, (np.integer, np.bool)),
+    ("Float", np.floating, (np.floating, np.integer, np.bool)),
+    ("Complex", np.complexfloating, (np.number, np.bool)),
 ]
 
 _NDIMS = [0, 1, 2, 3, None]


### PR DESCRIPTION
This opens the *door* to awesome runtime type-checking with [beartype](https://github.com/beartype/beartype) for the `optype.numpy.To*` array-like type aliases.

For example:

```pycon
>>> import beartype.door
>>> import optype
>>> beartype.door.is_bearable([1, 2], optype.numpy.ToFloat1D)
True
>>> beartype.door.is_bearable([1, 2], optype.numpy.ToJustFloat1D)
False
>>> beartype.door.is_bearable([[1, 2], [3, 4]], optype.numpy.ToFloat1D)
False
```

Towards #554 (I guess).



