### PR TITLE
`optype infer`: method descriptors

### DIFF
--- a/optype/infer/.ruff.toml
+++ b/optype/infer/.ruff.toml
@@ -1,0 +1,15 @@
+extend = "../../pyproject.toml"
+cache-dir = "../../.ruff_cache"
+
+[lint.per-file-ignores]
+"_api.py" = ["PLR0402"]
+"_cli.py" = ["S102", "S307", "T201"]
+"_render.py" = ["PLR0402"]
+"_spy.py" = ["TD002", "TD003", "PYI034", "PLR0904"]
+
+[lint.pylint]
+allow-dunder-method-names = [
+  "__array_function__",
+  "__array_ufunc__",
+  "__optype_trace_add__",
+]

--- a/optype/infer/_api.py
+++ b/optype/infer/_api.py
@@ -5,8 +5,9 @@ from inspect import Parameter
 from typing import cast
 
 # `from . import` would import the package itself, which imports this module
-import optype.infer._numpy as _numpy  # noqa: PLR0402
-from ._explore import _explore_spies, _Gen, _parameters, _Recon
+import optype.infer._numpy as _numpy
+from ._errors import InferError
+from ._explore import _explore_lenient, _explore_spies, _Gen, _parameters, _Recon
 from ._render import _Defaults, _Names, _signatures
 from ._spy import _AnyFunc, _TraceItem
 
@@ -53,7 +54,7 @@ def _bind(value: object, binding: Mapping[int, object]) -> object:
 
 def _bind_recon(recon: _Recon, defaults: _Defaults) -> _Recon:
     """The recon as it would look with every defaulted parameter omitted."""
