### PR TITLE
`optype infer`: avoid redundant `& CanLen`

### DIFF
--- a/docs/reference/experimental/infer.md
+++ b/docs/reference/experimental/infer.md
@@ -23,8 +23,9 @@ the result as a [PEP 695](https://peps.python.org/pep-0695/) signature.
 >>> from optype.infer import infer
 >>> infer(lambda x: x + 1)
 '[R](x: CanAdd[Literal[1], R]) -> R'
->>> infer(list)
-'[R](iterable: CanIter[CanNext[R]] & CanLen) -> list[R]'
+>>> print(infer(list))
+(iterable: tuple[()] = ...) -> list[Never]
+[R](iterable: CanIter[CanNext[R]] & ~tuple[()]) -> list[R]
 ```
 
 Pass parameter names or positions to report only those parameters:

--- a/optype/infer/__init__.py
+++ b/optype/infer/__init__.py
@@ -26,6 +26,8 @@ from typing import Any, NamedTuple, cast, final, overload
 
 from . import _ir, _numpy
 from ._spy import (
+    _ABSENT,
+    _AbsentError,
     _AnyFunc,
     _Args,
     _Fork,
@@ -166,19 +168,26 @@ def _resolve(trace: _TraceItem) -> _Op:
     raise InferError(msg)
 
 
-def _snapshot(params: Iterable[_SpyObject]) -> _Traces:
-    """Capture the traces of every spy reachable from `params`."""
-    traces: _Traces = {}
+def _reachable(params: Iterable[_SpyObject]) -> Generator[_SpyObject]:
+    # every spy reachable from `params` through the recorded operations
+    seen: set[int] = set()
     stack = list(params)
     while stack:
         spy = stack.pop()
-        if id(spy) in traces:
+        if id(spy) in seen:
             continue
-        items = traces[id(spy)] = list(spy.__optype_trace__)
+        seen.add(id(spy))
+        yield spy
         stack.extend(
-            ret for item in items if isinstance(ret := item.return_, _SpyObject)
+            ret
+            for item in spy.__optype_trace__
+            if isinstance(ret := item.return_, _SpyObject)
         )
-    return traces
+
+
+def _snapshot(params: Iterable[_SpyObject]) -> _Traces:
+    """Capture the traces of every spy reachable from `params`."""
+    return {id(spy): list(spy.__optype_trace__) for spy in _reachable(params)}
 
 
 def _analyze(
@@ -462,8 +471,13 @@ class _Renderer:
         return _ir.App(proto, tuple(args))
 
     def traces(self, items: Iterable[_TraceItem]) -> _ir.Node | None:
+        items = list(items)
+        # a surviving absence marker proves the dunder was only probed optionally
+        optional = {item.args[0] for item in items if item.attr == _ABSENT}
         groups: dict[tuple[_Proto, int, tuple[str, ...]], list[_Op]] = {}
         for item in items:
+            if item.attr == _ABSENT or item.attr in optional:
+                continue
             op = _resolve(item)
             key = op.proto, len(op.args), tuple(sorted(op.kwargs))
             groups.setdefault(key, []).append(op)
@@ -702,6 +716,10 @@ def _explore[T](
         if not stack:
             break
         plan = stack.pop()
+        marks = [
+            (spy, len(spy.__optype_trace__))
+            for spy in _reachable((*args, *kwds.values()))
+        ]
         token = _fork.set(iter(plan))
         try:
             result = func(*args, **kwds)
@@ -711,6 +729,10 @@ def _explore[T](
                 stack.extend(([*plan, False], [*plan, True]))
             else:
                 dropped = True
+        except _AbsentError:
+            # the dunder is genuinely needed, so this run (and its marker) never was
+            for spy, length in marks:
+                del spy.__optype_trace__[length:]
         finally:
             _fork.reset(token)
     if not results:

--- a/optype/infer/_spy.py
+++ b/optype/infer/_spy.py
@@ -14,6 +14,12 @@ type _Kwargs = dict[str, object]
 class _Fork(BaseException): ...
 
 
+class _AbsentError(TypeError):
+    """A simulated missing dunder; subclasses `TypeError` so probes suppress it."""
+
+
+_ABSENT = "__absent__"  # the trace marker of a simulated-missing dunder
+
 _fork: ContextVar[Iterator[bool] | None] = ContextVar("_fork", default=None)
 
 
@@ -168,8 +174,11 @@ class _SpyObject(_Spy):  # noqa: PLR0904
     ###
 
     def __len__(self, /) -> int:
-        # TODO: over-recorded as required when probed optionally (e.g. `list()` via
-        # `length_hint`); detect optional protocols by forking value-vs-raise
+        # `len()` is often probed optionally (e.g. `list()` via `length_hint`), so
+        # also fork on its presence; the absent branch raises like a missing dunder
+        if not _decide():
+            self.__optype_trace_add__(_ABSENT, ("__len__",), {}, None)
+            raise _AbsentError
         return self.__optype_trace_add__("__len__", (), {}, _decide())
 
     # no need for `__length_hint__`

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -39,9 +39,11 @@ UNARY_CASES: list[tuple[Callable[[Any], Any], str]] = [
         list,
         (
             "(iterable: tuple[()] = ...) -> list[Never]\n"
-            "[R](iterable: CanIter[CanNext[R]] & CanLen & ~tuple[()]) -> list[R]"
+            "[R](iterable: CanIter[CanNext[R]] & ~tuple[()]) -> list[R]"
         ),
     ),
+    # `list()` probes `__len__` optionally via `length_hint`, so it is no requirement
+    (lambda x: list(x), "[R](x: CanIter[CanNext[R]]) -> list[R]"),  # noqa: PLW0108
     (math.sqrt, "(x: CanFloat | CanIndex) -> float"),
     (lambda x: int(x), "(x: CanInt | CanIndex) -> int"),  # noqa: PLW0108
     (lambda x: complex(x), "(x: CanComplex | CanFloat | CanIndex) -> complex"),  # noqa: PLW0108


### PR DESCRIPTION
before:

```console
$ optype infer "list"
(iterable: tuple[()] = ...) -> list[Never]
[R](iterable: CanIter[CanNext[R]] & CanLen & ~tuple[()]) -> list[R]
```

after:

```console
$ optype infer "list"
(iterable: tuple[()] = ...) -> list[Never]
[R](iterable: CanIter[CanNext[R]] & ~tuple[()]) -> list[R]
```