### PR TITLE
`optype infer`: support for `*args` and `**kwargs`

### DIFF
--- a/docs/reference/experimental/infer.md
+++ b/docs/reference/experimental/infer.md
@@ -83,6 +83,31 @@ $ optype infer "lambda x, y: (x + y) if x else y"
 [T: CanBool, U: CanRAdd[T, R], R](x: T, y: U) -> R | U
 ```
 
+## Variadic parameters
+
+A `*args` parameter that is only passed around as a whole is inferred as a
+[PEP 646](https://peps.python.org/pep-0646/) `TypeVarTuple`:
+
+```console
+$ optype infer "lambda *args: args"
+[*Ts](*args: *Ts) -> tuple[*Ts]
+
+$ optype infer "lambda *args: (1, *args)"
+[*Ts](*args: *Ts) -> tuple[Literal[1], *Ts]
+```
+
+Operating on individual elements is not expressible with a `TypeVarTuple`, so the
+elements then share a single inferred element type, as does every value of `**kwargs`:
+
+```console
+$ optype infer "lambda *args: args[0] + args[1]"
+[T: CanAdd[T, R], R](*args: T) -> R
+[T: CanRAdd[T, R], R](*args: T) -> R
+
+$ optype infer "lambda **kwargs: kwargs"
+[T](**kwargs: T) -> dict[str, T]
+```
+
 ## Async
 
 Coroutine functions are run to completion, so `await`, `async with`, and `async for` are
@@ -172,9 +197,14 @@ $ optype infer "import numpy as np; np.mean"
 placeholder arguments (no real side effects, no reliance on concrete values).
 
 When `infer` can't handle the input, it raises `InferError` (a `NotImplementedError`
-subclass). That's the case for variadic parameters, operations without a matching
-protocol, and arguments that aren't callable to begin with. Exceptions raised from
-within the function itself aren't caught.
+subclass). That's the case for operations without a matching protocol, and for
+arguments that aren't callable to begin with. Exceptions raised from within the
+function itself aren't caught.
+
+Variadic parameters are explored with a few placeholders, retried with more after an
+out-of-range index, a failed unpacking, or a missing `**kwargs` key, and reported as an
+`InferError` once the budget runs out. The placeholders remain observable: `len(args)`
+reports their count, and `args` and `kwargs` are never empty.
 
 The number of explored branches is capped, so a function with many of them gets a
 signature that only covers the explored ones, along with an `InferWarning`.

--- a/optype/infer/__init__.py
+++ b/optype/infer/__init__.py
@@ -7,15 +7,21 @@ from collections.abc import (
     AsyncGenerator,
     Callable,
     Collection,
-    Container,
     Coroutine,
     Generator,
     Iterable,
     Mapping,
     Sequence,
 )
-from inspect import Parameter, isasyncgen, iscoroutine, isgenerator, signature
-from itertools import islice
+from inspect import (
+    Parameter,
+    _ParameterKind,
+    isasyncgen,
+    iscoroutine,
+    isgenerator,
+    signature,
+)
+from itertools import groupby, islice
 from typing import Any, NamedTuple, cast, final, overload
 
 from . import _ir, _numpy
@@ -45,9 +51,13 @@ class InferWarning(RuntimeWarning):
     """Emitted when `infer` could not explore the function exhaustively."""
 
 
-_PARAM_VAR = frozenset({Parameter.VAR_POSITIONAL, Parameter.VAR_KEYWORD})
+_PARAM_PREFIX: dict[_ParameterKind, str] = {
+    Parameter.VAR_POSITIONAL: "*",
+    Parameter.VAR_KEYWORD: "**",
+}
 
 _TYPEVARS = "TUVWXYZ"
+_TYPEVAR_TUPLE = "*Ts"
 _NEVER = "Never"
 _OBJECT = "object"
 
@@ -105,6 +115,10 @@ _RE_DOC_PARAM = re.compile(r"(?:^|,)\s*\**([a-zA-Z_]\w*)")
 _FORK_LIMIT = 64
 _RUN_LIMIT = 256
 _YIELD_LIMIT = 64
+# the `*args` placeholder counts to try: exact arities first, then doubling so that
+# large indices stay within reach
+_VARIADIC_COUNTS = (2, 3, 4, 5, 6, 7, 8, 16, 32, 64, 128, 256, 512, 1024)
+_KWARGS_LIMIT = 8  # max injected `**kwargs` keys
 
 
 type _Vars = dict[int, str]
@@ -226,6 +240,66 @@ def _select(params: Iterable[str | int], names: Sequence[str]) -> Sequence[str]:
     return selected or names
 
 
+def _spy_runs(items: Iterable[object], spy: _SpyObject) -> list[int]:
+    """Lengths of each consecutive run of `spy` within `items`."""
+    groups = groupby(items, key=lambda item: item is spy)
+    return [sum(1 for _ in group) for is_spy, group in groups if is_spy]
+
+
+def _packed_uses(value: object, spy: _SpyObject, count: int) -> Generator[bool]:
+    # yields each use of `spy`: True if packed (one full placeholder run in a tuple)
+    items: Iterable[object]
+    match value:
+        case _SpyObject():
+            if value is spy:
+                yield False
+            return
+        case _Gen():
+            items = value.yielded
+        case tuple():
+            tup = cast("tuple[object, ...]", value)
+            if runs := _spy_runs(tup, spy):
+                yield runs == [count]
+            items = (item for item in tup if item is not spy)
+        case list() | set() | frozenset():
+            items = cast("Collection[object]", value)
+        case dict():
+            mapping = cast("Mapping[object, object]", value)
+            items = (*mapping, *mapping.values())
+        case _:
+            return
+    for item in items:
+        yield from _packed_uses(item, spy, count)
+
+
+def _all_packed(
+    spy: _SpyObject,
+    results: Iterable[object],
+    traces: _Traces,
+    count: int,
+) -> bool:
+    """Whether `spy` is used at least once, but only ever packed.
+
+    PEP 646 cannot express bare element uses, and traces on `spy` are operations on its
+    elements, so a variadic parameter renders as a `TypeVarTuple` only when this holds.
+    """
+    if traces[id(spy)]:
+        return False
+
+    trace_values = (
+        value
+        for items in traces.values()
+        for item in items
+        for value in (*item.args, *item.kwargs.values())
+    )
+    uses = [
+        use
+        for value in (*results, *trace_values)
+        for use in _packed_uses(value, spy, count)
+    ]
+    return bool(uses) and all(uses)
+
+
 def _return_spies(value: object) -> Generator[_SpyObject]:
     match value:
         case _SpyObject():
@@ -251,23 +325,39 @@ class _Renderer:
 
     def __init__(
         self,
-        selected: Sequence[str],
         spies: Mapping[str, _SpyObject],
         results: Sequence[object],
-        optional: Container[str],
+        parameters: Mapping[str, Parameter],
+        count: int,
         traces: _Traces,
     ) -> None:
-        self._selected = selected
         self._spies = spies
         self._results = results
-        self._optional = optional
         self._traces = traces
+
+        self._prefix = {n: _PARAM_PREFIX.get(p.kind, "") for n, p in parameters.items()}
+        self._optional = {
+            name
+            for name, p in parameters.items()
+            if p.default is not Parameter.empty or p.kind in _PARAM_PREFIX
+        }
+        self._varpos = next(
+            (
+                spies[name]
+                for name, p in parameters.items()
+                if p.kind is Parameter.VAR_POSITIONAL
+            ),
+            None,
+        )
 
         param_spies = list(spies.values())
         order, appear = _analyze(param_spies, results, traces)
         param_ids = {id(spy) for spy in param_spies}
 
         self._vars: _Vars = {}
+        varpos = self._varpos
+        if varpos is not None and _all_packed(varpos, results, traces, count):
+            self._vars[id(varpos)] = _TYPEVAR_TUPLE
         self._result_spies: list[_SpyObject] = []
         ret_keys, arg_ids = _ret_keys(order, traces)
         shared: dict[_RetKey, str] = {}
@@ -291,7 +381,9 @@ class _Renderer:
                 self._result_spies.append(spy)
                 if key is not None:
                     shared[key] = var
-        self._pool = [spy for spy in param_spies if appear[id(spy)] >= 2]
+        self._pool = [
+            spy for spy in param_spies if appear[id(spy)] >= 2 or id(spy) in self._vars
+        ]
         self._pool += [
             spy
             for spy in order
@@ -299,7 +391,8 @@ class _Renderer:
             and id(spy) not in param_ids
             and id(spy) not in self._vars
         ]
-        for i, spy in enumerate(self._pool):
+        unnamed = [spy for spy in self._pool if id(spy) not in self._vars]
+        for i, spy in enumerate(unnamed):
             self._vars[id(spy)] = _TYPEVARS[i] if i < len(_TYPEVARS) else f"T{i}"
 
     def union(self, values: Iterable[object]) -> _ir.Node | None:
@@ -407,22 +500,40 @@ class _Renderer:
             case tuple() if cls is tuple:
                 if not result:
                     return _ir.Name("tuple[()]")
-                items = cast("tuple[object, ...]", result)
-                elems = (self.union((item,)) or _ir.Name(_NEVER) for item in items)
-                return _ir.App("tuple", tuple(elems))
+                return self._tuple(cast("tuple[object, ...]", result))
             case _:
                 return _ir.Type(cls)
+
+    def _tuple(self, items: tuple[object, ...]) -> _ir.Node:
+        spy = self._varpos
+        if spy is not None and any(item is spy for item in items):
+            if self._vars.get(id(spy)) == _TYPEVAR_TUPLE:
+                # every use is packed, so the placeholders splat into a single `*Ts`
+                start = next(i for i, item in enumerate(items) if item is spy)
+                parts = [
+                    self.union((item,)) or _ir.Name(_NEVER)
+                    for item in items
+                    if item is not spy
+                ]
+                parts.insert(start, _ir.Name(_TYPEVAR_TUPLE))
+                return _ir.App("tuple", tuple(parts))
+
+            if all(item is spy for item in items):
+                return _ir.App("tuple", (self.return_type(spy), _ir.Name("...")))
+
+        elems = (self.union((item,)) or _ir.Name(_NEVER) for item in items)
+        return _ir.App("tuple", tuple(elems))
 
     def return_types(self) -> str:
         node = _ir.union(dict.fromkeys(map(self.return_type, self._results)))
         return _ir.render(node) if node is not None else _NEVER
 
-    def render(self) -> str:
+    def render(self, selected: Sequence[str]) -> str:
         typevars = [self.typevar(spy) for spy in self._pool + self._result_spies]
         generics = f"[{', '.join(typevars)}]" if typevars else ""
         params = ", ".join(
-            f"{name}: {slot}"
-            for name in self._selected
+            f"{self._prefix[name]}{name}: {slot}"
+            for name in selected
             if (slot := self.slot(self._spies[name])) != _OBJECT
             or name not in self._optional
         )
@@ -552,6 +663,65 @@ def _explore[T](
     return results
 
 
+def _placeholders(
+    parameters: Mapping[str, Parameter],
+    count: int,
+    keys: Sequence[str],
+) -> tuple[dict[str, _SpyObject], list[_SpyObject], dict[str, _SpyObject]]:
+    """One spy per parameter, distributed over the call's `args` and `kwds`."""
+    spies = {name: _SpyObject() for name in parameters}
+    args: list[_SpyObject] = []
+    kwds: dict[str, _SpyObject] = {}
+    for name, param in parameters.items():
+        match param.kind:
+            case Parameter.VAR_POSITIONAL:
+                args += [spies[name]] * count
+            case Parameter.VAR_KEYWORD:
+                kwds |= dict.fromkeys(map(_SpyStr, keys or ("",)), spies[name])
+            case Parameter.KEYWORD_ONLY:
+                kwds[name] = spies[name]
+            case _:
+                args.append(spies[name])
+    return spies, args, kwds
+
+
+def _explore_spies(
+    func: _AnyFunc,
+    parameters: Mapping[str, Parameter],
+) -> tuple[dict[str, _SpyObject], list[object], int]:
+    # explore with fresh spies, retrying when the variadic placeholders come up short:
+    # an out-of-range index, a failed unpacking, or a missing `**kwargs` key
+    kinds = {p.kind for p in parameters.values()}
+    counts = iter(_VARIADIC_COUNTS)
+    count = next(counts)
+    keys: list[str] = []
+    while True:
+        spies, args, kwds = _placeholders(parameters, count, keys)
+        try:
+            results: list[object] = [_next(r) for r in _explore(func, args, kwds)]
+        except KeyError as exc:
+            key = exc.args[0] if exc.args else None
+            if (
+                Parameter.VAR_KEYWORD not in kinds
+                or not isinstance(key, str)
+                or key in keys
+                or key in parameters
+            ):
+                raise
+            if len(keys) >= _KWARGS_LIMIT:
+                msg = f"ran out of `**kwargs` placeholder keys ({exc})"
+                raise InferError(msg) from exc
+            keys.append(key)
+        except (IndexError, TypeError, ValueError) as exc:
+            if Parameter.VAR_POSITIONAL not in kinds:
+                raise
+            if (count := next(counts, 0)) == 0:
+                msg = f"ran out of `*args` placeholders ({exc})"
+                raise InferError(msg) from exc
+        else:
+            return spies, results, count
+
+
 def infer(func: _AnyFunc, /, *params: str | int) -> str:
     """Infer the `optype` protocol(s) required of `func`'s parameters.
 
@@ -561,36 +731,21 @@ def infer(func: _AnyFunc, /, *params: str | int) -> str:
     [R](x: CanAdd[Literal[1], R]) -> R
 
     Raises:
-        InferError: If `func` is not supported, such as a non-callable, variadic
-            parameters, or an operation without a matching protocol.
-    """
+        InferError: If `func` is not supported, such as a non-callable, or an
+            operation without a matching protocol.
+    """  # noqa: DOC502
     if nin := _numpy.ufunc_nin(func):
         names = _numpy.ufunc_params(nin)
         return _numpy.infer_ufunc(func, names, _select(params, names))
 
     parameters = _parameters(func)
-    if any(p.kind in _PARAM_VAR for p in parameters.values()):
-        raise InferError("variadic parameters")
+    selected = _select(params, list(parameters))
+    spies, results, count = _explore_spies(func, parameters)
 
-    names = list(parameters)
-    selected = _select(params, names)
-    optional = frozenset(
-        name for name, p in parameters.items() if p.default is not Parameter.empty
-    )
-
-    spies = {name: _SpyObject() for name in names}
-    args: list[_SpyObject] = []
-    kwds: dict[str, _SpyObject] = {}
-    for name, param in parameters.items():
-        if param.kind is Parameter.KEYWORD_ONLY:
-            kwds[name] = spies[name]
-        else:
-            args.append(spies[name])
-    results: list[object] = [_next(r) for r in _explore(func, args, kwds)]
     param_spies = list(spies.values())
     traces = _snapshot(param_spies)
     reflected = _reflect(param_spies, results, traces)
 
-    sig1 = _Renderer(selected, spies, results, optional, traces).render()
-    sig2 = _Renderer(selected, spies, results, optional, reflected).render()
+    sig1 = _Renderer(spies, results, parameters, count, traces).render(selected)
+    sig2 = _Renderer(spies, results, parameters, count, reflected).render(selected)
     return "\n".join(dict.fromkeys((sig1, sig2)))

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -260,7 +260,85 @@ BINARY_CASES: list[tuple[Callable[[Any, Any], Any], str]] = [
 ]
 
 
-INFER_CASES = [*UNARY_CASES, *BINARY_CASES]
+def _unused_args(x: Any, *_args: Any) -> Any:
+    return x + 1
+
+
+def _call_packed(x: Any, *args: Any) -> Any:
+    return x(args)
+
+
+def _prepend(x: Any, *args: Any) -> Any:
+    return (x, *args)
+
+
+def _unpack3(*args: Any) -> Any:
+    _a, b, _c = args
+    return b
+
+
+def _takes3(a: Any, _b: Any, _c: Any, /) -> Any:
+    return a
+
+
+def _spread(*args: Any) -> Any:
+    return _takes3(*args)
+
+
+def _kwargs_key(**kwargs: Any) -> Any:
+    return kwargs["key"]
+
+
+def _var_kwargs(**kwargs: Any) -> Any:
+    return kwargs
+
+
+def _sum_kwargs(**kwargs: Any) -> Any:
+    return sum(kwargs.values())
+
+
+VARIADIC_CASES: list[tuple[Callable[..., Any], str]] = [
+    # a variadic parameter whose every use is packed becomes a TypeVarTuple
+    (lambda *args: args, "[*Ts](*args: *Ts) -> tuple[*Ts]"),
+    (lambda *args: (args, 1), "[*Ts](*args: *Ts) -> tuple[tuple[*Ts], Literal[1]]"),
+    (_call_packed, "[*Ts, R](x: CanCall[tuple[*Ts], R], *args: *Ts) -> R"),
+    # a splat splices the TypeVarTuple into the surrounding tuple
+    (lambda *args: (1, *args), "[*Ts](*args: *Ts) -> tuple[Literal[1], *Ts]"),
+    (
+        lambda *args: (1, *args, 2),
+        "[*Ts](*args: *Ts) -> tuple[Literal[1], *Ts, Literal[2]]",
+    ),
+    (_prepend, "[T, *Ts](x: T, *args: *Ts) -> tuple[T, *Ts]"),
+    # a bare element use is inexpressible with a TypeVarTuple, so all elements
+    # share a single element type instead
+    (lambda *args: list(args), "[T](*args: T) -> list[T]"),
+    (lambda *args: args[0], "[T](*args: T) -> T"),
+    # too few placeholders are retried with more, until the call succeeds
+    (lambda *args: args[2], "[T](*args: T) -> T"),
+    (lambda *args: args[100], "[T](*args: T) -> T"),
+    (_unpack3, "[T](*args: T) -> T"),
+    (_spread, "[T](*args: T) -> T"),
+    # a missing `**kwargs` key is injected and retried
+    (_kwargs_key, "[T](**kwargs: T) -> T"),
+    (lambda *args: (args[0], *args), "[T](*args: T) -> tuple[T, ...]"),
+    (
+        lambda *args: args[0] + args[1],
+        "[T: CanAdd[T, R], R](*args: T) -> R\n[T: CanRAdd[T, R], R](*args: T) -> R",
+    ),
+    (
+        lambda *args: [a + 1 for a in args],
+        "[R](*args: CanAdd[Literal[1], R]) -> list[R]",
+    ),
+    # an unused variadic parameter is dropped, like an unused default
+    (_unused_args, "[R](x: CanAdd[Literal[1], R]) -> R"),
+    # the fixed placeholder count leaks through `len`
+    (lambda *args: (args[0], len(args)), "[T](*args: T) -> tuple[T, Literal[2]]"),
+    (_var_kwargs, "[T](**kwargs: T) -> dict[str, T]"),
+    (_sum_kwargs, "[R](**kwargs: CanRAdd[Literal[0], R]) -> R"),
+]
+
+
+INFER_CASES = [*UNARY_CASES, *BINARY_CASES, *VARIADIC_CASES]
 
 
 @pytest.mark.parametrize(
@@ -542,18 +620,20 @@ def test_unknown_param(selector: str | int) -> None:
         infer(abs, selector)
 
 
-def _var_args(*args: Any) -> Any:
-    return args
+def test_variadic_exhausted() -> None:
+    # placeholder growth is bounded; running out reports cleanly
+    with pytest.raises(InferError, match="placeholder"):
+        infer(lambda *args: args[10_000])
 
 
-def _var_kwargs(**kwargs: Any) -> Any:
-    return kwargs
+def test_variadic_mixed() -> None:
+    def f(x: Any, *args: Any, **kwargs: Any) -> Any:
+        return (x, args, kwargs)
 
-
-@pytest.mark.parametrize("func", [_var_args, _var_kwargs], ids=["args", "kwargs"])
-def test_variadic(func: Callable[..., Any]) -> None:
-    with pytest.raises(NotImplementedError):
-        infer(func)
+    assert infer(f) == (
+        "[T, *Ts, U](x: T, *args: *Ts, **kwargs: U)"
+        " -> tuple[T, tuple[*Ts], dict[str, U]]"
+    )
 
 
 def test_fork_explosion() -> None:
@@ -654,6 +734,12 @@ def test_cli_def() -> None:
     assert out.stdout.strip() == (
         "[T, R](x: CanMatmul[T, R], y: T) -> R\n[T, R](x: T, y: CanRMatmul[T, R]) -> R"
     )
+
+
+def test_cli_variadic() -> None:
+    out = _run_cli("-m", "optype", "infer", "lambda *args: args")
+    assert out.returncode == 0
+    assert out.stdout.strip() == "[*Ts](*args: *Ts) -> tuple[*Ts]"
 
 
 def test_cli_usage() -> None:


### PR DESCRIPTION
closes #626

```bash
$ optype infer "lambda *args: (1, *args)"
[*Ts](*args: *Ts) -> tuple[Literal[1], *Ts]

$ optype infer "lambda *args: args[100]"
[T](*args: T) -> T

$ optype infer "lambda **kw: kw"
[T](**kw: T) -> dict[str, T]
```