### PR TITLE
`infer`: `CanSequence`

### DIFF
--- a/docs/reference/experimental/infer.md
+++ b/docs/reference/experimental/infer.md
@@ -77,9 +77,14 @@ class CanNegRAdd[T, R](CanNeg[T], CanRAdd[T, R], Protocol): ...
 ```
 
 This turns the `CanNeg[T] & CanRAdd[T, R]` above into the valid `CanNegRAdd[T, R]`.
-Where `optype` already ships the combined protocol, `infer` reports it directly: a
-traced `with` statement renders as [`CanWith`](#context-managers) rather than
-`CanEnter & CanExit`.
+Where `optype` already ships the combined protocol, `infer` reports it directly:
+`CanGetitem & CanLen` merges into `CanSequence`, and a traced `with` statement renders
+as [`CanWith`](#context-managers) rather than `CanEnter & CanExit`:
+
+```console
+$ optype infer "lambda x, i: x[i] if len(x) else None"
+[T, R](x: CanSequence[T, R], i: T) -> R | None
+```
 
 Only an intersection of the same protocol shares its method, which happens when an
 operation is traced at several arities:

--- a/optype/infer/_render.py
+++ b/optype/infer/_render.py
@@ -249,27 +249,32 @@ _CLEAN_AEXIT = _ir.App(
     "CanAExit",
     (*(_ir.Name("None"),) * 3, _ir.App("CanAwait", (_ir.Name(_OBJECT),))),
 )
+_LEN = _ir.App("CanLen", ())
 
 
-def _merge_context(parts: list[_ir.Node]) -> list[_ir.Node]:
-    """Merge a traced `(async) with` statement into its combined protocol.
+def _merge_combined(parts: list[_ir.Node]) -> list[_ir.Node]:
+    """Merge an intersection pair into the combined protocol that optype ships.
 
     A `with` statement requires `__enter__` and a clean-exit `__exit__` together,
-    which optype combines as `CanWith`; the unused `__exit__` result is unconstrained.
-    An `async with` merges into `CanAsyncWith` likewise, whose declared parameters are
-    the awaited results, so the `CanAwait` wrappers unwrap.
+    which combine as `CanWith`; the unused `__exit__` result is unconstrained.
+    `CanAsyncWith` is alike, but its declared parameters are the awaited results, so
+    the `CanAwait` wrappers unwrap. `CanGetitem & CanLen` combines as `CanSequence`.
     """
-    for enter in parts:
-        match enter:
+    for app in parts:
+        match app:
             case _ir.App("CanEnter", (entered,)):
-                clean_exit, combined = _CLEAN_EXIT, "CanWith"
+                partner = _CLEAN_EXIT
+                merged = _ir.App("CanWith", (entered, _ir.Name(_OBJECT)))
             case _ir.App("CanAEnter", (_ir.App("CanAwait", (entered,)),)):
-                clean_exit, combined = _CLEAN_AEXIT, "CanAsyncWith"
+                partner = _CLEAN_AEXIT
+                merged = _ir.App("CanAsyncWith", (entered, _ir.Name(_OBJECT)))
+            case _ir.App("CanGetitem", (key, value)):
+                partner = _LEN
+                merged = _ir.App("CanSequence", (key, value))
             case _:
                 continue
-        if clean_exit in parts:
-            merged = _ir.App(combined, (entered, _ir.Name(_OBJECT)))
-            parts = [merged if p is enter else p for p in parts if p != clean_exit]
+        if partner in parts:
+            parts = [merged if p is app else p for p in parts if p != partner]
     return parts
 
 
@@ -424,7 +429,7 @@ class _Renderer:
             key = op.proto, len(op.args), tuple(sorted(op.kwargs))
             groups.setdefault(key, []).append(op)
         parts = [self.group(key[0], group) for key, group in groups.items()]
-        return _ir.inter(_merge_context(parts))
+        return _ir.inter(_merge_combined(parts))
 
     def spy(self, spy: _SpyObject) -> _ir.Node | None:
         return self.traces(self._traces[id(spy)])

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -96,9 +96,10 @@ UNARY_CASES: list[tuple[Callable[[Any], Any], str]] = [
             "CanSub[Literal[1], R2]) -> R | R2"
         ),
     ),
+    # `CanGetitem & CanLen` combines as `CanSequence`
     (
         lambda x: x[0] if len(x) else None,
-        "[R](x: CanLen & CanGetitem[Literal[0], R]) -> R | None",
+        "[R](x: CanSequence[Literal[0], R]) -> R | None",
     ),
     (
         lambda x: -x if int(x) else +x,
@@ -110,7 +111,7 @@ UNARY_CASES: list[tuple[Callable[[Any], Any], str]] = [
     ),
     (
         lambda x: "empty" if len(x) == 0 else x[0],
-        "[R](x: CanLen & CanGetitem[Literal[0], R]) -> R | str",
+        "[R](x: CanSequence[Literal[0], R]) -> R | str",
     ),
     (lambda x: len(x) + int(x), "(x: CanLen & (CanInt | CanIndex)) -> int"),
     (lambda x: True if x else 1, "(x: CanBool) -> int"),
@@ -126,7 +127,7 @@ UNARY_CASES: list[tuple[Callable[[Any], Any], str]] = [
     (
         lambda x: x[0] if len(x) else (-x if int(x) else None),
         (
-            "[R, R2](x: CanLen & CanGetitem[Literal[0], R] & "
+            "[R, R2](x: CanSequence[Literal[0], R] & "
             "(CanInt | CanIndex) & CanNeg[R2]) -> R | R2 | None"
         ),
     ),
@@ -262,7 +263,11 @@ BINARY_CASES: list[tuple[Callable[[Any, Any], Any], str]] = [
     ),
     (
         lambda x, y: x[0] if len(x) else y,
-        "[T, R](x: CanLen & CanGetitem[Literal[0], R], y: T) -> R | T",
+        "[T, R](x: CanSequence[Literal[0], R], y: T) -> R | T",
+    ),
+    (
+        lambda x, y: x[y] if len(x) else None,
+        "[T, R](x: CanSequence[T, R], y: T) -> R | None",
     ),
     (
         lambda x, y: (x + y) if len(x) else y,


### PR DESCRIPTION
`CanGetitem[R, T] & CanLen` now simplifies to `CanSequence[R, T]`