### PR TITLE
`optype infer`: support for direct `def (...): ...` eval

### DIFF
--- a/docs/reference/experimental/infer.md
+++ b/docs/reference/experimental/infer.md
@@ -34,8 +34,8 @@ Pass parameter names or positions to report only those parameters:
 '[T, R](x: CanGetitem[T, R]) -> R'
 ```
 
-The `optype infer` command takes a Python expression; leading statements are allowed, as
-long as the last line is an expression:
+The `optype infer` command takes a Python snippet whose final statement is
+an expression or a `def`/`class` definition; any leading statements run as setup:
 
 ```console
 $ optype infer "lambda x: x * 2"
@@ -81,6 +81,19 @@ Branching and overloads combine:
 $ optype infer "lambda x, y: (x + y) if x else y"
 [T, R](x: CanBool & CanAdd[T, R], y: T) -> R | T
 [T: CanBool, U: CanRAdd[T, R], R](x: T, y: U) -> R | U
+```
+
+## Async
+
+Coroutine functions are run to completion, so `await`, `async with`, and `async for` are
+traced like their synchronous counterparts:
+
+```console
+$ optype infer "async def f(x): return await x"
+[R](x: CanAwait[R]) -> R
+
+$ optype infer "async def f(xs): return [x async for x in xs]"
+[R](xs: CanAIter[CanANext[CanAwait[R]]]) -> list[R]
 ```
 
 ## NumPy

--- a/optype/__main__.py
+++ b/optype/__main__.py
@@ -8,7 +8,7 @@ from optype.infer._cli import run
 def main() -> None:
     match sys.argv[1:]:
         case ["infer", *args]:
-            run(args)
+            run(*args)
         case _:
             sys.exit("usage: optype infer EXPR [PARAM ...]")
 

--- a/optype/infer/__main__.py
+++ b/optype/infer/__main__.py
@@ -5,4 +5,4 @@ import sys
 from optype.infer._cli import run
 
 if __name__ == "__main__":
-    run(sys.argv[1:])
+    run(*sys.argv[1:])

--- a/optype/infer/_cli.py
+++ b/optype/infer/_cli.py
@@ -6,7 +6,7 @@ import sys
 from optype.infer import infer
 
 
-def run(args: list[str]) -> None:
+def run(*args: str) -> None:
     if not args:
         sys.exit("usage: optype infer EXPR [PARAM ...]")
 
@@ -15,8 +15,12 @@ def run(args: list[str]) -> None:
 
     body = ast.parse(source).body
     last = body[-1] if body else None
+    if isinstance(last, ast.FunctionDef | ast.AsyncFunctionDef | ast.ClassDef):
+        # append a reference to the definition so it becomes the final expression
+        body = ast.parse(f"{source}\n{last.name}").body
+        last = body[-1]
     if not isinstance(last, ast.Expr):
-        sys.exit("the final statement must be an expression")
+        sys.exit("the final statement must be an expression or a definition")
 
     namespace: dict[str, object] = {}
     exec(compile(ast.Module(body[:-1], []), "<expr>", "exec"), namespace)  # noqa: S102

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -450,6 +450,15 @@ def test_cli_subcommand() -> None:
     assert out.stdout.strip() == "[R](x: CanMul[Literal[2], R]) -> R"
 
 
+def test_cli_def() -> None:
+    # a trailing def/class is inferred directly, without a closing name reference
+    out = _run_cli("-m", "optype", "infer", "def f(x, y): return x @ y")
+    assert out.returncode == 0
+    assert out.stdout.strip() == (
+        "[T, R](x: CanMatmul[T, R], y: T) -> R\n[T, R](x: T, y: CanRMatmul[T, R]) -> R"
+    )
+
+
 def test_cli_usage() -> None:
     out = _run_cli("-m", "optype")
     assert out.returncode == 1


### PR DESCRIPTION
We can now do stuff like

```console
$ optype infer "async def f(x): return await x"
[R](x: CanAwait[R]) -> R
```