### PR TITLE
`infer`: higher order function types

### DIFF
--- a/docs/reference/experimental/infer.md
+++ b/docs/reference/experimental/infer.md
@@ -440,7 +440,8 @@ $ optype infer "import numpy as np; np.mean"
 `infer` calls the function, so it only works on functions that are safe to run with
 placeholder arguments (no real side effects, no reliance on concrete values). This
 extends to anything it returns: a returned function is called with placeholders of its
-own, and a returned lazy iterator is iterated.
+own, and a returned lazy iterator is iterated. A returned function that raises during
+this exploration is not treated as an error: its type stays an opaque `function`.
 
 When `infer` can't handle the input, it raises `InferError` (a `NotImplementedError`
 subclass). That's the case for operations without a matching protocol, and for

--- a/docs/reference/experimental/infer.md
+++ b/docs/reference/experimental/infer.md
@@ -302,6 +302,62 @@ $ optype infer "async def f(xs): return (x async for x in xs)"
 [R](xs: CanAIter[CanANext[CanAwait[R]]]) -> AsyncGenerator[R]
 ```
 
+Lazy builtin iterators (`map`, `filter`, `zip`, and `enumerate`) are iterated the same
+way, and a callable argument is traced right through them:
+
+```console
+$ optype infer "lambda x: map(str, x)"
+(x: CanIter[CanNext[CanStr]]) -> map[str]
+
+$ optype infer "lambda f, x: map(f, x)"
+[T, R](f: CanCall[T, R], x: CanIter[CanNext[T]]) -> map[R]
+```
+
+## Returned functions
+
+A returned function is lazy too, so it is explored with placeholders of its own, and
+its type renders in the same signature syntax:
+
+```console
+$ optype infer "lambda x: lambda y: (x, y)"
+[T, U](x: T) -> (y: U) -> tuple[T, U]
+```
+
+An operation inside the returned function is required of the closed-over parameter,
+and overloads reflect as usual:
+
+```console
+$ optype infer "lambda x: lambda y: x + y"
+[T, R](x: CanAdd[T, R]) -> (y: T) -> R
+[T, R](x: T) -> (y: CanRAdd[T, R]) -> R
+```
+
+This applies to anything function-like: builtins, method descriptors, and a
+`functools.partial` (explored with its bound arguments in place), also from within a
+returned container:
+
+```console
+$ optype infer "lambda: str.upper"
+() -> (self: str) -> str
+
+$ optype infer "import functools
+def add(x, y): return x + y
+lambda: functools.partial(add, 1)"
+[R]() -> (y: CanRAdd[Literal[1], R]) -> R
+
+$ optype infer "def counter(start): return (lambda: start), (lambda by: start + by)"
+[T: CanAdd[U, R], U, R](start: T) -> tuple[() -> T, (by: U) -> R]
+[T, R](start: T) -> tuple[() -> T, (by: CanRAdd[T, R]) -> R]
+```
+
+A recursive function (factory) has an inexpressible type, so it stays an opaque
+`function`, as does one with variadic parameters:
+
+```console
+$ optype infer "def f(x): return f"
+(x: object) -> function
+```
+
 ## Containers
 
 Element types are tracked through the containers that hold them, so a typevar can
@@ -373,7 +429,9 @@ $ optype infer "import numpy as np; np.mean"
 ## Limitations
 
 `infer` calls the function, so it only works on functions that are safe to run with
-placeholder arguments (no real side effects, no reliance on concrete values).
+placeholder arguments (no real side effects, no reliance on concrete values). This
+extends to anything it returns: a returned function is called with placeholders of its
+own, and a returned lazy iterator is iterated.
 
 When `infer` can't handle the input, it raises `InferError` (a `NotImplementedError`
 subclass). That's the case for operations without a matching protocol, and for

--- a/docs/reference/experimental/infer.md
+++ b/docs/reference/experimental/infer.md
@@ -113,6 +113,15 @@ $ optype infer "lambda x: reversed(x)"
 [R](x: CanReversed[R]) -> R
 ```
 
+A call dispatches through `__call__`, but a parameter that is called renders in
+signature syntax rather than as `CanCall` or `Callable`, with any keyword arguments
+as named parameters:
+
+```console
+$ optype infer "lambda f: f(1, b=2)"
+[R](f: (Literal[1], b: Literal[2]) -> R) -> R
+```
+
 ## Classes
 
 `type` reads the class directly instead of dispatching through a dunder, but every
@@ -287,7 +296,7 @@ $ optype infer "async def f(xs): return [x async for x in xs]"
 '[R](x: CanAEnter[CanAwait[R]] & CanAExit[None, None, None, CanAwait]) -> R'
 ```
 
-## Generators
+## Generators and lazy iterators
 
 A generator is lazy, so it is iterated to collect the types it yields:
 
@@ -310,7 +319,7 @@ $ optype infer "lambda x: map(str, x)"
 (x: CanIter[CanNext[CanStr]]) -> map[str]
 
 $ optype infer "lambda f, x: map(f, x)"
-[T, R](f: CanCall[T, R], x: CanIter[CanNext[T]]) -> map[R]
+[T, R](f: (T) -> R, x: CanIter[CanNext[T]]) -> map[R]
 ```
 
 ## Returned functions
