### PR TITLE
`infer`: `CanWith` and `CanAsyncWith`

### DIFF
--- a/docs/reference/experimental/infer.md
+++ b/docs/reference/experimental/infer.md
@@ -77,6 +77,9 @@ class CanNegRAdd[T, R](CanNeg[T], CanRAdd[T, R], Protocol): ...
 ```
 
 This turns the `CanNeg[T] & CanRAdd[T, R]` above into the valid `CanNegRAdd[T, R]`.
+Where `optype` already ships the combined protocol, `infer` reports it directly: a
+traced `with` statement renders as [`CanWith`](#context-managers) rather than
+`CanEnter & CanExit`.
 
 Only an intersection of the same protocol shares its method, which happens when an
 operation is traced at several arities:
@@ -262,15 +265,15 @@ $ optype infer "str.split"
 
 ## Context managers
 
-A `with` statement requires `CanEnter` and `CanExit`; on a clean exit, `__exit__` is
-called with `(None, None, None)`:
+A `with` statement requires `__enter__` and `__exit__` together, which `optype` combines
+as `CanWith`; the `__exit__` result is unused, so it stays `object`:
 
 ```pycon
 >>> def f(x):
 ...     with x as y:
 ...         return y
 >>> infer(f)
-'[R](x: CanEnter[R] & CanExit[None, None, None]) -> R'
+'[R](x: CanWith[R, object]) -> R'
 ```
 
 ## Async
@@ -286,14 +289,15 @@ $ optype infer "async def f(xs): return [x async for x in xs]"
 [R](xs: CanAIter[CanANext[CanAwait[R]]]) -> list[R]
 ```
 
-`async with` requires `CanAEnter` and `CanAExit`, whose results must be awaitable:
+`async with` combines `__aenter__` and `__aexit__` as `CanAsyncWith`, whose parameters
+are the awaited results:
 
 ```pycon
 >>> async def f(x):
 ...     async with x as y:
 ...         return y
 >>> infer(f)
-'[R](x: CanAEnter[CanAwait[R]] & CanAExit[None, None, None, CanAwait]) -> R'
+'[R](x: CanAsyncWith[R, object]) -> R'
 ```
 
 ## Generators and lazy iterators

--- a/optype/infer/_render.py
+++ b/optype/infer/_render.py
@@ -244,6 +244,35 @@ def _suffix(defaults: _Defaults, name: str) -> str:
     return f" = {value!r}" if simple else " = ..."
 
 
+_CLEAN_EXIT = _ir.App("CanExit", (_ir.Name("None"),) * 3)
+_CLEAN_AEXIT = _ir.App(
+    "CanAExit",
+    (*(_ir.Name("None"),) * 3, _ir.App("CanAwait", (_ir.Name(_OBJECT),))),
+)
+
+
+def _merge_context(parts: list[_ir.Node]) -> list[_ir.Node]:
+    """Merge a traced `(async) with` statement into its combined protocol.
+
+    A `with` statement requires `__enter__` and a clean-exit `__exit__` together,
+    which optype combines as `CanWith`; the unused `__exit__` result is unconstrained.
+    An `async with` merges into `CanAsyncWith` likewise, whose declared parameters are
+    the awaited results, so the `CanAwait` wrappers unwrap.
+    """
+    for enter in parts:
+        match enter:
+            case _ir.App("CanEnter", (entered,)):
+                clean_exit, combined = _CLEAN_EXIT, "CanWith"
+            case _ir.App("CanAEnter", (_ir.App("CanAwait", (entered,)),)):
+                clean_exit, combined = _CLEAN_AEXIT, "CanAsyncWith"
+            case _:
+                continue
+        if clean_exit in parts:
+            merged = _ir.App(combined, (entered, _ir.Name(_OBJECT)))
+            parts = [merged if p is enter else p for p in parts if p != clean_exit]
+    return parts
+
+
 @final
 class _Renderer:
     """Render an inferred `def` signature from the recorded spy traces."""
@@ -394,7 +423,8 @@ class _Renderer:
             op = _resolve(item)
             key = op.proto, len(op.args), tuple(sorted(op.kwargs))
             groups.setdefault(key, []).append(op)
-        return _ir.inter([self.group(key[0], group) for key, group in groups.items()])
+        parts = [self.group(key[0], group) for key, group in groups.items()]
+        return _ir.inter(_merge_context(parts))
 
     def spy(self, spy: _SpyObject) -> _ir.Node | None:
         return self.traces(self._traces[id(spy)])

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -824,6 +824,34 @@ def test_ternary_pow() -> None:
     )
 
 
+def test_infer_with() -> None:
+    # a `with` statement requires `__enter__` and `__exit__` together, which is the
+    # combined `CanWith`; its unused `__exit__` result is unconstrained
+    def f(x: Any) -> Any:
+        with x as y:
+            return y
+
+    assert infer(f) == "[R](x: CanWith[R, object]) -> R"
+
+    def g(x: Any) -> Any:
+        with x as y:
+            return y + 1
+
+    assert infer(g) == "[R](x: CanWith[CanAdd[Literal[1], R], object]) -> R"
+
+    # a lone `__enter__` or `__exit__` does not imply the other, so it stays as-is
+    def enter_only(x: Any) -> Any:
+        x.__enter__()  # noqa: PLC2801
+        return x
+
+    assert infer(enter_only) == "[T: CanEnter[object]](x: T) -> T"
+
+    def exit_only(x: Any) -> Any:
+        return x.__exit__(None, None, None)
+
+    assert infer(exit_only) == "(x: CanExit[None, None, None]) -> None"
+
+
 def test_infer_async() -> None:
     # coroutine functions are driven to completion; await/async with/async for trace
     async def aw(x: Any) -> Any:
@@ -835,10 +863,26 @@ def test_infer_async() -> None:
         async with x as y:
             return y
 
-    # the `__aexit__` awaitable resolves to an unused, and so unconstrained, result
-    assert infer(async_with) == (
-        "[R](x: CanAEnter[CanAwait[R]] & "
-        "CanAExit[None, None, None, CanAwait[object]]) -> R"
+    # like `CanWith`, but its declared parameters are the awaited results
+    assert infer(async_with) == "[R](x: CanAsyncWith[R, object]) -> R"
+
+    async def aenter_only(x: Any) -> Any:
+        return await x.__aenter__()  # noqa: PLC2801
+
+    assert infer(aenter_only) == "[R](x: CanAEnter[CanAwait[R]]) -> R"
+
+    async def aexit_only(x: Any) -> Any:
+        return await x.__aexit__(None, None, None)
+
+    assert infer(aexit_only) == "[R](x: CanAExit[None, None, None, CanAwait[R]]) -> R"
+
+    async def both(x: Any) -> Any:
+        with x:
+            async with x as y:
+                return y
+
+    assert infer(both) == (
+        "[R](x: CanWith[object, object] & CanAsyncWith[R, object]) -> R"
     )
 
     async def async_for(x: Any) -> Any:


### PR DESCRIPTION
`CanEnter & CanExit` are now simplified to `CanWith`. Same with (pun intended) the async variants.