### PR TITLE
`infer`: generic `type[T]`

### DIFF
--- a/docs/reference/experimental/infer.md
+++ b/docs/reference/experimental/infer.md
@@ -113,6 +113,37 @@ $ optype infer "lambda x: reversed(x)"
 [R](x: CanReversed[R]) -> R
 ```
 
+## Classes
+
+`type` reads the class directly instead of dispatching through a dunder, but every
+recording proxy has a unique class, so the result is still tied to its parameter:
+
+```console
+$ optype infer "type"
+[T](object: T) -> type[T]
+
+$ optype infer "lambda x: type(next(x))"
+[R](x: CanNext[R]) -> type[R]
+```
+
+That unique class also ties its instances back to the parameter:
+
+```console
+$ optype infer "lambda x: type(x)()"
+[T](x: T) -> T
+```
+
+A concrete class renders parameterized when it resolves by name (a local class stays
+a bare `type`), and `type` is covariant, so a subclass is absorbed by its parent:
+
+```console
+$ optype infer "lambda: bool"
+() -> type[bool]
+
+$ optype infer "lambda x: int if x else bool"
+(x: CanBool) -> type[int]
+```
+
 ## Branches
 
 Both sides of a conditional are explored, so the parameter has to satisfy every branch

--- a/optype/infer/_api.py
+++ b/optype/infer/_api.py
@@ -56,6 +56,8 @@ def _bind_recon(recon: _Recon, defaults: _Defaults) -> _Recon:
     """The recon as it would look with every defaulted parameter omitted."""
     spies, traces, results, count, fixed = recon
     binding = {id(spies[name]): value for name, value in defaults.items()}
+    # so that a `type(spy)` result becomes `type(default)`
+    binding |= {id(type(spies[name])): type(value) for name, value in defaults.items()}
     bound = {
         spy_id: [
             _TraceItem(

--- a/optype/infer/_explore.py
+++ b/optype/infer/_explore.py
@@ -24,6 +24,8 @@ from ._spy import (
     _AnyFunc,
     _Fork,
     _fork,
+    _Marker,
+    _own_spy,
     _SpyObject,
     _SpyStr,
     _TraceItem,
@@ -89,8 +91,16 @@ def _reachable(params: Iterable[object]) -> Generator[_SpyObject]:
 
 
 def _snapshot(params: Iterable[_SpyObject]) -> _Traces:
-    """Capture the traces of every spy reachable from `params`."""
-    return {id(spy): list(spy.__optype_trace__) for spy in _reachable(params)}
+    """Capture the traces of every spy reachable from `params`.
+
+    An operation on a `type(spy)(...)` sibling requires it of the spy's type, so a
+    sibling's trace merges into its owner's, and the markers themselves are dropped.
+    """
+    traces: _Traces = {}
+    for spy in _reachable(params):
+        items = (item for item in spy.__optype_trace__ if item.attr != _Marker.SIBLING)
+        traces.setdefault(id(_own_spy(spy)), []).extend(items)
+    return traces
 
 
 def _doc_params(func: _AnyFunc) -> list[str] | None:

--- a/optype/infer/_ir.py
+++ b/optype/infer/_ir.py
@@ -14,6 +14,7 @@ _VARIANCES = {
     "Generator": "+-+",
     "frozenset": "+",
     "tuple": "+",
+    "type": "+",
 }
 
 

--- a/optype/infer/_render.py
+++ b/optype/infer/_render.py
@@ -1,10 +1,11 @@
 """Render the recorded spy traces as a PEP 695 signature."""
 
+import sys
 from collections import defaultdict
 from collections.abc import Collection, Generator, Iterable, Mapping, Sequence
 from inspect import Parameter, _ParameterKind
 from itertools import groupby
-from typing import NamedTuple, cast, final
+from typing import Any, NamedTuple, cast, final
 
 # `from . import` would import the package itself, which imports this module
 import optype.infer._ir as _ir
@@ -12,15 +13,18 @@ import optype.infer._numpy as _numpy
 from ._errors import InferError
 from ._explore import _Gen, _Recon, _Traces
 from ._spy import (
-    _ABSENT,
     _AnyFunc,
     _Args,
+    _class_spy,
     _Kwargs,
+    _Marker,
+    _own_spy,
     _Spy,
     _SpyBytes,
     _SpyObject,
     _SpyStr,
     _TraceItem,
+    as_spy,
 )
 from optype._core import _can, _has
 from optype.inspect import get_protocol_members
@@ -140,8 +144,8 @@ def _analyze(
         order.append(spy)
         for op in traces[id(spy)]:
             for value in (*op.args, *op.kwargs.values()):
-                if isinstance(value, _SpyObject):
-                    appear[id(value)] += 1
+                if (arg := as_spy(value)) is not None:
+                    appear[id(arg)] += 1
             if isinstance(op.return_, _SpyObject):
                 appear[id(op.return_)] += 1
                 stack.append(op.return_)
@@ -158,8 +162,8 @@ def _ret_keys(
     for owner in order:
         for item in traces[id(owner)]:
             for value in (*item.args, *item.kwargs.values()):
-                if isinstance(value, _SpyObject):
-                    args.add(id(value))
+                if (arg := as_spy(value)) is not None:
+                    args.add(id(arg))
             if isinstance(item.return_, _SpyObject):
                 key = id(owner), item.attr, len(item.args), tuple(sorted(item.kwargs))
                 keys[id(item.return_)] = key
@@ -227,8 +231,8 @@ def _all_packed(
 
 def _return_spies(value: object) -> Generator[_SpyObject]:
     match value:
-        case _SpyObject():
-            yield value
+        case _SpyObject() | type() if (spy := as_spy(value)) is not None:
+            yield spy
         case _Gen():
             for item in value.yielded:
                 yield from _return_spies(item)
@@ -386,10 +390,10 @@ class _Renderer:
     def traces(self, items: Iterable[_TraceItem]) -> _ir.Node | None:
         items = list(items)
         # a surviving absence marker proves the dunder was only probed optionally
-        optional = {item.args[0] for item in items if item.attr == _ABSENT}
+        optional = {item.args[0] for item in items if item.attr == _Marker.ABSENT}
         groups: dict[tuple[_Proto, int, tuple[str, ...]], list[_Op]] = {}
         for item in items:
-            if item.attr == _ABSENT or item.attr in optional:
+            if item.attr == _Marker.ABSENT or item.attr in optional:
                 continue
             op = _resolve(item)
             key = op.proto, len(op.args), tuple(sorted(op.kwargs))
@@ -425,7 +429,7 @@ class _Renderer:
     def return_type(self, result: object) -> _ir.Node:
         match result:
             case _SpyObject():
-                return _ir.Name(self._vars.get(id(result), _OBJECT))
+                return _ir.Name(self._vars.get(id(_own_spy(result)), _OBJECT))
             case _SpyStr():
                 return _ir.Type(str)
             case _SpyBytes():
@@ -439,9 +443,25 @@ class _Renderer:
             case _:
                 return self._container(result)
 
+    def _class_of(self, cls: type[Any]) -> _ir.Node | None:
+        """The type of `cls`'s instances, if it is expressible."""
+        if (spy := _class_spy(cls)) is not None:
+            return self.return_type(spy)
+        if issubclass(cls, _SpyStr):
+            return _ir.Type(str)
+        if issubclass(cls, _SpyBytes):
+            return _ir.Type(bytes)
+        if cls is type(None):
+            return _ir.Name("None")
+        if getattr(sys.modules.get(cls.__module__), cls.__name__, None) is cls:
+            return _ir.Type(cls)
+        return None  # a local class has no nameable type, so it stays a bare `type`
+
     def _container(self, result: object) -> _ir.Node:
         cls = type(result)
         match result:
+            case type() if (inner := self._class_of(result)) is not None:
+                return _ir.App("type", (inner,))
             case dict():
                 mapping = cast("Mapping[object, object]", result)
                 key = self.union(mapping) or _ir.Name(_NEVER)
@@ -542,7 +562,7 @@ def _reflect(
             rhs = item.args[0] if item.args else None
             if item.attr in _DUNDER_CAN_R and isinstance(rhs, _SpyObject):
                 reflected = _TraceItem("__r" + item.attr[2:], (spy,), {}, item.return_)
-                added[id(rhs)].append(reflected)
+                added[id(_own_spy(rhs))].append(reflected)
             else:
                 keep.append(item)
         kept[id(spy)] = keep

--- a/optype/infer/_spy.py
+++ b/optype/infer/_spy.py
@@ -2,7 +2,8 @@
 
 from collections.abc import Callable, Generator, Iterator
 from contextvars import ContextVar
-from typing import Any, NamedTuple, final, override
+from enum import StrEnum
+from typing import Any, ClassVar, NamedTuple, Self, cast, final, override
 
 type _AnyFunc = Callable[..., object]
 type _Args = tuple[object, ...]
@@ -16,7 +17,12 @@ class _AbsentError(TypeError):
     """A simulated missing dunder; subclasses `TypeError` so probes suppress it."""
 
 
-_ABSENT = "__absent__"  # the trace marker of a simulated-missing dunder
+class _Marker(StrEnum):
+    """A pseudo-operation trace marker, not a real dunder."""
+
+    ABSENT = "__absent__"  # a simulated-missing dunder
+    SIBLING = "__sibling__"  # a `type(spy)(...)` instantiation
+
 
 _fork: ContextVar[Iterator[bool] | None] = ContextVar("_fork", default=None)
 
@@ -66,6 +72,21 @@ class _SpyBytes(bytes, _Spy):
 class _SpyObject(_Spy):
     __optype_element__: "_SpyObject | None" = None
     __optype_iterator__: bool = False
+    # spies are descriptors (`__get__`), so only ever read through the class `__dict__`
+    __optype_instance__: "ClassVar[_SpyObject | None]" = None
+
+    def __new__(cls, /, *_args: object, **_kwargs: object) -> "_SpyObject":
+        if cls is not _SpyObject:
+            # a `type(spy)(...)` sibling; the marker keeps it reachable from the spy
+            self = super().__new__(cls)
+            if (owner := _class_spy(cls)) is not None:
+                owner.__optype_trace__.append(_TraceItem(_Marker.SIBLING, (), {}, self))
+            return self
+        # every spy gets a class of its own, so that `type(spy)` identifies the spy
+        unique = cast("type[Self]", type("_SpyObject", (cls,), {}))
+        self = super().__new__(unique)
+        unique.__optype_instance__ = self
+        return self
 
     ###
 
@@ -91,8 +112,6 @@ class _SpyObject(_Spy):
     def __dir__(self, /) -> "_SpyObject":
         # TODO: maybe return specialized `_SpyObject & Iterable[str]`
         return self.__optype_trace_add__("__dir__", (), {}, _SpyObject())
-
-    # TODO: __class__ -> _SpyType
 
     ###
 
@@ -175,7 +194,7 @@ class _SpyObject(_Spy):
         # `len()` is often probed optionally (e.g. `list()` via `length_hint`), so
         # also fork on its presence; the absent branch raises like a missing dunder
         if not _decide():
-            self.__optype_trace_add__(_ABSENT, ("__len__",), {}, None)
+            self.__optype_trace_add__(_Marker.ABSENT, ("__len__",), {}, None)
             raise _AbsentError
         return self.__optype_trace_add__("__len__", (), {}, _decide())
 
@@ -452,6 +471,26 @@ class _SpyObject(_Spy):
 
 
 # Free functions, not methods: a method would be an unrecorded hole in the proxy.
+def _class_spy(cls: object) -> _SpyObject | None:
+    """The spy whose unique class `cls` is, if any."""
+    if isinstance(cls, type) and issubclass(cls, _SpyObject):
+        spy = cls.__dict__.get("__optype_instance__")
+        if isinstance(spy, _SpyObject):
+            return spy
+    return None
+
+
+def _own_spy(spy: _SpyObject) -> _SpyObject:
+    """The first spy of `spy`'s class: `type(spy)()` siblings collapse onto it."""
+    owner = _class_spy(type(spy))  # `or spy` would trace a `__bool__` on the owner
+    return spy if owner is None else owner
+
+
+def as_spy(value: object) -> _SpyObject | None:
+    """The (first-of-its-class) spy itself, or the spy whose class it is, if any."""
+    return _own_spy(value) if isinstance(value, _SpyObject) else _class_spy(value)
+
+
 def _element_of(spy: _SpyObject) -> _SpyObject:
     if (element := spy.__optype_element__) is None:
         element = _SpyObject()

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -13,6 +13,11 @@ from optype.infer import InferError, InferWarning, infer
 from optype.infer._explore import _doc_params
 from optype.infer._ir import App, Lit, Name, Type, subtype
 
+
+def _type_of[T](x: T) -> type[T]:
+    return type(x)
+
+
 UNARY_CASES: list[tuple[Callable[[Any], Any], str]] = [
     (lambda x: x + 1, "[R](x: CanAdd[Literal[1], R]) -> R"),
     (
@@ -179,6 +184,20 @@ UNARY_CASES: list[tuple[Callable[[Any], Any], str]] = [
     (lambda x: x + (1, 2), "[R](x: CanAdd[tuple[Literal[1], Literal[2]], R]) -> R"),  # noqa: RUF005
     (lambda x: [x], "[T](x: T) -> list[T]"),
     (lambda x: (x, 1), "[T](x: T) -> tuple[T, Literal[1]]"),
+    # every spy has a unique class, so a `type(x)` result renders generically
+    (_type_of, "[T](x: T) -> type[T]"),
+    (lambda x: x.__class__, "[T](x: T) -> type[T]"),
+    (lambda x: (x, type(x)), "[T](x: T) -> tuple[T, type[T]]"),
+    (lambda x: type(next(x)), "[R](x: CanNext[R]) -> type[R]"),
+    (lambda x: type(str(x)), "(x: CanStr) -> type[str]"),
+    # an instance of a spy's class collapses onto the spy itself, and an operation
+    # on such an instance is required of the spy's type
+    (lambda x: type(x)(), "[T](x: T) -> T"),
+    (lambda x: type(x)() + 1, "[R](x: CanAdd[Literal[1], R]) -> R"),
+    (lambda x: str(type(x)()), "(x: CanStr) -> str"),
+    # a nameable class renders parameterized, and `type` is covariant
+    (lambda x: int if x else bool, "(x: CanBool) -> type[int]"),
+    (lambda x: bool if x else type(None), "(x: CanBool) -> type[bool] | type[None]"),
     (lambda x: x.__name__, "[R](x: HasName[R]) -> R"),
     (lambda x: x.__qualname__, "[R](x: HasQualname[R]) -> R"),
     (lambda x: x.__match_args__, "[R](x: HasMatchArgs[R]) -> R"),
@@ -213,6 +232,11 @@ BINARY_CASES: list[tuple[Callable[[Any, Any], Any], str]] = [
     (lambda x, y: x[y], "[T, R](x: CanGetitem[T, R], y: T) -> R"),
     (lambda x, y: y[str(x)], "[R](x: CanStr, y: CanGetitem[str, R]) -> R"),
     (lambda x, y: x, "[T](x: T, y: object) -> T"),  # noqa: ARG005
+    (lambda x, y: (type(x), type(y)), "[T, U](x: T, y: U) -> tuple[type[T], type[U]]"),
+    (
+        lambda x, y: y + type(x)(),
+        "[T, R](x: T, y: CanAdd[T, R]) -> R\n[T, R](x: CanRAdd[T, R], y: T) -> R",
+    ),
     (lambda x, y: x or y, "[T: CanBool, U](x: T, y: U) -> T | U"),
     (lambda x, y: x if x in y else y, "[T, U: CanContains[T]](x: T, y: U) -> T | U"),
     (lambda x, y: x and y, "[T: CanBool, U](x: T, y: U) -> U | T"),
@@ -391,6 +415,10 @@ def _str_default(x: Any = 0) -> Any:
     return str(x)
 
 
+def _type_default(x: object = 0) -> type[object]:
+    return type(x)
+
+
 def _unused_default(x: Any, _y: Any = 0) -> Any:
     return x + 1
 
@@ -410,6 +438,7 @@ DEFAULT_CASES: list[tuple[Callable[..., Any], str]] = [
     ),
     (_getitem_default, "[R, T = Literal[1]](x: CanGetitem[T, R], y: T = 1) -> R"),
     (_yield_default, "[T = Literal[0]](x: T = 0) -> Generator[T]"),
+    (_type_default, "[T = Literal[0]](x: T = 0) -> type[T]"),
     # a parameter whose typevar would only appear once shows the default inline
     (_or_default, "(x: CanBool = None) -> None"),
     (_str_default, "(x: CanStr = 0) -> str"),
@@ -525,6 +554,9 @@ SUBTYPE_CASES: list[tuple[Any, Any, bool]] = [
     (App("tuple", (Type(bool), Lit((1,)))), App("tuple", (Type(int),) * 2), True),
     (App("tuple", (Type(bool),)), App("tuple", (Type(int),) * 2), False),
     (App("list", (Type(bool),)), App("list", (Type(int),)), False),
+    # type is covariant
+    (App("type", (Type(bool),)), App("type", (Type(int),)), True),
+    (App("type", (Type(int),)), App("type", (Type(bool),)), False),
 ]
 
 
@@ -815,6 +847,10 @@ def test_doc_params() -> None:
 def test_doc_signature() -> None:
     # builtins like `int` have no signature; fall back to the docstring
     assert infer(int) == "(x: CanInt | CanIndex) -> int"
+
+
+def test_type() -> None:
+    assert infer(type) == "[T](object: T) -> type[T]"
 
 
 def _set_attr(x: Any) -> object:


### PR DESCRIPTION
```bash
$ optype infer "type"
[T](object: T) -> type[T]

$ optype infer "lambda x: type(x)"
[T](x: T) -> type[T]

$ optype infer "lambda x: type(next(x))"
[R](x: CanNext[R]) -> type[R]
```

closes #629