### PR TITLE
`infer`: hide pos-only param names

### DIFF
--- a/docs/reference/experimental/infer.md
+++ b/docs/reference/experimental/infer.md
@@ -24,8 +24,8 @@ the result as a [PEP 695](https://peps.python.org/pep-0695/) signature.
 >>> infer(lambda x: x + 1)
 '[R](x: CanAdd[Literal[1], R]) -> R'
 >>> print(infer(list))
-(iterable: tuple[()] = ...) -> list[Never]
-[R](iterable: CanIter[CanNext[R]] & ~tuple[()]) -> list[R]
+(tuple[()] = ...) -> list[Never]
+[R](CanIter[CanNext[R]] & ~tuple[()]) -> list[R]
 ```
 
 Pass parameter names or positions to report only those parameters:
@@ -43,7 +43,7 @@ $ optype infer "lambda x: x * 2"
 [R](x: CanMul[Literal[2], R]) -> R
 
 $ optype infer "import math; math.sqrt"
-(x: CanFloat | CanIndex) -> float
+(CanFloat | CanIndex) -> float
 ```
 
 ## Overloads
@@ -258,16 +258,17 @@ def f(x=MISSING): return [] if x is MISSING else x"
 ## Methods
 
 Anything callable can be inferred: not just functions, but also builtins (like
-`math.sqrt` above), callable instances, and unbound method descriptors. A method
-descriptor's `self` requires a real instance of its defining class, so it is reported
-as that concrete type:
+`math.sqrt` above), callable instances, and unbound method descriptors. A
+positional-only parameter cannot be passed by keyword, so it renders as a bare type
+without its name. A method descriptor's `self` requires a real instance of its
+defining class, so it is reported as that concrete type:
 
 ```console
 $ optype infer "str.upper"
-(self: str) -> str
+(str) -> str
 
 $ optype infer "dict.get"
-[T = None](self: dict, key: CanHash, default: T = None) -> T
+[T = None](dict, CanHash, T = None) -> T
 ```
 
 When a builtin rejects the recording proxy for a defaulted parameter, its default is
@@ -276,7 +277,7 @@ structural:
 
 ```console
 $ optype infer "str.split"
-(self: str, sep: None = None, maxsplit: CanIndex = -1) -> list[Never]
+(str, sep: None = None, maxsplit: CanIndex = -1) -> list[Never]
 ```
 
 ## Context managers