@@ -423,7 +432,7 @@ A [NEP 18](https://numpy.org/neps/nep-0018-array-function-protocol.html) functio
 
 ```console
 $ optype infer "import numpy as np; np.mean"
-[R](a: CanArrayFunction[CanCall[Any, R], R]) -> R
+[R](a: CanArrayFunction[(Any) -> R, R]) -> R
 ```
 
 ## Limitations
@@ -447,9 +456,8 @@ The number of explored branches is capped, so a function with many of them gets 
 signature that only covers the explored ones, along with an `InferWarning`.
 
 It can only observe operations that go through a dunder method. Anything that inspects a
-parameter at the C level is invisible, so a parameter passed to `type()`, `id()`,
-`isinstance()`, or an identity check (`is`) is reported as `object` rather than its real
-requirement.
+parameter at the C level is invisible, so a parameter passed to `id()`, `isinstance()`,
+or an identity check (`is`) is reported as `object` rather than its real requirement.
 
 !!! warning "Generic bounds"
 

--- a/optype/infer/_api.py
+++ b/optype/infer/_api.py
@@ -7,9 +7,10 @@ from typing import cast
 # `from . import` would import the package itself, which imports this module
 import optype.infer._numpy as _numpy
 from ._errors import InferError
-from ._explore import _explore_lenient, _explore_spies, _Gen, _parameters, _Recon
+from ._explore import _explore_lenient, _explore_spies, _parameters, _Recon
 from ._render import _Defaults, _Names, _signatures
 from ._spy import _AnyFunc, _TraceItem
+from ._values import _Fn, _Gen
 
 __all__ = ("infer",)
 
@@ -36,20 +37,24 @@ def _bind(value: object, binding: Mapping[int, object]) -> object:
     match value:
         case _Gen():
             yielded = [_bind(item, binding) for item in value.yielded]
-            return _Gen(yielded, value.is_async)
+            out: object = _Gen(yielded, value.kind)
+        case _Fn():
+            bound = [_bind(item, binding) for item in value.results]
+            out = _Fn(value.names, value.spies, value.fixed, bound)
         case tuple() if cls is tuple:
             tup = cast("tuple[object, ...]", value)
-            return tuple(_bind(item, binding) for item in tup)
+            out = tuple(_bind(item, binding) for item in tup)
         case list():
-            return [_bind(item, binding) for item in cast("list[object]", value)]
+            out = [_bind(item, binding) for item in cast("list[object]", value)]
         case set() | frozenset():
             items = {_bind(item, binding) for item in cast("Collection[object]", value)}
-            return frozenset(items) if isinstance(value, frozenset) else items
+            out = frozenset(items) if isinstance(value, frozenset) else items
         case dict():
             mapping = cast("Mapping[object, object]", value)
-            return {_bind(k, binding): _bind(v, binding) for k, v in mapping.items()}
+            out = {_bind(k, binding): _bind(v, binding) for k, v in mapping.items()}
         case _:
-            return binding.get(id(value), value)
+            out = binding.get(id(value), value)
+    return out
 
 
 def _bind_recon(recon: _Recon, defaults: _Defaults) -> _Recon:

--- a/optype/infer/_api.py
+++ b/optype/infer/_api.py
@@ -7,7 +7,13 @@ from typing import cast
 # `from . import` would import the package itself, which imports this module
 import optype.infer._numpy as _numpy
 from ._errors import InferError
-from ._explore import _explore_lenient, _explore_spies, _parameters, _Recon
+from ._explore import (
+    _declared_defaults,
+    _explore_lenient,
+    _explore_spies,
+    _parameters,
+    _Recon,
+)
 from ._render import _Defaults, _Names, _signatures
 from ._spy import _AnyFunc, _TraceItem
 from ._values import _Fn, _Gen
@@ -37,10 +43,10 @@ def _bind(value: object, binding: Mapping[int, object]) -> object:
     match value:
         case _Gen():
             yielded = [_bind(item, binding) for item in value.yielded]
-            out: object = _Gen(yielded, value.kind)
+            out: object = value._replace(yielded=yielded)
         case _Fn():
             bound = [_bind(item, binding) for item in value.results]
-            out = _Fn(value.names, value.spies, value.fixed, bound)
+            out = value._replace(results=bound)
         case tuple() if cls is tuple:
             tup = cast("tuple[object, ...]", value)
             out = tuple(_bind(item, binding) for item in tup)
@@ -92,11 +98,7 @@ def _defaults(
     mismatch the omitted calls are reported as separate overload lines, and a
     single defaulted parameter's type is excluded from the generic signature.
     """
-    defaults = {
-        name: p.default
-        for name, p in params.items()
-        if p.default is not Parameter.empty
-    }
+    defaults = _declared_defaults(params)
     kinds = {p.kind for p in params.values()}
     if not defaults or (
         # `*args` placeholders would positionally fill an omitted default

--- a/optype/infer/_explore.py
+++ b/optype/infer/_explore.py
@@ -13,6 +13,7 @@ from collections.abc import (
     Sequence,
 )
 from contextlib import suppress
+from contextvars import ContextVar
 from functools import partial
 from inspect import Parameter, isasyncgen, iscoroutine, isgenerator, signature
 from itertools import islice
@@ -42,6 +43,7 @@ from ._values import _Fn, _fn_spies, _Gen, _walk
 __all__ = (
     "_Recon",
     "_Traces",
+    "_declared_defaults",
     "_doc_params",
     "_explore_lenient",
     "_explore_spies",
@@ -123,6 +125,11 @@ def _parameters(func: _AnyFunc) -> Mapping[str, Parameter]:
         return {n: Parameter(n, Parameter.POSITIONAL_OR_KEYWORD) for n in names}
 
 
+def _declared_defaults(params: Mapping[str, Parameter]) -> dict[str, object]:
+    """The declared parameter defaults, by name."""
+    return {n: p.default for n, p in params.items() if p.default is not Parameter.empty}
+
+
 def _await[R](coro: Coroutine[Any, Any, R]) -> R:
     # a spy's awaitables resolve synchronously, so the coroutine runs straight through
     try:
@@ -173,7 +180,7 @@ _FUNCTION_TYPES = (
 _VARIADIC_KINDS = frozenset({Parameter.VAR_POSITIONAL, Parameter.VAR_KEYWORD})
 
 # the (unwrapped) functions currently being explored, see `_explore_key`
-_exploring: set[int] = set()
+_exploring: ContextVar[frozenset[int]] = ContextVar("_exploring", default=frozenset())
 
 
 def _unwrap(obj: object) -> object:
@@ -215,33 +222,34 @@ def _closed_over(func: object, seen: set[int] | None = None) -> Generator[object
 
 def _explore_func(func: _AnyFunc) -> object:
     """Explore a returned function, so it renders in signature syntax."""
-    if _explore_key(func) in _exploring:
+    if _explore_key(func) in _exploring.get():
         return func  # a recursive function type is inexpressible
     try:
         params = _parameters(func)
         if any(p.kind in _VARIADIC_KINDS for p in params.values()):
             return func  # variadic parameters are not expressible (yet)
-        spies, _, results, _, fixed = _explore_spies(func, params)
+        recon, _ = _explore_lenient(func, params)
     except Exception:  # noqa: BLE001  # an unexplorable function stays opaque
         return func
-    return _Fn(tuple(params), spies, fixed, results)
+    spies, _, results, _, fixed = recon
+    return _Fn(tuple(params), spies, fixed, _declared_defaults(params), results)
 
 
 def _next(result: object) -> object:
+    # a function (or iterator) within the yields or a container is explored as well
     cls = type(result)
     if isgenerator(result):
-        out: object = _Gen(_yields(result), "Generator")
+        out: object = _Gen([_next(v) for v in _yields(result)], "Generator")
     elif isasyncgen(result):
-        out = _Gen(_yields(_sync(result)), "AsyncGenerator")
+        out = _Gen([_next(v) for v in _yields(_sync(result))], "AsyncGenerator")
     elif cls in _ITERATOR_TYPES:
         values = _yields(cast("Iterable[object]", result))
         if cls is enumerate:
             # `enumerate[R]` is parameterized by the element type, not the yields
             values = [item for _, item in cast("list[tuple[int, object]]", values)]
-        out = _Gen(values, cls.__name__)
+        out = _Gen([_next(v) for v in values], cls.__name__)
     elif isinstance(_unwrap(result), _FUNCTION_TYPES):
         out = _explore_func(cast("_AnyFunc", result))
-    # a function (or iterator) within a returned container is explored as well
     elif cls is tuple:
         out = tuple(map(_next, cast("tuple[object, ...]", result)))
     elif cls is list:
@@ -354,8 +362,7 @@ def _explore_spies(
     count = next(counts)
     keys: list[str] = []
     # registering `func` itself keeps a returned self-reference from recursing
-    nested = (guard := _explore_key(func)) in _exploring
-    _exploring.add(guard)
+    token = _exploring.set(_exploring.get() | {_explore_key(func)})
     try:
         while True:
             # a fresh `self` instance per attempt, so a mutated one cannot leak
@@ -386,8 +393,7 @@ def _explore_spies(
                 traces = _snapshot((*spies.values(), *_fn_spies(results)))
                 return spies, traces, results, count, fixed
     finally:
-        if not nested:
-            _exploring.discard(guard)
+        _exploring.reset(token)
 
 
 def _explore_lenient(
@@ -399,9 +405,7 @@ def _explore_lenient(
     try:
         return _explore_spies(func, params), {}
     except (TypeError, ValueError):
-        defaults = {
-            n: p.default for n, p in params.items() if p.default is not Parameter.empty
-        }
+        defaults = _declared_defaults(params)
         if not defaults:
             raise
     # start from the all-fixed baseline and greedily promote one spy at a time

--- a/optype/infer/_explore.py
+++ b/optype/infer/_explore.py
@@ -13,10 +13,17 @@ from collections.abc import (
     Sequence,
 )
 from contextlib import suppress
+from functools import partial
 from inspect import Parameter, isasyncgen, iscoroutine, isgenerator, signature
 from itertools import islice
-from types import MethodDescriptorType, WrapperDescriptorType
-from typing import Any, NamedTuple, cast, overload
+from types import (
+    BuiltinFunctionType,
+    FunctionType,
+    MethodDescriptorType,
+    MethodType,
+    WrapperDescriptorType,
+)
+from typing import Any, cast
 
 from ._errors import InferError, InferWarning
 from ._spy import (
@@ -30,9 +37,9 @@ from ._spy import (
     _SpyStr,
     _TraceItem,
 )
+from ._values import _Fn, _fn_spies, _Gen, _walk
 
 __all__ = (
-    "_Gen",
     "_Recon",
     "_Traces",
     "_doc_params",
@@ -63,15 +70,6 @@ type _Recon = tuple[
     int,
     Mapping[str, object],
 ]
-
-
-class _Gen(NamedTuple):
-    yielded: list[object]
-    is_async: bool
-
-    @property
-    def kind(self) -> str:
-        return "AsyncGenerator" if self.is_async else "Generator"
 
 
 def _reachable(params: Iterable[object]) -> Generator[_SpyObject]:
@@ -162,16 +160,98 @@ def _sync[T](agen: AsyncGenerator[T, Any]) -> Generator[T]:
             return
 
 
-@overload
-def _next(result: Generator[object] | AsyncGenerator[object]) -> _Gen: ...
-@overload
-def _next[T](result: T) -> T: ...
+# lazy builtin iterators with a single type argument
+_ITERATOR_TYPES = frozenset({enumerate, filter, map, zip})
+
+_FUNCTION_TYPES = (
+    FunctionType,
+    BuiltinFunctionType,
+    MethodType,
+    MethodDescriptorType,
+    WrapperDescriptorType,
+)
+_VARIADIC_KINDS = frozenset({Parameter.VAR_POSITIONAL, Parameter.VAR_KEYWORD})
+
+# the (unwrapped) functions currently being explored, see `_explore_key`
+_exploring: set[int] = set()
+
+
+def _unwrap(obj: object) -> object:
+    """The underlying callable of (nested) `functools.partial` wrappers."""
+    while isinstance(obj, partial):
+        obj = obj.func
+    return obj
+
+
+def _explore_key(func: object) -> int:
+    # closures from a single def share their code object, so a recursive function
+    # factory is recognized even though it returns a fresh closure on every call
+    base = _unwrap(func)
+    return id(getattr(base, "__code__", base))
+
+
+def _closed_over(func: object, seen: set[int] | None = None) -> Generator[object]:
+    # every value a function can reach besides its arguments, transitively
+    seen = set() if seen is None else seen
+    if id(func) in seen:
+        return
+    seen.add(id(func))
+    values: list[object] = []
+    while isinstance(func, partial):
+        values += func.args
+        values += func.keywords.values()
+        func = func.func
+    values += getattr(func, "__defaults__", None) or ()
+    values += (getattr(func, "__kwdefaults__", None) or {}).values()
+    for cell in getattr(func, "__closure__", None) or ():
+        with suppress(ValueError):  # an unset cell
+            values.append(cell.cell_contents)
+    for value in values:
+        for node in _walk(value):
+            yield node
+            if isinstance(_unwrap(node), _FUNCTION_TYPES):
+                yield from _closed_over(node, seen)
+
+
+def _explore_func(func: _AnyFunc) -> object:
+    """Explore a returned function, so it renders in signature syntax."""
+    if _explore_key(func) in _exploring:
+        return func  # a recursive function type is inexpressible
+    try:
+        params = _parameters(func)
+        if any(p.kind in _VARIADIC_KINDS for p in params.values()):
+            return func  # variadic parameters are not expressible (yet)
+        spies, _, results, _, fixed = _explore_spies(func, params)
+    except Exception:  # noqa: BLE001  # an unexplorable function stays opaque
+        return func
+    return _Fn(tuple(params), spies, fixed, results)
+
+
 def _next(result: object) -> object:
+    cls = type(result)
     if isgenerator(result):
-        return _Gen(_yields(result), is_async=False)
-    if isasyncgen(result):
-        return _Gen(_yields(_sync(result)), is_async=True)
-    return result
+        out: object = _Gen(_yields(result), "Generator")
+    elif isasyncgen(result):
+        out = _Gen(_yields(_sync(result)), "AsyncGenerator")
+    elif cls in _ITERATOR_TYPES:
+        values = _yields(cast("Iterable[object]", result))
+        if cls is enumerate:
+            # `enumerate[R]` is parameterized by the element type, not the yields
+            values = [item for _, item in cast("list[tuple[int, object]]", values)]
+        out = _Gen(values, cls.__name__)
+    elif isinstance(_unwrap(result), _FUNCTION_TYPES):
+        out = _explore_func(cast("_AnyFunc", result))
+    # a function (or iterator) within a returned container is explored as well
+    elif cls is tuple:
+        out = tuple(map(_next, cast("tuple[object, ...]", result)))
+    elif cls is list:
+        out = [_next(item) for item in cast("list[object]", result)]
+    elif cls is dict:  # the keys must stay hashable, so only the values recurse
+        mapping = cast("Mapping[object, object]", result)
+        out = {key: _next(value) for key, value in mapping.items()}
+    else:
+        out = result
+    return out
 
 
 def _explore[T](
@@ -186,9 +266,10 @@ def _explore[T](
         if not stack:
             break
         plan = stack.pop()
+        # a failed run must also roll back its traces on the closed-over spies
         marks = [
             (spy, len(spy.__optype_trace__))
-            for spy in _reachable((*args, *kwds.values()))
+            for spy in _reachable((*args, *kwds.values(), *_closed_over(func)))
         ]
         token = _fork.set(iter(plan))
         try:
@@ -272,33 +353,41 @@ def _explore_spies(
     counts = iter(_VARIADIC_COUNTS)
     count = next(counts)
     keys: list[str] = []
-    while True:
-        # a fresh `self` instance per attempt, so a mutated one cannot leak
-        fixed = _fixed_self(func, params) | {n: params[n].default for n in fix}
-        spies, args, kwds = _placeholders(params, count, keys, omit, fixed)
-        try:
-            results: list[object] = [_next(r) for r in _explore(func, args, kwds)]
-        except KeyError as exc:
-            key = exc.args[0] if exc.args else None
-            if (
-                Parameter.VAR_KEYWORD not in kinds
-                or not isinstance(key, str)
-                or key in keys
-                or key in params
-            ):
-                raise
-            if len(keys) >= _KWARGS_LIMIT:
-                msg = f"ran out of `**kwargs` placeholder keys ({exc})"
-                raise InferError(msg) from exc
-            keys.append(key)
-        except (IndexError, TypeError, ValueError) as exc:
-            if Parameter.VAR_POSITIONAL not in kinds:
-                raise
-            if (count := next(counts, 0)) == 0:
-                msg = f"ran out of `*args` placeholders ({exc})"
-                raise InferError(msg) from exc
-        else:
-            return spies, _snapshot(spies.values()), results, count, fixed
+    # registering `func` itself keeps a returned self-reference from recursing
+    nested = (guard := _explore_key(func)) in _exploring
+    _exploring.add(guard)
+    try:
+        while True:
+            # a fresh `self` instance per attempt, so a mutated one cannot leak
+            fixed = _fixed_self(func, params) | {n: params[n].default for n in fix}
+            spies, args, kwds = _placeholders(params, count, keys, omit, fixed)
+            try:
+                results: list[object] = [_next(r) for r in _explore(func, args, kwds)]
+            except KeyError as exc:
+                key = exc.args[0] if exc.args else None
+                if (
+                    Parameter.VAR_KEYWORD not in kinds
+                    or not isinstance(key, str)
+                    or key in keys
+                    or key in params
+                ):
+                    raise
+                if len(keys) >= _KWARGS_LIMIT:
+                    msg = f"ran out of `**kwargs` placeholder keys ({exc})"
+                    raise InferError(msg) from exc
+                keys.append(key)
+            except (IndexError, TypeError, ValueError) as exc:
+                if Parameter.VAR_POSITIONAL not in kinds:
+                    raise
+                if (count := next(counts, 0)) == 0:
+                    msg = f"ran out of `*args` placeholders ({exc})"
+                    raise InferError(msg) from exc
+            else:
+                traces = _snapshot((*spies.values(), *_fn_spies(results)))
+                return spies, traces, results, count, fixed
+    finally:
+        if not nested:
+            _exploring.discard(guard)
 
 
 def _explore_lenient(

--- a/optype/infer/_ir.py
+++ b/optype/infer/_ir.py
@@ -12,12 +12,10 @@ _NOT = "~"  # the type complement prefix
 _VARIANCES = {
     "AsyncGenerator": "+-",
     "Generator": "+-+",
-    "enumerate": "+",
-    "filter": "+",
     "frozenset": "+",
-    "map": "+",
     "tuple": "+",
     "type": "+",
+    # `enumerate`, `filter`, and `map` are invariant in typeshed; only `zip` is not
     "zip": "+",
 }
 
@@ -62,6 +60,7 @@ class Arg:
 
     key: str
     value: Node
+    suffix: str = ""  # an optional ` = <default>` display suffix
 
 
 @dataclass(frozen=True, slots=True)
@@ -225,7 +224,9 @@ def render(node: Node) -> str:
             out = f"{base}[{', '.join(parts)}]" if parts else base
         case Fn(params, ret):
             decls = ", ".join(
-                f"{p.key}: {render(p.value)}" if isinstance(p, Arg) else render(p)
+                f"{p.key}: {render(p.value)}{p.suffix}"
+                if isinstance(p, Arg)
+                else render(p)
                 for p in params
             )
             out = f"({decls}) -> {render(ret)}"

--- a/optype/infer/_ir.py
+++ b/optype/infer/_ir.py
@@ -58,7 +58,7 @@ class Name:
 
 @dataclass(frozen=True, slots=True)
 class Arg:
-    """A keyword-labeled type argument, e.g. the `a=Literal[1]` in `CanCall`."""
+    """A keyword-labeled parameter, e.g. `a: Literal[1]` in `(a: Literal[1]) -> R`."""
 
     key: str
     value: Node
@@ -74,10 +74,15 @@ class App:
 
 @dataclass(frozen=True, slots=True)
 class Fn:
-    """A function type in signature syntax, e.g. `(x: T) -> R`."""
+    """A function type in signature syntax, e.g. `(x: T) -> R` or `(T) -> R`."""
 
-    params: tuple[Arg, ...]
+    params: tuple[Node | Arg, ...]
     ret: Node
+
+
+def _param_type(param: "Node | Arg") -> "Node":
+    """The type of a (possibly keyword-labeled) parameter."""
+    return param.value if isinstance(param, Arg) else param
 
 
 @dataclass(frozen=True, slots=True)
@@ -135,7 +140,7 @@ def subtype(sub: Node | Arg, sup: Node | Arg) -> bool:
                 len(params) == len(wider_params)
                 and subtype(ret, wider_ret)
                 and all(
-                    subtype(wide.value, param.value)
+                    subtype(_param_type(wide), _param_type(param))
                     for param, wide in zip(params, wider_params, strict=True)
                 )
             )
@@ -219,7 +224,10 @@ def render(node: Node) -> str:
             ]
             out = f"{base}[{', '.join(parts)}]" if parts else base
         case Fn(params, ret):
-            decls = ", ".join(f"{p.key}: {render(p.value)}" for p in params)
+            decls = ", ".join(
+                f"{p.key}: {render(p.value)}" if isinstance(p, Arg) else render(p)
+                for p in params
+            )
             out = f"({decls}) -> {render(ret)}"
         case Not(part):
             inner = render(part)

--- a/optype/infer/_ir.py
+++ b/optype/infer/_ir.py
@@ -4,7 +4,7 @@ from collections.abc import Iterable
 from dataclasses import dataclass
 from typing import override
 
-type Node = Lit | Type | Name | App | Union | Inter | Not
+type Node = Lit | Type | Name | App | Fn | Union | Inter | Not
 
 _NOT = "~"  # the type complement prefix
 
@@ -12,9 +12,13 @@ _NOT = "~"  # the type complement prefix
 _VARIANCES = {
     "AsyncGenerator": "+-",
     "Generator": "+-+",
+    "enumerate": "+",
+    "filter": "+",
     "frozenset": "+",
+    "map": "+",
     "tuple": "+",
     "type": "+",
+    "zip": "+",
 }
 
 
@@ -69,6 +73,14 @@ class App:
 
 
 @dataclass(frozen=True, slots=True)
+class Fn:
+    """A function type in signature syntax, e.g. `(x: T) -> R`."""
+
+    params: tuple[Arg, ...]
+    ret: Node
+
+
+@dataclass(frozen=True, slots=True)
 class Not:
     """A type complement, e.g. the `~None` of everything but `None`."""
 
@@ -114,6 +126,17 @@ def subtype(sub: Node | Arg, sup: Node | Arg) -> bool:
                     if variances[min(i, len(variances) - 1)] == "+"
                     else subtype(wide, arg)
                     for i, (arg, wide) in enumerate(zip(args, wider_args, strict=True))
+                )
+            )
+        case Fn(params, ret), Fn(wider_params, wider_ret):
+            # parameters are contravariant (and positionally matched), the return
+            # type is covariant
+            result = (
+                len(params) == len(wider_params)
+                and subtype(ret, wider_ret)
+                and all(
+                    subtype(wide.value, param.value)
+                    for param, wide in zip(params, wider_params, strict=True)
                 )
             )
         case _:
@@ -181,12 +204,12 @@ def render(node: Node) -> str:
     """Format a type expression, parenthesized where precedence requires."""
     match node:
         case Lit(values):
-            return f"Literal[{', '.join(map(repr, values))}]"
+            out = f"Literal[{', '.join(map(repr, values))}]"
         case Type(cls):
             prefix = "np." if cls.__module__.partition(".")[0] == "numpy" else ""
-            return prefix + cls.__name__
+            out = prefix + cls.__name__
         case Name(name):
-            return name
+            out = name
         case App(base, args):
             parts = [
                 f"{arg.key}={render(arg.value)}"
@@ -194,15 +217,21 @@ def render(node: Node) -> str:
                 else render(arg)
                 for arg in args
             ]
-            return f"{base}[{', '.join(parts)}]" if parts else base
+            out = f"{base}[{', '.join(parts)}]" if parts else base
+        case Fn(params, ret):
+            decls = ", ".join(f"{p.key}: {render(p.value)}" for p in params)
+            out = f"({decls}) -> {render(ret)}"
         case Not(part):
             inner = render(part)
-            return (
-                f"{_NOT}({inner})" if isinstance(part, Union | Inter) else _NOT + inner
+            out = (
+                f"{_NOT}({inner})"
+                if isinstance(part, Union | Inter | Fn)
+                else _NOT + inner
             )
         case Union(parts) | Inter(parts):
             sep, dual = (" | ", Inter) if isinstance(node, Union) else (" & ", Union)
-            return sep.join(
-                f"({render(part)})" if isinstance(part, dual) else render(part)
+            out = sep.join(
+                f"({render(part)})" if isinstance(part, dual | Fn) else render(part)
                 for part in parts
             )
+    return out

--- a/optype/infer/_numpy.py
+++ b/optype/infer/_numpy.py
@@ -76,5 +76,5 @@ def _required_args(func: _AnyFunc) -> int | None:
 def array_function_type(func: _AnyFunc, ret: str) -> str:
     """Render `CanArrayFunction` with the dispatched function's arity."""
     n = _required_args(func)
-    args = ["Any"] * n if n is not None else ["..."]
-    return f"CanArrayFunction[CanCall[{', '.join([*args, ret])}], {ret}]"
+    args = ", ".join(["Any"] * n) if n is not None else "..."
+    return f"CanArrayFunction[({args}) -> {ret}, {ret}]"

--- a/optype/infer/_render.py
+++ b/optype/infer/_render.py
@@ -450,15 +450,19 @@ class _Renderer:
     def _function(self, fn: _Fn) -> _ir.Node:
         """The signature-syntax type of an explored function result."""
         params = tuple(
-            _ir.Arg(
-                name,
-                _ir.Type(type(fn.fixed[name]))
-                if name in fn.fixed
-                else self._slot(fn.spies[name]),
-            )
+            _ir.Arg(name, self._fn_param(fn, name), _suffix(fn.defaults, name))
             for name in fn.names
         )
         return _ir.Fn(params, self._union_type(fn.results))
+
+    def _fn_param(self, fn: _Fn, name: str) -> _ir.Node:
+        if (spy := fn.spies.get(name)) is not None:
+            return self._slot(spy)
+        value = fn.fixed[name]
+        if name in fn.defaults:
+            # a pinned default renders as its value, like the outer parameters do
+            return self.union((value,)) or _ir.Name(_NEVER)
+        return _ir.Type(type(value))  # a method descriptor's pinned `self`
 
     def _class_of(self, cls: type[Any]) -> _ir.Node | None:
         """The type of `cls`'s instances, if it is expressible."""

--- a/optype/infer/_render.py
+++ b/optype/infer/_render.py
@@ -11,7 +11,7 @@ from typing import Any, NamedTuple, cast, final
 import optype.infer._ir as _ir
 import optype.infer._numpy as _numpy
 from ._errors import InferError
-from ._explore import _Gen, _Recon, _Traces
+from ._explore import _Recon, _Traces
 from ._spy import (
     _AnyFunc,
     _Args,
@@ -26,6 +26,7 @@ from ._spy import (
     _TraceItem,
     as_spy,
 )
+from ._values import _children, _Fn, _fn_spies, _Gen, _walk
 from optype._core import _can, _has
 from optype.inspect import get_protocol_members
 
@@ -183,20 +184,13 @@ def _packed_uses(value: object, spy: _SpyObject, count: int) -> Generator[bool]:
             if value is spy:
                 yield False
             return
-        case _Gen():
-            items = value.yielded
-        case tuple():
+        case tuple() if not isinstance(value, _Gen | _Fn):
             tup = cast("tuple[object, ...]", value)
             if runs := _spy_runs(tup, spy):
                 yield runs == [count]
-            items = (item for item in tup if item is not spy)
-        case list() | set() | frozenset():
-            items = cast("Collection[object]", value)
-        case dict():
-            mapping = cast("Mapping[object, object]", value)
-            items = (*mapping, *mapping.values())
+            items: Iterable[object] = (item for item in tup if item is not spy)
         case _:
-            return
+            items = _children(value)
     for item in items:
         yield from _packed_uses(item, spy, count)
 
@@ -230,22 +224,10 @@ def _all_packed(
 
 
 def _return_spies(value: object) -> Generator[_SpyObject]:
-    match value:
-        case _SpyObject() | type() if (spy := as_spy(value)) is not None:
+    # an `_Fn`'s parameter spies are not returns; they are named like parameters
+    for node in _walk(value):
+        if (spy := as_spy(node)) is not None:
             yield spy
-        case _Gen():
-            for item in value.yielded:
-                yield from _return_spies(item)
-        case list() | set() | frozenset() | tuple():
-            for item in cast("Collection[object]", value):
-                yield from _return_spies(item)
-        case dict():
-            mapping = cast("Mapping[object, object]", value)
-            for key, val in mapping.items():
-                yield from _return_spies(key)
-                yield from _return_spies(val)
-        case _:
-            pass
 
 
 def _suffix(defaults: _Defaults, name: str) -> str:
@@ -287,7 +269,8 @@ class _Renderer:
             None,
         )
 
-        param_spies = list(spies.values())
+        # a returned function's parameter spies are named like regular parameters
+        param_spies = [*spies.values(), *_fn_spies(results)]
         order, appear = _analyze(param_spies, results, traces)
         param_ids = {id(spy) for spy in param_spies}
 
@@ -353,9 +336,11 @@ class _Renderer:
     def returns(self, members: Iterable[_Op]) -> _ir.Node | None:
         named: list[str] = []
         items: list[_TraceItem] = []
+        returned = False
         for m in members:
             if not isinstance(m.ret, _SpyObject):
                 continue
+            returned = True
             if (var := self._vars.get(id(m.ret))) is not None:
                 named.append(var)
             else:
@@ -363,7 +348,11 @@ class _Renderer:
         parts: list[_ir.Node] = [_ir.Name(var) for var in dict.fromkeys(named)]
         if items and (node := self.traces(items)) is not None:
             parts.append(node)
-        return _ir.inter(parts)
+        if (out := _ir.inter(parts)) is None and returned:
+            # an unused result is unconstrained, but omitting it would leave the
+            # last argument in the return slot, e.g. the `R` of `CanCall[T, R]`
+            out = _ir.Name(_OBJECT)
+        return out
 
     def group(self, proto: _Proto, members: Sequence[_Op]) -> _ir.Node:
         if isinstance(proto, tuple):  # coercion protocols, which record no args
@@ -403,11 +392,14 @@ class _Renderer:
     def spy(self, spy: _SpyObject) -> _ir.Node | None:
         return self.traces(self._traces[id(spy)])
 
-    def slot(self, spy: _SpyObject) -> str:
+    def _slot(self, spy: _SpyObject) -> _ir.Node:
         if (var := self._vars.get(id(spy))) is not None:
-            return var
+            return _ir.Name(var)
         node = self.spy(spy)
-        return _ir.render(node) if node is not None else _OBJECT
+        return node if node is not None else _ir.Name(_OBJECT)
+
+    def slot(self, spy: _SpyObject) -> str:
+        return _ir.render(self._slot(spy))
 
     def typevar(
         self,
@@ -429,19 +421,38 @@ class _Renderer:
     def return_type(self, result: object) -> _ir.Node:
         match result:
             case _SpyObject():
-                return _ir.Name(self._vars.get(id(_own_spy(result)), _OBJECT))
+                node: _ir.Node = _ir.Name(self._vars.get(id(_own_spy(result)), _OBJECT))
             case _SpyStr():
-                return _ir.Type(str)
+                node = _ir.Type(str)
             case _SpyBytes():
-                return _ir.Type(bytes)
+                node = _ir.Type(bytes)
             case _Gen():
-                yields = list(dict.fromkeys(map(self.return_type, result.yielded)))
-                inner = _ir.union(yields) or _ir.Name(_NEVER)
-                return _ir.App(result.kind, (inner,))
+                node = _ir.App(result.kind, (self._union_type(result.yielded),))
+            case _Fn():
+                node = self._function(result)
             case None:
-                return _ir.Name("None")
+                node = _ir.Name("None")
             case _:
-                return self._container(result)
+                node = self._container(result)
+        return node
+
+    def _union_type(self, values: Iterable[object]) -> _ir.Node:
+        """The deduplicated union of the types of `values`, or `Never` if empty."""
+        parts = dict.fromkeys(map(self.return_type, values))
+        return _ir.union(parts) or _ir.Name(_NEVER)
+
+    def _function(self, fn: _Fn) -> _ir.Node:
+        """The signature-syntax type of an explored function result."""
+        params = tuple(
+            _ir.Arg(
+                name,
+                _ir.Type(type(fn.fixed[name]))
+                if name in fn.fixed
+                else self._slot(fn.spies[name]),
+            )
+            for name in fn.names
+        )
+        return _ir.Fn(params, self._union_type(fn.results))
 
     def _class_of(self, cls: type[Any]) -> _ir.Node | None:
         """The type of `cls`'s instances, if it is expressible."""
@@ -498,8 +509,7 @@ class _Renderer:
         return _ir.App("tuple", tuple(elems))
 
     def return_types(self) -> str:
-        node = _ir.union(dict.fromkeys(map(self.return_type, self._results)))
-        return _ir.render(node) if node is not None else _NEVER
+        return _ir.render(self._union_type(self._results))
 
     def render(
         self,
@@ -578,7 +588,8 @@ def _signatures(
     negate: bool = False,
 ) -> list[str]:
     spies, traces, results, _, _ = recon
-    reflected = _reflect(list(spies.values()), results, traces)
+    roots = [*spies.values(), *_fn_spies(results)]
+    reflected = _reflect(roots, results, traces)
     return [
         _Renderer(recon, params, t).render(selected, defaults, negate=negate)
         for t in (traces, reflected)

--- a/optype/infer/_render.py
+++ b/optype/infer/_render.py
@@ -122,6 +122,11 @@ def _resolve(trace: _TraceItem) -> _Op:
     raise InferError(msg)
 
 
+def _or_object(node: _ir.Node | None) -> _ir.Node:
+    """The node itself, or `object` for an unconstrained (`None`) one."""
+    return _ir.Name(_OBJECT) if node is None else node
+
+
 def _analyze(
     params: Sequence[_SpyObject],
     results: Iterable[object],
@@ -350,7 +355,7 @@ class _Renderer:
             parts.append(node)
         if (out := _ir.inter(parts)) is None and returned:
             # an unused result is unconstrained, but omitting it would leave the
-            # last argument in the return slot, e.g. the `R` of `CanCall[T, R]`
+            # last argument in the return slot, e.g. the `R` of `(T) -> R`
             out = _ir.Name(_OBJECT)
         return out
 
@@ -358,8 +363,7 @@ class _Renderer:
         if isinstance(proto, tuple):  # coercion protocols, which record no args
             return _ir.Union(tuple(map(_ir.Name, proto)))
         if proto == "CanArrayFunction":
-            ret = self.returns(members)
-            ret_str = _ir.render(ret) if ret is not None else _OBJECT
+            ret_str = _ir.render(_or_object(self.returns(members)))
             func = cast("_AnyFunc", members[0].args[0])
             return _ir.Name(_numpy.array_function_type(func, ret_str))
         args: list[_ir.Node | _ir.Arg] = [
@@ -372,7 +376,10 @@ class _Renderer:
             for key in members[0].kwargs
             if (kw := self.union(m.kwargs[key] for m in members)) is not None
         ]
-        if (ret := self.returns(members)) is not None:
+        ret = self.returns(members)
+        if proto == "CanCall":
+            return _ir.Fn(tuple(args), _or_object(ret))
+        if ret is not None:
             args.append(ret)
         return _ir.App(proto, tuple(args))
 
@@ -395,8 +402,7 @@ class _Renderer:
     def _slot(self, spy: _SpyObject) -> _ir.Node:
         if (var := self._vars.get(id(spy))) is not None:
             return _ir.Name(var)
-        node = self.spy(spy)
-        return node if node is not None else _ir.Name(_OBJECT)
+        return _or_object(self.spy(spy))
 
     def slot(self, spy: _SpyObject) -> str:
         return _ir.render(self._slot(spy))

--- a/optype/infer/_values.py
+++ b/optype/infer/_values.py
@@ -22,6 +22,7 @@ class _Fn(NamedTuple):
     names: tuple[str, ...]
     spies: Mapping[str, _SpyObject]
     fixed: Mapping[str, object]
+    defaults: Mapping[str, object]
     results: list[object]
 
 

--- a/optype/infer/_values.py
+++ b/optype/infer/_values.py
@@ -1,0 +1,55 @@
+"""The composite shapes of explored results, and the traversal over them."""
+
+from collections.abc import Collection, Generator, Iterable, Mapping
+from itertools import chain
+from typing import NamedTuple, cast
+
+from ._spy import _SpyObject
+
+__all__ = ("_Fn", "_Gen", "_children", "_fn_spies", "_walk")
+
+
+class _Gen(NamedTuple):
+    """An explored generator or lazy iterator result, e.g. `Generator[R]`."""
+
+    yielded: list[object]
+    kind: str
+
+
+class _Fn(NamedTuple):
+    """An explored function result, rendered in signature syntax."""
+
+    names: tuple[str, ...]
+    spies: Mapping[str, _SpyObject]
+    fixed: Mapping[str, object]
+    results: list[object]
+
+
+def _children(value: object) -> Iterable[object]:
+    """The values directly contained in an explored result."""
+    match value:
+        case _Gen():
+            return value.yielded
+        case _Fn():
+            return value.results
+        case tuple() | list() | set() | frozenset():
+            return cast("Collection[object]", value)
+        case dict():
+            mapping = cast("Mapping[object, object]", value)
+            return chain.from_iterable(mapping.items())
+        case _:
+            return ()
+
+
+def _walk(value: object) -> Generator[object]:
+    yield value
+    for child in _children(value):
+        yield from _walk(child)
+
+
+def _fn_spies(results: Iterable[object]) -> Generator[_SpyObject]:
+    # every parameter spy of the explored function results, in signature order
+    for result in results:
+        for node in _walk(result):
+            if isinstance(node, _Fn):
+                yield from node.spies.values()

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -1,5 +1,8 @@
 # ruff: noqa: FURB118
+# pyright: reportUnknownArgumentType=false, reportUnknownLambdaType=false
+# pyright: reportUnknownVariableType=false, reportUnusedParameter=false
 
+import functools
 import math
 import operator
 import subprocess  # noqa: S404
@@ -11,7 +14,7 @@ import pytest
 
 from optype.infer import InferError, InferWarning, infer
 from optype.infer._explore import _doc_params
-from optype.infer._ir import App, Lit, Name, Type, subtype
+from optype.infer._ir import App, Arg, Fn, Lit, Name, Type, subtype
 
 
 def _type_of[T](x: T) -> type[T]:
@@ -231,6 +234,12 @@ BINARY_CASES: list[tuple[Callable[[Any, Any], Any], str]] = [
     ),
     (lambda x, y: x[y], "[T, R](x: CanGetitem[T, R], y: T) -> R"),
     (lambda x, y: y[str(x)], "[R](x: CanStr, y: CanGetitem[str, R]) -> R"),
+    # `sorted` discards the `key` results, so they are unconstrained; the explicit
+    # `object` keeps the last argument out of the return slot
+    (
+        lambda xs, key: sorted(xs, key=key),
+        "[R](xs: CanIter[CanNext[R]], key: CanCall[R, object]) -> list[R]",
+    ),
     (lambda x, y: x, "[T](x: T, y: object) -> T"),  # noqa: ARG005
     (lambda x, y: (type(x), type(y)), "[T, U](x: T, y: U) -> tuple[type[T], type[U]]"),
     (
@@ -466,7 +475,138 @@ DEFAULT_CASES: list[tuple[Callable[..., Any], str]] = [
 ]
 
 
-INFER_CASES = [*UNARY_CASES, *BINARY_CASES, *VARIADIC_CASES, *DEFAULT_CASES]
+def _self_return(x: Any) -> Any:  # noqa: ARG001
+    return _self_return
+
+
+def _fn_factory(n: Any) -> Any:
+    return lambda: _fn_factory(n)
+
+
+def _fn_default(x: Any = 0) -> Any:
+    return lambda: x
+
+
+def _add2(x: Any, y: Any) -> Any:
+    return x + y
+
+
+def _counter(start: Any) -> Any:
+    return (lambda: start), (lambda by: start + by)
+
+
+FUNCTION_CASES: list[tuple[Callable[..., Any], str]] = [
+    # a returned function is lazy, so it is explored with placeholders of its own
+    # and renders in signature syntax; its parameter spies are named like parameters
+    (lambda x: lambda y: (x, y), "[T, U](x: T) -> (y: U) -> tuple[T, U]"),
+    (lambda x: lambda: x, "[T](x: T) -> () -> T"),
+    (lambda x: lambda y: y, "[T](x: object) -> (y: T) -> T"),  # noqa: ARG005
+    (lambda x: lambda *, y: (x, y), "[T, U](x: T) -> (y: U) -> tuple[T, U]"),
+    (lambda x: lambda y=1: (x, y), "[T, U](x: T) -> (y: U) -> tuple[T, U]"),
+    (
+        lambda x: lambda y: lambda z: (x, y, z),
+        "[T, U, V](x: T) -> (y: U) -> (z: V) -> tuple[T, U, V]",
+    ),
+    # an operation inside the returned function is required of the closed-over
+    # parameter, and is reflected onto its right-hand side like any other
+    (
+        lambda x: lambda y: x + y,
+        (
+            "[T, R](x: CanAdd[T, R]) -> (y: T) -> R\n"
+            "[T, R](x: T) -> (y: CanRAdd[T, R]) -> R"
+        ),
+    ),
+    (lambda x: lambda f: f(x), "[T, R](x: T) -> (f: CanCall[T, R]) -> R"),
+    # a failed inner run rolls back its traces on the closed-over parameter, so
+    # an optionally probed `__len__` is no requirement, just like in a direct call
+    (lambda x: lambda: len(x), "(x: CanLen) -> () -> int"),
+    (lambda x: lambda: list(x), "[R](x: CanIter[CanNext[R]]) -> () -> list[R]"),
+    # a returned builtin or method descriptor explores like a direct `infer`
+    (lambda: len, "() -> (obj: CanLen) -> int"),
+    (lambda: math.sqrt, "() -> (x: CanFloat | CanIndex) -> float"),
+    (lambda: str.upper, "() -> (self: str) -> str"),
+    # a `functools.partial` explores with its bound arguments in place
+    (
+        lambda: functools.partial(_add2, 1),
+        "[R]() -> (y: CanRAdd[Literal[1], R]) -> R",
+    ),
+    (
+        lambda x: functools.partial(_add2, x),
+        (
+            "[T, R](x: CanAdd[T, R]) -> (y: T) -> R\n"
+            "[T, R](x: T) -> (y: CanRAdd[T, R]) -> R"
+        ),
+    ),
+    # a function within a returned container is explored as well, but a set member
+    # must stay hashable, so it is left as-is
+    (
+        lambda x: (lambda y: y, 1),  # noqa: ARG005
+        "[T](x: object) -> tuple[(y: T) -> T, Literal[1]]",
+    ),
+    (lambda x: [lambda: x], "[T](x: T) -> list[() -> T]"),
+    (lambda x: {"get": lambda: x}, "[T](x: T) -> dict[Literal['get'], () -> T]"),
+    (lambda x: {lambda: x}, "(x: object) -> set[function]"),
+    (
+        _counter,
+        (
+            "[T: CanAdd[U, R], U, R](start: T) -> tuple[() -> T, (by: U) -> R]\n"
+            "[T, R](start: T) -> tuple[() -> T, (by: CanRAdd[T, R]) -> R]"
+        ),
+    ),
+    # a function type in a union is parenthesized; a covariant return type lets
+    # one union member absorb the other
+    (lambda x: (lambda: 1) if x else None, "(x: CanBool) -> (() -> int) | None"),
+    (lambda x: (lambda: True) if x else (lambda: 1), "(x: CanBool) -> () -> int"),
+    # a returned function returning a generator or a packed `*args` traces through
+    (
+        lambda x: lambda: (i for i in x),
+        "[R](x: CanIter[CanNext[R]]) -> () -> Generator[R]",
+    ),
+    (lambda *args: lambda: args, "[*Ts](*args: *Ts) -> () -> tuple[*Ts]"),
+    # a recursive function (factory) has an inexpressible type, so it stays opaque,
+    # as do variadic parameters and a `partial` of a non-function
+    (_self_return, "(x: object) -> function"),
+    (_fn_factory, "(n: object) -> () -> function"),
+    (lambda x: lambda *args: x, "(x: object) -> function"),  # noqa: ARG005
+    (lambda f: functools.partial(f, 1), "(f: object) -> partial"),
+    (lambda: functools.partial(print, "a"), "() -> partial"),
+]
+
+ITERATOR_CASES: list[tuple[Callable[..., Any], str]] = [
+    # lazy builtin iterators are iterated like generators, and render covariantly
+    (lambda x: map(str, x), "(x: CanIter[CanNext[CanStr]]) -> map[str]"),
+    (
+        lambda f, x: map(f, x),  # noqa: PLW0108
+        "[T, R](f: CanCall[T, R], x: CanIter[CanNext[T]]) -> map[R]",
+    ),
+    (lambda x: filter(None, x), "[R: CanBool](x: CanIter[CanNext[R]]) -> filter[R]"),
+    (
+        lambda x, y: zip(x, y),  # noqa: B905, PLW0108
+        "[R, R2](x: CanIter[CanNext[R]], y: CanIter[CanNext[R2]]) -> zip[tuple[R, R2]]",
+    ),
+    # `enumerate[R]` is parameterized by the element type, not the yielded pair
+    (lambda x: enumerate(x), "[R](x: CanIter[CanNext[R]]) -> enumerate[R]"),  # noqa: PLW0108
+    (
+        lambda x: enumerate([True]) if x else enumerate([1]),
+        "(x: CanBool) -> enumerate[int]",
+    ),
+    (lambda: map(str, [1, 2]), "() -> map[str]"),
+    (lambda: zip((), ()), "() -> zip[Never]"),  # noqa: B905
+    (
+        lambda x: ((i for i in x), 1),
+        "[R](x: CanIter[CanNext[R]]) -> tuple[Generator[R], Literal[1]]",
+    ),
+]
+
+
+INFER_CASES = [
+    *UNARY_CASES,
+    *BINARY_CASES,
+    *VARIADIC_CASES,
+    *DEFAULT_CASES,
+    *FUNCTION_CASES,
+    *ITERATOR_CASES,
+]
 
 
 @pytest.mark.parametrize(
@@ -557,6 +697,20 @@ SUBTYPE_CASES: list[tuple[Any, Any, bool]] = [
     # type is covariant
     (App("type", (Type(bool),)), App("type", (Type(int),)), True),
     (App("type", (Type(int),)), App("type", (Type(bool),)), False),
+    # a function's parameters are contravariant, its return type is covariant
+    (Fn((), Type(bool)), Fn((), Type(int)), True),
+    (Fn((), Type(int)), Fn((), Type(bool)), False),
+    (
+        Fn((Arg("x", Type(int)),), Type(int)),
+        Fn((Arg("x", Type(bool)),), Type(int)),
+        True,
+    ),
+    (
+        Fn((Arg("x", Type(bool)),), Type(int)),
+        Fn((Arg("x", Type(int)),), Type(int)),
+        False,
+    ),
+    (Fn((), Type(int)), Fn((Arg("x", Type(int)),), Type(int)), False),
 ]
 
 
@@ -653,8 +807,10 @@ def test_infer_async() -> None:
         async with x as y:
             return y
 
+    # the `__aexit__` awaitable resolves to an unused, and so unconstrained, result
     assert infer(async_with) == (
-        "[R](x: CanAEnter[CanAwait[R]] & CanAExit[None, None, None, CanAwait]) -> R"
+        "[R](x: CanAEnter[CanAwait[R]] & "
+        "CanAExit[None, None, None, CanAwait[object]]) -> R"
     )
 
     async def async_for(x: Any) -> Any:
@@ -730,6 +886,33 @@ def test_infer_generator_yields() -> None:
             yield x + 1
 
     assert infer(loop) == "[R](x: CanAdd[Literal[1], R]) -> Generator[R]"
+
+
+def test_returned_function_default() -> None:
+    # a typevar default reaches through the returned function's body
+    assert infer(_fn_default) == "[T = Literal[0]](x: T = 0) -> () -> T"
+
+
+def test_returned_function_async() -> None:
+    # an inner coroutine function is driven to completion, like the outer one
+    async def make(x: Any) -> Any:  # noqa: RUF029
+        async def inner(y: Any) -> Any:  # noqa: RUF029
+            return (x, y)
+
+        return inner
+
+    assert infer(make) == "[T, U](x: T) -> (y: U) -> tuple[T, U]"
+
+
+def test_returned_function_mutual_recursion() -> None:
+    # mutually recursive functions terminate; the cycle stays opaque
+    def ping(x: Any) -> Any:  # noqa: ARG001
+        return pong
+
+    def pong(x: Any) -> Any:  # noqa: ARG001
+        return ping
+
+    assert infer(ping) == "(x: object) -> (x: object) -> function"
 
 
 def test_infer_empty_container() -> None:
@@ -872,10 +1055,16 @@ def test_set_name() -> None:
 NO_PROTOCOL_CASES: list[Callable[[Any], Any]] = [
     lambda x: x.foo,
     _set_attr,
+    # an inexpressible operation inside a returned function fails just as honestly
+    lambda x: lambda y: y.foo,  # noqa: ARG005  # pyright: ignore[reportUnknownMemberType]
 ]
 
 
-@pytest.mark.parametrize("func", NO_PROTOCOL_CASES, ids=["getattr", "setattr"])
+@pytest.mark.parametrize(
+    "func",
+    NO_PROTOCOL_CASES,
+    ids=["getattr", "setattr", "returned"],
+)
 def test_no_protocol(func: Callable[[Any], Any]) -> None:
     with pytest.raises(InferError, match="no protocol"):
         infer(func)
@@ -921,6 +1110,12 @@ def test_cli_variadic() -> None:
     out = _run_cli("-m", "optype", "infer", "lambda *args: args")
     assert out.returncode == 0
     assert out.stdout.strip() == "[*Ts](*args: *Ts) -> tuple[*Ts]"
+
+
+def test_cli_returned_function() -> None:
+    out = _run_cli("-m", "optype", "infer", "lambda x: lambda y: (x, y)")
+    assert out.returncode == 0
+    assert out.stdout.strip() == "[T, U](x: T) -> (y: U) -> tuple[T, U]"
 
 
 def test_cli_usage() -> None:

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -57,10 +57,10 @@ UNARY_CASES: list[tuple[Callable[[Any], Any], str]] = [
     (lambda x: int(x), "(x: CanInt | CanIndex) -> int"),  # noqa: PLW0108
     (lambda x: complex(x), "(x: CanComplex | CanFloat | CanIndex) -> complex"),  # noqa: PLW0108
     (operator.index, "(a: CanIndex) -> int"),
-    (lambda x: x(), "[R](x: CanCall[R]) -> R"),
-    (lambda x: x(1, 2), "[R](x: CanCall[Literal[1], Literal[2], R]) -> R"),
-    (lambda x: x(a=1), "[R](x: CanCall[a=Literal[1], R]) -> R"),
-    (lambda x: x(1, b=2), "[R](x: CanCall[Literal[1], b=Literal[2], R]) -> R"),
+    (lambda x: x(), "[R](x: () -> R) -> R"),
+    (lambda x: x(1, 2), "[R](x: (Literal[1], Literal[2]) -> R) -> R"),
+    (lambda x: x(a=1), "[R](x: (a: Literal[1]) -> R) -> R"),
+    (lambda x: x(1, b=2), "[R](x: (Literal[1], b: Literal[2]) -> R) -> R"),
     (lambda x: format(x, ">10"), "(x: CanFormat[Literal['>10']]) -> str"),
     (lambda x: f"{x}", "(x: CanFormat[Literal['']]) -> str"),
     (lambda x: x[0], "[R](x: CanGetitem[Literal[0], R]) -> R"),
@@ -238,7 +238,7 @@ BINARY_CASES: list[tuple[Callable[[Any, Any], Any], str]] = [
     # `object` keeps the last argument out of the return slot
     (
         lambda xs, key: sorted(xs, key=key),
-        "[R](xs: CanIter[CanNext[R]], key: CanCall[R, object]) -> list[R]",
+        "[R](xs: CanIter[CanNext[R]], key: (R) -> object) -> list[R]",
     ),
     (lambda x, y: x, "[T](x: T, y: object) -> T"),  # noqa: ARG005
     (lambda x, y: (type(x), type(y)), "[T, U](x: T, y: U) -> tuple[type[T], type[U]]"),
@@ -343,7 +343,7 @@ VARIADIC_CASES: list[tuple[Callable[..., Any], str]] = [
     # a variadic parameter whose every use is packed becomes a TypeVarTuple
     (lambda *args: args, "[*Ts](*args: *Ts) -> tuple[*Ts]"),
     (lambda *args: (args, 1), "[*Ts](*args: *Ts) -> tuple[tuple[*Ts], Literal[1]]"),
-    (_call_packed, "[*Ts, R](x: CanCall[tuple[*Ts], R], *args: *Ts) -> R"),
+    (_call_packed, "[*Ts, R](x: (tuple[*Ts]) -> R, *args: *Ts) -> R"),
     # a splat splices the TypeVarTuple into the surrounding tuple
     (lambda *args: (1, *args), "[*Ts](*args: *Ts) -> tuple[Literal[1], *Ts]"),
     (
@@ -516,7 +516,7 @@ FUNCTION_CASES: list[tuple[Callable[..., Any], str]] = [
             "[T, R](x: T) -> (y: CanRAdd[T, R]) -> R"
         ),
     ),
-    (lambda x: lambda f: f(x), "[T, R](x: T) -> (f: CanCall[T, R]) -> R"),
+    (lambda x: lambda f: f(x), "[T, R](x: T) -> (f: (T) -> R) -> R"),
     # a failed inner run rolls back its traces on the closed-over parameter, so
     # an optionally probed `__len__` is no requirement, just like in a direct call
     (lambda x: lambda: len(x), "(x: CanLen) -> () -> int"),
@@ -577,7 +577,7 @@ ITERATOR_CASES: list[tuple[Callable[..., Any], str]] = [
     (lambda x: map(str, x), "(x: CanIter[CanNext[CanStr]]) -> map[str]"),
     (
         lambda f, x: map(f, x),  # noqa: PLW0108
-        "[T, R](f: CanCall[T, R], x: CanIter[CanNext[T]]) -> map[R]",
+        "[T, R](f: (T) -> R, x: CanIter[CanNext[T]]) -> map[R]",
     ),
     (lambda x: filter(None, x), "[R: CanBool](x: CanIter[CanNext[R]]) -> filter[R]"),
     (
@@ -959,12 +959,12 @@ def test_infer_ufunc_in_function() -> None:
 def test_infer_array_function() -> None:
     np = pytest.importorskip("numpy")
     # NEP-18 functions (np.mean, np.strings.upper, ...) dispatch via __array_function__
-    sig = "[R](a: CanArrayFunction[CanCall[Any, R], R]) -> R"
+    sig = "[R](a: CanArrayFunction[(Any) -> R, R]) -> R"
     assert infer(np.mean) == sig
     assert infer(np.sum) == sig
     # the func type's arity tracks the required positional params (a, b)
     assert infer(np.outer) == (
-        "[R](a: CanArrayFunction[CanCall[Any, Any, R], R], b: object) -> R"
+        "[R](a: CanArrayFunction[(Any, Any) -> R, R], b: object) -> R"
     )
 
 

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -495,6 +495,10 @@ def _counter(start: Any) -> Any:
     return (lambda: start), (lambda by: start + by)
 
 
+def _yield_fn(x: Any) -> Any:
+    yield lambda: x
+
+
 FUNCTION_CASES: list[tuple[Callable[..., Any], str]] = [
     # a returned function is lazy, so it is explored with placeholders of its own
     # and renders in signature syntax; its parameter spies are named like parameters
@@ -502,7 +506,7 @@ FUNCTION_CASES: list[tuple[Callable[..., Any], str]] = [
     (lambda x: lambda: x, "[T](x: T) -> () -> T"),
     (lambda x: lambda y: y, "[T](x: object) -> (y: T) -> T"),  # noqa: ARG005
     (lambda x: lambda *, y: (x, y), "[T, U](x: T) -> (y: U) -> tuple[T, U]"),
-    (lambda x: lambda y=1: (x, y), "[T, U](x: T) -> (y: U) -> tuple[T, U]"),
+    (lambda x: lambda y=1: (x, y), "[T, U](x: T) -> (y: U = 1) -> tuple[T, U]"),
     (
         lambda x: lambda y: lambda z: (x, y, z),
         "[T, U, V](x: T) -> (y: U) -> (z: V) -> tuple[T, U, V]",
@@ -521,10 +525,19 @@ FUNCTION_CASES: list[tuple[Callable[..., Any], str]] = [
     # an optionally probed `__len__` is no requirement, just like in a direct call
     (lambda x: lambda: len(x), "(x: CanLen) -> () -> int"),
     (lambda x: lambda: list(x), "[R](x: CanIter[CanNext[R]]) -> () -> list[R]"),
-    # a returned builtin or method descriptor explores like a direct `infer`
+    # a returned builtin or method descriptor explores like a direct `infer`,
+    # including the lenient fallback that pins a rejected defaulted parameter
     (lambda: len, "() -> (obj: CanLen) -> int"),
     (lambda: math.sqrt, "() -> (x: CanFloat | CanIndex) -> float"),
     (lambda: str.upper, "() -> (self: str) -> str"),
+    (
+        lambda: str.split,
+        "() -> (self: str, sep: None = None, maxsplit: CanIndex = -1) -> list[Never]",
+    ),
+    (
+        lambda: dict.get,  # pyright: ignore[reportUnknownMemberType]
+        "[T]() -> (self: dict, key: CanHash, default: T = None) -> T",
+    ),
     # a `functools.partial` explores with its bound arguments in place
     (
         lambda: functools.partial(_add2, 1),
@@ -546,6 +559,8 @@ FUNCTION_CASES: list[tuple[Callable[..., Any], str]] = [
     (lambda x: [lambda: x], "[T](x: T) -> list[() -> T]"),
     (lambda x: {"get": lambda: x}, "[T](x: T) -> dict[Literal['get'], () -> T]"),
     (lambda x: {lambda: x}, "(x: object) -> set[function]"),
+    # ...and so is a function within the yields of a generator
+    (_yield_fn, "[T](x: T) -> Generator[() -> T]"),
     (
         _counter,
         (
@@ -573,11 +588,15 @@ FUNCTION_CASES: list[tuple[Callable[..., Any], str]] = [
 ]
 
 ITERATOR_CASES: list[tuple[Callable[..., Any], str]] = [
-    # lazy builtin iterators are iterated like generators, and render covariantly
+    # lazy builtin iterators are iterated like generators
     (lambda x: map(str, x), "(x: CanIter[CanNext[CanStr]]) -> map[str]"),
     (
         lambda f, x: map(f, x),  # noqa: PLW0108
         "[T, R](f: (T) -> R, x: CanIter[CanNext[T]]) -> map[R]",
+    ),
+    (
+        lambda x: map(lambda v: lambda: v, x),
+        "[R](x: CanIter[CanNext[R]]) -> map[() -> R]",
     ),
     (lambda x: filter(None, x), "[R: CanBool](x: CanIter[CanNext[R]]) -> filter[R]"),
     (
@@ -586,9 +605,14 @@ ITERATOR_CASES: list[tuple[Callable[..., Any], str]] = [
     ),
     # `enumerate[R]` is parameterized by the element type, not the yielded pair
     (lambda x: enumerate(x), "[R](x: CanIter[CanNext[R]]) -> enumerate[R]"),  # noqa: PLW0108
+    # only `zip` is covariant in typeshed, so an `enumerate` union does not absorb
+    (
+        lambda x: zip([FileNotFoundError()]) if x else zip([OSError()]),
+        "(x: CanBool) -> zip[tuple[OSError]]",
+    ),
     (
         lambda x: enumerate([True]) if x else enumerate([1]),
-        "(x: CanBool) -> enumerate[int]",
+        "(x: CanBool) -> enumerate[bool] | enumerate[int]",
     ),
     (lambda: map(str, [1, 2]), "() -> map[str]"),
     (lambda: zip((), ()), "() -> zip[Never]"),  # noqa: B905
@@ -711,6 +735,10 @@ SUBTYPE_CASES: list[tuple[Any, Any, bool]] = [
         False,
     ),
     (Fn((), Type(int)), Fn((Arg("x", Type(int)),), Type(int)), False),
+    # `zip` is covariant in typeshed; `map`, `filter`, and `enumerate` are invariant
+    (App("zip", (Type(bool),)), App("zip", (Type(int),)), True),
+    (App("map", (Type(bool),)), App("map", (Type(int),)), False),
+    (App("enumerate", (Type(bool),)), App("enumerate", (Type(int),)), False),
 ]
 
 


### PR DESCRIPTION
```bash
$ optype infer "lambda x: lambda y: (x, y)"
[T, U](x: T) -> (y: U) -> tuple[T, U]

$ optype infer "lambda f, x: f(x)"
[T, R](f: (T) -> R, x: T) -> R

$ optype infer "lambda f, g: lambda x: f(g(x))"
[T, U, R](f: (U) -> R, g: (T) -> U) -> (x: T) -> R

$ optype infer "lambda f: f(f)"
[T: (T) -> R, R](f: T) -> R
```

closes #643