-    spies, traces, results, count = recon
+    spies, traces, results, count, fixed = recon
     binding = {id(spies[name]): value for name, value in defaults.items()}
     bound = {
         spy_id: [
@@ -68,7 +69,7 @@ def _bind_recon(recon: _Recon, defaults: _Defaults) -> _Recon:
         for spy_id, items in traces.items()
     }
     kept = {name: spy for name, spy in spies.items() if name not in defaults}
-    return kept, bound, [_bind(result, binding) for result in results], count
+    return kept, bound, [_bind(result, binding) for result in results], count, fixed
 
 
 def _defaults(
@@ -130,16 +131,24 @@ def infer(func: _AnyFunc, /, *params: str | int) -> str:
     [R](x: CanAdd[Literal[1], R]) -> R
 
     Raises:
-        InferError: If `func` is not supported, such as a non-callable, or an
-            operation without a matching protocol.
-    """  # noqa: DOC502
+        InferError: If `func` is not supported, such as a non-callable, an
+            operation without a matching protocol, or a parameter that requires
+            a value that no placeholder can provide.
+    """
     if nin := _numpy.ufunc_nin(func):
         names = _numpy.ufunc_params(nin)
         return _numpy.infer_ufunc(func, names, _select(params, names))
 
     parameters = _parameters(func)
     selected = _select(params, list(parameters))
-    recon = _explore_spies(func, parameters)
+    try:
+        recon, fallback = _explore_lenient(func, parameters)
+    except (IndexError, TypeError, ValueError) as exc:
+        raise InferError(str(exc)) from exc
+    if fallback:
+        # the rejected parameters render from their defaults; skip the probing
+        lines = _signatures(recon, parameters, selected, fallback)
+        return "\n".join(dict.fromkeys(lines))
     defaults, negate, overloads = _defaults(func, parameters, selected, recon)
     lines = _signatures(recon, parameters, selected, defaults, negate=negate)
     return "\n".join(dict.fromkeys((*overloads, *lines)))

--- a/optype/infer/_cli.py
+++ b/optype/infer/_cli.py
@@ -23,9 +23,9 @@ def run(*args: str) -> None:
         sys.exit("the final statement must be an expression or a definition")
 
     namespace: dict[str, object] = {}
-    exec(compile(ast.Module(body[:-1], []), "<expr>", "exec"), namespace)  # noqa: S102
+    exec(compile(ast.Module(body[:-1], []), "<expr>", "exec"), namespace)
     code = compile(ast.Expression(last.value), "<expr>", "eval")
     try:
-        print(infer(eval(code, namespace), *params))  # noqa: S307, T201
+        print(infer(eval(code, namespace), *params))
     except (InferError, ValueError) as exc:
         sys.exit(f"{type(exc).__name__}: {exc}")

--- a/optype/infer/_explore.py
+++ b/optype/infer/_explore.py
@@ -12,8 +12,10 @@ from collections.abc import (
     Mapping,
     Sequence,
 )
+from contextlib import suppress
 from inspect import Parameter, isasyncgen, iscoroutine, isgenerator, signature
 from itertools import islice
+from types import MethodDescriptorType, WrapperDescriptorType
 from typing import Any, NamedTuple, cast, overload
 
 from ._errors import InferError, InferWarning
@@ -27,7 +29,15 @@ from ._spy import (
     _TraceItem,
 )
 
-__all__ = ("_Gen", "_Recon", "_Traces", "_doc_params", "_explore_spies", "_parameters")
+__all__ = (
+    "_Gen",
+    "_Recon",
+    "_Traces",
+    "_doc_params",
+    "_explore_lenient",
+    "_explore_spies",
+    "_parameters",
+)
 
 _RE_DOC_SIGNATURE = re.compile(r"\b(\w+)\(([^)]*)\)")
 _RE_DOC_PARAM = re.compile(r"(?:^|,)\s*\**([a-zA-Z_]\w*)")
@@ -42,8 +52,15 @@ _KWARGS_LIMIT = 8  # max injected `**kwargs` keys
 
 type _Traces = dict[int, list[_TraceItem]]
 
-# the spies, their traces, the results, and the `*args` placeholder count
-type _Recon = tuple[Mapping[str, _SpyObject], _Traces, list[object], int]
+# the spies, their traces, the results, the `*args` placeholder count, and the fixed
+# parameter values (passed as-is instead of a spy)
+type _Recon = tuple[
+    Mapping[str, _SpyObject],
+    _Traces,
+    list[object],
+    int,
+    Mapping[str, object],
+]
 
 
 class _Gen(NamedTuple):
@@ -55,13 +72,12 @@ class _Gen(NamedTuple):
         return "AsyncGenerator" if self.is_async else "Generator"
 
 
-def _reachable(params: Iterable[_SpyObject]) -> Generator[_SpyObject]:
+def _reachable(params: Iterable[object]) -> Generator[_SpyObject]:
     # every spy reachable from `params` through the recorded operations
     seen: set[int] = set()
-    stack = list(params)
+    stack = [spy for spy in params if isinstance(spy, _SpyObject)]
     while stack:
-        spy = stack.pop()
-        if id(spy) in seen:
+        if id(spy := stack.pop()) in seen:
             continue
         seen.add(id(spy))
         yield spy
@@ -150,8 +166,8 @@ def _next(result: object) -> object:
 
 def _explore[T](
     func: Callable[..., T] | Callable[..., Coroutine[Any, None, T]],
-    args: Sequence[_SpyObject],
-    kwds: Mapping[str, _SpyObject],
+    args: Sequence[object],
+    kwds: Mapping[str, object],
 ) -> list[T]:
     results: list[T] = []
     stack: list[list[bool]] = [[]]
@@ -186,35 +202,52 @@ def _explore[T](
     return results
 
 
+def _fixed_self(func: _AnyFunc, params: Mapping[str, Parameter]) -> dict[str, object]:
+    if not isinstance(func, MethodDescriptorType | WrapperDescriptorType) or not params:
+        return {}
+    cls = func.__objclass__
+    # a spy argument satisfies constructors that need a buffer/index/iterable/...
+    for args in ((), (_SpyObject(),)):
+        with suppress(Exception):
+            return {next(iter(params)): cls(*args)}
+    msg = f"cannot instantiate {cls.__name__!r} for {func.__qualname__!r}"
+    raise InferError(msg)
+
+
 def _placeholders(
     params: Mapping[str, Parameter],
     count: int,
     keys: Sequence[str],
-    omit: Collection[str] = (),
-) -> tuple[dict[str, _SpyObject], list[_SpyObject], dict[str, _SpyObject]]:
-    # one spy per non-omitted parameter, distributed over the call's args and kwds
-    spies = {name: _SpyObject() for name in params if name not in omit}
-    args: list[_SpyObject] = []
-    kwds: dict[str, _SpyObject] = {}
+    omit: Collection[str],
+    fixed: Mapping[str, object],
+) -> tuple[dict[str, _SpyObject], list[object], dict[str, object]]:
+    # one spy per non-omitted, non-fixed parameter, distributed over the call's
+    # args and kwds
+    spies = {
+        name: _SpyObject() for name in params if name not in omit and name not in fixed
+    }
+    args: list[object] = []
+    kwds: dict[str, object] = {}
     gap = False  # a positional parameter after an omitted one must pass by keyword
     for name, param in params.items():
         if name in omit:
             gap = gap or param.kind is not Parameter.KEYWORD_ONLY
             continue
+        value = fixed[name] if name in fixed else spies[name]
         match param.kind:
             case Parameter.VAR_POSITIONAL:
-                args += [spies[name]] * count
+                args += [value] * count
             case Parameter.VAR_KEYWORD:
-                kwds |= dict.fromkeys(map(_SpyStr, keys or ("",)), spies[name])
+                kwds |= dict.fromkeys(map(_SpyStr, keys or ("",)), value)
             case Parameter.KEYWORD_ONLY:
-                kwds[name] = spies[name]
+                kwds[name] = value
             case Parameter.POSITIONAL_ONLY if gap:
                 msg = f"cannot pass {name!r} by keyword"
                 raise InferError(msg)
             case _ if gap:
-                kwds[name] = spies[name]
+                kwds[name] = value
             case _:
-                args.append(spies[name])
+                args.append(value)
     return spies, args, kwds
 
 
@@ -222,6 +255,7 @@ def _explore_spies(
     func: _AnyFunc,
     params: Mapping[str, Parameter],
     omit: Collection[str] = (),
+    fix: Collection[str] = (),
 ) -> _Recon:
     # rerun with fresh spies whenever the variadic placeholders come up short
     kinds = {p.kind for p in params.values()}
@@ -229,7 +263,9 @@ def _explore_spies(
     count = next(counts)
     keys: list[str] = []
     while True:
-        spies, args, kwds = _placeholders(params, count, keys, omit)
+        # a fresh `self` instance per attempt, so a mutated one cannot leak
+        fixed = _fixed_self(func, params) | {n: params[n].default for n in fix}
+        spies, args, kwds = _placeholders(params, count, keys, omit, fixed)
         try:
             results: list[object] = [_next(r) for r in _explore(func, args, kwds)]
         except KeyError as exc:
@@ -252,4 +288,28 @@ def _explore_spies(
                 msg = f"ran out of `*args` placeholders ({exc})"
                 raise InferError(msg) from exc
         else:
-            return spies, _snapshot(spies.values()), results, count
+            return spies, _snapshot(spies.values()), results, count, fixed
+
+
+def _explore_lenient(
+    func: _AnyFunc,
+    params: Mapping[str, Parameter],
+) -> tuple[_Recon, Mapping[str, object]]:
+    # if a spy placeholder is rejected, fall back to fixing the defaulted parameters,
+    # and also return every parameter default for rendering
+    try:
+        return _explore_spies(func, params), {}
+    except (TypeError, ValueError):
+        defaults = {
+            n: p.default for n, p in params.items() if p.default is not Parameter.empty
+        }
+        if not defaults:
+            raise
+    # start from the all-fixed baseline and greedily promote one spy at a time
+    fix = set(defaults)
+    recon = _explore_spies(func, params, fix=fix)
+    for name in defaults:
+        with suppress(Exception):
+            recon = _explore_spies(func, params, fix=fix - {name})
+            fix.discard(name)
+    return recon, defaults

--- a/optype/infer/_render.py
+++ b/optype/infer/_render.py
@@ -7,8 +7,8 @@ from itertools import groupby
 from typing import NamedTuple, cast, final
 
 # `from . import` would import the package itself, which imports this module
-import optype.infer._ir as _ir  # noqa: PLR0402
-import optype.infer._numpy as _numpy  # noqa: PLR0402
+import optype.infer._ir as _ir
+import optype.infer._numpy as _numpy
 from ._errors import InferError
 from ._explore import _Gen, _Recon, _Traces
 from ._spy import (
@@ -259,12 +259,11 @@ class _Renderer:
 
     def __init__(
         self,
-        spies: Mapping[str, _SpyObject],
-        results: Sequence[object],
+        recon: _Recon,
         params: Mapping[str, Parameter],
-        count: int,
         traces: _Traces,
     ) -> None:
+        spies, _, results, count, self._fixed = recon
         self._spies = spies
         self._results = results
         self._traces = traces
@@ -293,28 +292,7 @@ class _Renderer:
         if varpos is not None and _all_packed(varpos, results, traces, count):
             self._vars[id(varpos)] = _TYPEVAR_TUPLE
         self._result_spies: list[_SpyObject] = []
-        ret_keys, arg_ids = _ret_keys(order, traces)
-        shared: dict[_RetKey, str] = {}
-        for result in results:
-            for spy in _return_spies(result):
-                if id(spy) in param_ids or id(spy) in self._vars:
-                    continue
-                # untraced results of same-shaped ops that are never passed as an
-                # argument are interchangeable, so they share a typevar
-                key = (
-                    ret_keys.get(id(spy))
-                    if not traces[id(spy)] and id(spy) not in arg_ids
-                    else None
-                )
-                if key is not None and key in shared:
-                    self._vars[id(spy)] = shared[key]
-                    continue
-                n = len(self._result_spies)
-                var = "R" if not n else f"R{n + 1}"
-                self._vars[id(spy)] = var
-                self._result_spies.append(spy)
-                if key is not None:
-                    shared[key] = var
+        self._name_results(order, param_ids)
         self._pool = [
             spy for spy in param_spies if appear[id(spy)] >= 2 or id(spy) in self._vars
         ]
@@ -328,6 +306,30 @@ class _Renderer:
         unnamed = [spy for spy in self._pool if id(spy) not in self._vars]
         for i, spy in enumerate(unnamed):
             self._vars[id(spy)] = _TYPEVARS[i] if i < len(_TYPEVARS) else f"T{i}"
+
+    def _name_results(self, order: Iterable[_SpyObject], param_ids: set[int]) -> None:
+        ret_keys, arg_ids = _ret_keys(order, self._traces)
+        shared: dict[_RetKey, str] = {}
+        for result in self._results:
+            for spy in _return_spies(result):
+                if id(spy) in param_ids or id(spy) in self._vars:
+                    continue
+                # untraced results of same-shaped ops that are never passed as an
+                # argument are interchangeable, so they share a typevar
+                key = (
+                    ret_keys.get(id(spy))
+                    if not self._traces[id(spy)] and id(spy) not in arg_ids
+                    else None
+                )
+                if key is not None and key in shared:
+                    self._vars[id(spy)] = shared[key]
+                    continue
+                n = len(self._result_spies)
+                var = "R" if not n else f"R{n + 1}"
+                self._vars[id(spy)] = var
+                self._result_spies.append(spy)
+                if key is not None:
+                    shared[key] = var
 
     def union(self, values: Iterable[object]) -> _ir.Node | None:
         literals: list[object] = []
@@ -508,6 +510,9 @@ class _Renderer:
         return f"{generics}({params}) -> {self.return_types()}"
 
     def _param(self, name: str, defaults: _Defaults, *, negate: bool) -> str | None:
+        if name in self._fixed and name not in self._optional:
+            # a fixed parameter without a default is a method descriptor's `self`
+            return f"{name}: {_ir.render(_ir.Type(type(self._fixed[name])))}"
         if (spy := self._spies.get(name)) is None:
             # an omitted parameter binds its default, so passing it behaves the same
             node = self.union((defaults[name],)) or _ir.Name(_NEVER)
@@ -552,13 +557,9 @@ def _signatures(
     *,
     negate: bool = False,
 ) -> list[str]:
-    spies, traces, results, count = recon
+    spies, traces, results, _, _ = recon
     reflected = _reflect(list(spies.values()), results, traces)
     return [
-        _Renderer(spies, results, params, count, t).render(
-            selected,
-            defaults,
-            negate=negate,
-        )
+        _Renderer(recon, params, t).render(selected, defaults, negate=negate)
         for t in (traces, reflected)
     ]

--- a/optype/infer/_spy.py
+++ b/optype/infer/_spy.py
@@ -1,5 +1,3 @@
-# ruff: noqa: TD002, TD003, PYI034
-
 """Recording proxy objects that trace the operations performed on them."""
 
 from collections.abc import Callable, Generator, Iterator
@@ -41,7 +39,7 @@ class _TraceItem(NamedTuple):
 class _Spy:
     __optype_trace__: list[_TraceItem]
 
-    def __optype_trace_add__[OutT](  # noqa: PLW3201
+    def __optype_trace_add__[OutT](
         self,
         attr: str,
         args: _Args,
@@ -65,7 +63,7 @@ class _SpyBytes(bytes, _Spy):
     __slots__ = ()  # pyrefly:ignore[implicit-any-attribute]
 
 
-class _SpyObject(_Spy):  # noqa: PLR0904
+class _SpyObject(_Spy):
     __optype_element__: "_SpyObject | None" = None
     __optype_iterator__: bool = False
 

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -559,6 +559,46 @@ def test_callable_instance() -> None:
     assert infer(Add1()) == "[R](x: CanAdd[Literal[1], R]) -> R"
 
 
+def test_method_descriptor() -> None:
+    # an unbound method descriptor's `self` requires a real `__objclass__` instance
+    assert infer(str.upper) == "(self: str) -> str"
+    assert infer(int.bit_length) == "(self: int) -> int"
+    assert infer(float.hex) == "(self: float) -> str"
+    assert infer(list[Any].append) == "(self: list, object: object) -> None"
+    assert infer(object.__str__) == "(self: object) -> str"
+    assert infer(dict[Any, Any].get) == (
+        "[T = None](self: dict, key: CanHash, default: T = None) -> T"
+    )
+    # `memoryview()` is constructed from a spy through its `__buffer__`
+    assert infer(memoryview.tobytes) == (
+        "(self: memoryview, order: Literal['C'] = 'C') -> bytes"
+    )
+
+
+def test_method_descriptor_fixed_defaults() -> None:
+    # a defaulted parameter whose spy the function rejects passes its default
+    # instead, while the accepting parameters stay structural
+    assert infer(str.split) == (
+        "(self: str, sep: None = None, maxsplit: CanIndex = -1) -> list[Never]"
+    )
+    assert infer(bytes.decode) == (
+        "(self: bytes, encoding: Literal['utf-8'] = 'utf-8', "
+        "errors: Literal['strict'] = 'strict') -> str"
+    )
+
+
+def test_method_descriptor_unsupported() -> None:
+    # generators cannot be constructed, spy-rejecting parameters without a default
+    # have nothing to fall back on, and an empty `self` cannot always run
+    send = type(x for x in range(0)).send
+    with pytest.raises(InferError, match="cannot instantiate 'generator'"):
+        infer(send)
+    with pytest.raises(InferError, match="expected str instance"):
+        infer(str.join)
+    with pytest.raises(InferError, match="pop from empty list"):
+        infer(list[Any].pop)
+
+
 def test_ternary_pow() -> None:
     # the optional modulo is used forward but dropped from the reflected overload
     def f(x: Any, y: Any, z: Any = None) -> Any:


### PR DESCRIPTION
Now we can do

```bash
$ optype infer "str.upper"
(self: str) -> str
```

Closes #641