@@ -367,7 +368,7 @@ returned container:
 
 ```console
 $ optype infer "lambda: str.upper"
-() -> (self: str) -> str
+() -> (str) -> str
 
 $ optype infer "import functools
 def add(x, y): return x + y

--- a/optype/infer/_api.py
+++ b/optype/infer/_api.py
@@ -129,18 +129,17 @@ def _defaults(
     if signatures(_bind_recon(recon, defaults), required, names) == observed:
         return defaults, False, []
 
-    overloads = signatures(omitted, required, selected, defaults)
+    overloads = signatures(omitted, params, selected, defaults)
 
     if len(defaults) == 1:
         return defaults, True, overloads
 
     for name, value in defaults.items():
-        rest = {n: p for n, p in params.items() if n != name}
         try:
             variant = _explore_spies(func, params, omit={name})
         except Exception:  # noqa: BLE001, S112
             continue
-        overloads += signatures(variant, rest, selected, {name: value})
+        overloads += signatures(variant, params, selected, {name: value})
 
     return {}, False, overloads
 

--- a/optype/infer/_explore.py
+++ b/optype/infer/_explore.py
@@ -232,7 +232,7 @@ def _explore_func(func: _AnyFunc) -> object:
     except Exception:  # noqa: BLE001  # an unexplorable function stays opaque
         return func
     spies, _, results, _, fixed = recon
-    return _Fn(tuple(params), spies, fixed, _declared_defaults(params), results)
+    return _Fn(params, spies, fixed, _declared_defaults(params), results)
 
 
 def _next(result: object) -> object:

--- a/optype/infer/_ir.py
+++ b/optype/infer/_ir.py
@@ -56,9 +56,9 @@ class Name:
 
 @dataclass(frozen=True, slots=True)
 class Arg:
-    """A keyword-labeled parameter, e.g. `a: Literal[1]` in `(a: Literal[1]) -> R`."""
+    """An optionally keyword-labeled parameter, e.g. `a: Literal[1]` or `T = 1`."""
 
-    key: str
+    key: str | None
     value: Node
     suffix: str = ""  # an optional ` = <default>` display suffix
 
@@ -224,7 +224,7 @@ def render(node: Node) -> str:
             out = f"{base}[{', '.join(parts)}]" if parts else base
         case Fn(params, ret):
             decls = ", ".join(
-                f"{p.key}: {render(p.value)}{p.suffix}"
+                (f"{p.key}: " if p.key else "") + f"{render(p.value)}{p.suffix}"
                 if isinstance(p, Arg)
                 else render(p)
                 for p in params

--- a/optype/infer/_render.py
+++ b/optype/infer/_render.py
@@ -302,6 +302,9 @@ class _Renderer:
         self._traces = traces
 
         self._prefix = {n: _PARAM_PREFIX.get(p.kind, "") for n, p in params.items()}
+        self._nameless = {
+            n for n, p in params.items() if p.kind is Parameter.POSITIONAL_ONLY
+        }
         self._optional = {
             name
             for name, p in params.items()
@@ -494,8 +497,12 @@ class _Renderer:
     def _function(self, fn: _Fn) -> _ir.Node:
         """The signature-syntax type of an explored function result."""
         params = tuple(
-            _ir.Arg(name, self._fn_param(fn, name), _suffix(fn.defaults, name))
-            for name in fn.names
+            _ir.Arg(
+                None if p.kind is Parameter.POSITIONAL_ONLY else name,
+                self._fn_param(fn, name),
+                _suffix(fn.defaults, name),
+            )
+            for name, p in fn.params.items()
         )
         return _ir.Fn(params, self._union_type(fn.results))
 
@@ -596,21 +603,23 @@ class _Renderer:
         return f"{generics}({params}) -> {self.return_types()}"
 
     def _param(self, name: str, defaults: _Defaults, *, negate: bool) -> str | None:
+        # a positional-only parameter cannot be passed by keyword, so no name shows
+        label = "" if name in self._nameless else f"{self._prefix[name]}{name}: "
         if name in self._fixed and name not in self._optional:
             # a fixed parameter without a default is a method descriptor's `self`
-            return f"{name}: {_ir.render(_ir.Type(type(self._fixed[name])))}"
+            return f"{label}{_ir.render(_ir.Type(type(self._fixed[name])))}"
         if (spy := self._spies.get(name)) is None:
             # an omitted parameter binds its default, so passing it behaves the same
             node = self.union((defaults[name],)) or _ir.Name(_NEVER)
-            return f"{name}: {_ir.render(node)}{_suffix(defaults, name)}"
+            return f"{label}{_ir.render(node)}{_suffix(defaults, name)}"
         slot = self.slot(spy)
         if negate and name in defaults:
             if id(spy) not in self._vars and (mark := self.union((defaults[name],))):
                 slot = _ir.render(_ir.exclude(self.spy(spy), mark))
-            return f"{self._prefix[name]}{name}: {slot}"
+            return f"{label}{slot}"
         if slot == _OBJECT and name in self._optional:
             return None
-        return f"{self._prefix[name]}{name}: {slot}{_suffix(defaults, name)}"
+        return f"{label}{slot}{_suffix(defaults, name)}"
 
 
 def _reflect(

--- a/optype/infer/_values.py
+++ b/optype/infer/_values.py
@@ -1,6 +1,7 @@
 """The composite shapes of explored results, and the traversal over them."""
 
 from collections.abc import Collection, Generator, Iterable, Mapping
+from inspect import Parameter
 from itertools import chain
 from typing import NamedTuple, cast
 
@@ -17,7 +18,7 @@ class _Gen(NamedTuple):
 class _Fn(NamedTuple):
     """An explored function result, rendered in signature syntax."""
 
-    names: tuple[str, ...]
+    params: Mapping[str, Parameter]
     spies: Mapping[str, _SpyObject]
     fixed: Mapping[str, object]
     defaults: Mapping[str, object]

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -1,4 +1,4 @@
-# ruff: noqa: FURB118
+# ruff: noqa: FURB118, PLW0108
 # pyright: reportUnknownArgumentType=false, reportUnknownLambdaType=false
 # pyright: reportUnknownVariableType=false, reportUnusedParameter=false
 
@@ -43,21 +43,23 @@ UNARY_CASES: list[tuple[Callable[[Any], Any], str]] = [
     (lambda x: x >= 1, "[R](x: CanGe[Literal[1], R]) -> R"),
     (lambda x: -x, "[R](x: CanNeg[R]) -> R"),
     (lambda x: ~x, "[R](x: CanInvert[R]) -> R"),
-    (lambda x: abs(x), "[R](x: CanAbs[R]) -> R"),  # noqa: PLW0108
-    (len, "(obj: CanLen) -> int"),
+    (lambda x: abs(x), "[R](x: CanAbs[R]) -> R"),
+    # a positional-only parameter cannot be passed by keyword, so no name is shown
+    (lambda x, /: x, "[T](T) -> T"),
+    (len, "(CanLen) -> int"),
     (
         list,
         (
-            "(iterable: tuple[()] = ...) -> list[Never]\n"
-            "[R](iterable: CanIter[CanNext[R]] & ~tuple[()]) -> list[R]"
+            "(tuple[()] = ...) -> list[Never]\n"
+            "[R](CanIter[CanNext[R]] & ~tuple[()]) -> list[R]"
         ),
     ),
     # `list()` probes `__len__` optionally via `length_hint`, so it is no requirement
-    (lambda x: list(x), "[R](x: CanIter[CanNext[R]]) -> list[R]"),  # noqa: PLW0108
-    (math.sqrt, "(x: CanFloat | CanIndex) -> float"),
-    (lambda x: int(x), "(x: CanInt | CanIndex) -> int"),  # noqa: PLW0108
-    (lambda x: complex(x), "(x: CanComplex | CanFloat | CanIndex) -> complex"),  # noqa: PLW0108
-    (operator.index, "(a: CanIndex) -> int"),
+    (lambda x: list(x), "[R](x: CanIter[CanNext[R]]) -> list[R]"),
+    (math.sqrt, "(CanFloat | CanIndex) -> float"),
+    (lambda x: int(x), "(x: CanInt | CanIndex) -> int"),
+    (lambda x: complex(x), "(x: CanComplex | CanFloat | CanIndex) -> complex"),
+    (operator.index, "(CanIndex) -> int"),
     (lambda x: x(), "[R](x: () -> R) -> R"),
     (lambda x: x(1, 2), "[R](x: (Literal[1], Literal[2]) -> R) -> R"),
     (lambda x: x(a=1), "[R](x: (a: Literal[1]) -> R) -> R"),
@@ -149,7 +151,7 @@ UNARY_CASES: list[tuple[Callable[[Any], Any], str]] = [
         "[R: CanStr & CanHash](x: CanIter[CanNext[R]]) -> dict[R, str]",
     ),
     (
-        lambda x: sum(x),  # noqa: PLW0108
+        lambda x: sum(x),
         "[R](x: CanIter[CanNext[CanRAdd[Literal[0], R]]]) -> R",
     ),
     (lambda x: (x + 1, x + 1), "[R](x: CanAdd[Literal[1], R]) -> tuple[R, R]"),
@@ -211,6 +213,8 @@ UNARY_CASES: list[tuple[Callable[[Any], Any], str]] = [
 ]
 
 BINARY_CASES: list[tuple[Callable[[Any, Any], Any], str]] = [
+    # a positional-only parameter renders bare, a keyword-passable one by name
+    (lambda x, /, y: (x, y), "[T, U](T, y: U) -> tuple[T, U]"),
     (
         lambda x, y: x * y,
         "[T, R](x: CanMul[T, R], y: T) -> R\n[T, R](x: T, y: CanRMul[T, R]) -> R",
@@ -513,6 +517,9 @@ FUNCTION_CASES: list[tuple[Callable[..., Any], str]] = [
     (lambda x: lambda y: y, "[T](x: object) -> (y: T) -> T"),  # noqa: ARG005
     (lambda x: lambda *, y: (x, y), "[T, U](x: T) -> (y: U) -> tuple[T, U]"),
     (lambda x: lambda y=1: (x, y), "[T, U](x: T) -> (y: U = 1) -> tuple[T, U]"),
+    # ...except for a positional-only parameter, which renders without its name
+    (lambda x: lambda y, /: (x, y), "[T, U](x: T) -> (U) -> tuple[T, U]"),
+    (lambda x: lambda y=1, /: (x, y), "[T, U](x: T) -> (U = 1) -> tuple[T, U]"),
     (
         lambda x: lambda y: lambda z: (x, y, z),
         "[T, U, V](x: T) -> (y: U) -> (z: V) -> tuple[T, U, V]",
@@ -533,16 +540,16 @@ FUNCTION_CASES: list[tuple[Callable[..., Any], str]] = [
     (lambda x: lambda: list(x), "[R](x: CanIter[CanNext[R]]) -> () -> list[R]"),
     # a returned builtin or method descriptor explores like a direct `infer`,
     # including the lenient fallback that pins a rejected defaulted parameter
-    (lambda: len, "() -> (obj: CanLen) -> int"),
-    (lambda: math.sqrt, "() -> (x: CanFloat | CanIndex) -> float"),
-    (lambda: str.upper, "() -> (self: str) -> str"),
+    (lambda: len, "() -> (CanLen) -> int"),
+    (lambda: math.sqrt, "() -> (CanFloat | CanIndex) -> float"),
+    (lambda: str.upper, "() -> (str) -> str"),
     (
         lambda: str.split,
-        "() -> (self: str, sep: None = None, maxsplit: CanIndex = -1) -> list[Never]",
+        "() -> (str, sep: None = None, maxsplit: CanIndex = -1) -> list[Never]",
     ),
     (
         lambda: dict.get,  # pyright: ignore[reportUnknownMemberType]
-        "[T]() -> (self: dict, key: CanHash, default: T = None) -> T",
+        "[T]() -> (dict, CanHash, T = None) -> T",
     ),
     # a `functools.partial` explores with its bound arguments in place
     (
@@ -597,7 +604,7 @@ ITERATOR_CASES: list[tuple[Callable[..., Any], str]] = [
     # lazy builtin iterators are iterated like generators
     (lambda x: map(str, x), "(x: CanIter[CanNext[CanStr]]) -> map[str]"),
     (
-        lambda f, x: map(f, x),  # noqa: PLW0108
+        lambda f, x: map(f, x),
         "[T, R](f: (T) -> R, x: CanIter[CanNext[T]]) -> map[R]",
     ),
     (
@@ -606,11 +613,11 @@ ITERATOR_CASES: list[tuple[Callable[..., Any], str]] = [
     ),
     (lambda x: filter(None, x), "[R: CanBool](x: CanIter[CanNext[R]]) -> filter[R]"),
     (
-        lambda x, y: zip(x, y),  # noqa: B905, PLW0108
+        lambda x, y: zip(x, y),  # noqa: B905
         "[R, R2](x: CanIter[CanNext[R]], y: CanIter[CanNext[R2]]) -> zip[tuple[R, R2]]",
     ),
     # `enumerate[R]` is parameterized by the element type, not the yielded pair
-    (lambda x: enumerate(x), "[R](x: CanIter[CanNext[R]]) -> enumerate[R]"),  # noqa: PLW0108
+    (lambda x: enumerate(x), "[R](x: CanIter[CanNext[R]]) -> enumerate[R]"),
     # only `zip` is covariant in typeshed, so an `enumerate` union does not absorb
     (
         lambda x: zip([FileNotFoundError()]) if x else zip([OSError()]),
@@ -781,17 +788,15 @@ def test_callable_instance() -> None:
 
 def test_method_descriptor() -> None:
     # an unbound method descriptor's `self` requires a real `__objclass__` instance
-    assert infer(str.upper) == "(self: str) -> str"
-    assert infer(int.bit_length) == "(self: int) -> int"
-    assert infer(float.hex) == "(self: float) -> str"
-    assert infer(list[Any].append) == "(self: list, object: object) -> None"
-    assert infer(object.__str__) == "(self: object) -> str"
-    assert infer(dict[Any, Any].get) == (
-        "[T = None](self: dict, key: CanHash, default: T = None) -> T"
-    )
+    assert infer(str.upper) == "(str) -> str"
+    assert infer(int.bit_length) == "(int) -> int"
+    assert infer(float.hex) == "(float) -> str"
+    assert infer(list[Any].append) == "(list, object) -> None"
+    assert infer(object.__str__) == "(object) -> str"
+    assert infer(dict[Any, Any].get) == "[T = None](dict, CanHash, T = None) -> T"
     # `memoryview()` is constructed from a spy through its `__buffer__`
     assert infer(memoryview.tobytes) == (
-        "(self: memoryview, order: Literal['C'] = 'C') -> bytes"
+        "(memoryview, order: Literal['C'] = 'C') -> bytes"
     )
 
 
@@ -799,10 +804,10 @@ def test_method_descriptor_fixed_defaults() -> None:
     # a defaulted parameter whose spy the function rejects passes its default
     # instead, while the accepting parameters stay structural
     assert infer(str.split) == (
-        "(self: str, sep: None = None, maxsplit: CanIndex = -1) -> list[Never]"
+        "(str, sep: None = None, maxsplit: CanIndex = -1) -> list[Never]"
     )
     assert infer(bytes.decode) == (
-        "(self: bytes, encoding: Literal['utf-8'] = 'utf-8', "
+        "(bytes, encoding: Literal['utf-8'] = 'utf-8', "
         "errors: Literal['strict'] = 'strict') -> str"
     )
 


### PR DESCRIPTION
closes #645