### PR TITLE
`infer`: non-optypean protocols

### DIFF
--- a/docs/reference/experimental/infer.md
+++ b/docs/reference/experimental/infer.md
@@ -130,6 +130,57 @@ $ optype infer "lambda f: f(1, b=2)"
 [R](f: (Literal[1], b: Literal[2]) -> R) -> R
 ```
 
+## Attributes
+
+Attribute access dispatches through `__getattr__`, except for the few attributes
+that every object already has, like `__doc__`, which require nothing. Reading a
+special attribute that `optype` ships a single-member `Has*` protocol for reports
+that protocol directly:
+
+```console
+$ optype infer "lambda x: x.__name__"
+[R](x: HasName[R]) -> R
+```
+
+An attribute without a shipped protocol renders as the fictional inline form
+`Has['name', T]`. Like `&` and `~`, it is not valid Python, but it is expressible as
+a protocol with a single member. The type argument carries a polarity sigil: a read
+requires only the covariant `+T`, so a `@property` getter suffices:
+
+```python
+class HasSpam[T](Protocol):
+    @property
+    def spam(self) -> T: ...
+```
+
+This turns `Has['spam', +R]` into the valid `HasSpam[R]`:
+
+```console
+$ optype infer "lambda x: x.spam"
+[R](x: Has['spam', +R]) -> R
+```
+
+When the attribute is called, the sigil sinks into the callable's return type, where
+the covariance applies: `Has['spam', () -> +R]` is the method `def spam(self) -> R`:
+
+```console
+$ optype infer "lambda x: x.spam()"
+[R](x: Has['spam', () -> +R]) -> R
+```
+
+An assignment requires the contravariant `-T`: a mutable attribute that accepts the
+assigned value's type, such as `spam: T` itself, or any wider type. A deletion, or a
+read whose result is unused, requires only that the attribute exists (deletability
+itself is not expressible):
+
+```console
+$ optype infer "def f(x): x.spam = 1; return x"
+[T: Has['spam', -Literal[1]]](x: T) -> T
+
+$ optype infer "def f(x): del x.spam"
+(x: Has['spam']) -> None
+```
+
 ## Classes
 
 `type` reads the class directly instead of dispatching through a dunder, but every
@@ -470,9 +521,13 @@ placeholder arguments (no real side effects, no reliance on concrete values). Th
 extends to anything it returns: a returned function is called with placeholders of its
 own, and a returned lazy iterator is iterated. A returned function that raises during
 this exploration is not treated as an error: its type stays an opaque `function`.
+An attribute probe with a fallback, such as `hasattr` or `getattr` with a default,
+reports the attribute as a requirement anyway: a placeholder has every attribute, so
+the fallback branch is never taken.
 
 When `infer` can't handle the input, it raises `InferError` (a `NotImplementedError`
-subclass). That's the case for operations without a matching protocol, and for
+subclass). That's the case for operations without a matching protocol, such as an
+attribute access whose name is not statically known (a computed `getattr`), and for
 arguments that aren't callable to begin with. Exceptions raised from within the
 function itself aren't caught.
 

--- a/optype/infer/_ir.py
+++ b/optype/infer/_ir.py
@@ -4,7 +4,7 @@ from collections.abc import Iterable
 from dataclasses import dataclass
 from typing import override
 
-type Node = Lit | Type | Name | App | Fn | Union | Inter | Not
+type Node = Lit | Type | Name | App | Fn | Union | Inter | Not | Polarity
 
 _NOT = "~"  # the type complement prefix
 
@@ -88,6 +88,14 @@ def _param_type(param: "Node | Arg") -> "Node":
 class Not:
     """A type complement, e.g. the `~None` of everything but `None`."""
 
+    part: Node
+
+
+@dataclass(frozen=True, slots=True)
+class Polarity:
+    """A polarity-marked type: covariant (read-only) or contravariant (write-only)."""
+
+    sign: str
     part: Node
 
 
@@ -204,6 +212,12 @@ def inter(parts: Iterable[Node]) -> Node | None:
     return next(iter(flat)) if len(flat) == 1 else Inter(tuple(flat))
 
 
+def _prefix(op: str, part: Node) -> str:
+    """Format a prefix-operated type, parenthesized where precedence requires."""
+    inner = render(part)
+    return f"{op}({inner})" if isinstance(part, Union | Inter | Fn) else op + inner
+
+
 def render(node: Node) -> str:
     """Format a type expression, parenthesized where precedence requires."""
     match node:
@@ -231,12 +245,9 @@ def render(node: Node) -> str:
             )
             out = f"({decls}) -> {render(ret)}"
         case Not(part):
-            inner = render(part)
-            out = (
-                f"{_NOT}({inner})"
-                if isinstance(part, Union | Inter | Fn)
-                else _NOT + inner
-            )
+            out = _prefix(_NOT, part)
+        case Polarity(sign, part):
+            out = _prefix(sign, part)
         case Union(parts) | Inter(parts):
             sep, dual = (" | ", Inter) if isinstance(node, Union) else (" & ", Union)
             out = sep.join(

--- a/optype/infer/_render.py
+++ b/optype/infer/_render.py
@@ -41,12 +41,12 @@ _TYPEVAR_TUPLE = "*Ts"
 _NEVER = "Never"
 _OBJECT = "object"
 
-_DUNDER_ATTR = frozenset({
-    "__delattr__",
-    "__getattr__",
-    "__getattribute__",
-    "__setattr__",
-})
+# the attribute polarity sigils of the fictional inline `Has['name', T]` form
+_READ = "+"  # covariant: a read-only property suffices
+_WRITE = "-"  # contravariant: the attribute only has to accept the value
+
+_DUNDER_ATTR_WRITE = frozenset({"__delattr__", "__setattr__"})
+_DUNDER_ATTR = _DUNDER_ATTR_WRITE | {"__getattr__", "__getattribute__"}
 
 
 def _get_dunder_can_map() -> dict[str, str]:
@@ -90,7 +90,7 @@ _COERCION_PROTOS = {
 }
 
 type _Vars = dict[int, str]
-type _RetKey = tuple[int, str, int, tuple[str, ...]]
+type _RetKey = tuple[int, str, object, tuple[str, ...]]
 type _Proto = str | tuple[str, ...]  # a tuple is rendered as a union of protocols
 
 type _Names = Sequence[str]
@@ -102,21 +102,31 @@ class _Op(NamedTuple):
     args: _Args
     kwargs: _Kwargs
     ret: object
+    attr: str | None = None  # the subject of a synthesized `Has[...]` form
 
 
 def _resolve(trace: _TraceItem) -> _Op:
     if trace.attr in _DUNDER_ATTR:
         name = trace.args[0]
-        if not isinstance(name, str) or name not in _DUNDER_HAS_MAP:
-            msg = f"no protocol for attribute {name!r}"
+        if not isinstance(name, str) or isinstance(name, _Spy):
+            msg = "no protocol for a dynamic attribute name"
             raise InferError(msg)
-        return _Op(_DUNDER_HAS_MAP[name], (), {}, trace.return_)
+        # a read of an attribute with a shipped single-member `Has*` protocol
+        if name in _DUNDER_HAS_MAP and trace.attr not in _DUNDER_ATTR_WRITE:
+            return _Op(_DUNDER_HAS_MAP[name], (), {}, trace.return_)
+
+        # everything else synthesizes the inline `Has['name', T]` form; a write
+        # binds the assigned value's type, which a bounded `Has*` could reject
+        return _Op("Has", trace.args[1:], {}, trace.return_, name)
+
     # checked before _DUNDER_CAN_MAP, which also contains the coercion dunders
     if trace.attr in _COERCION_PROTOS:
         return _Op(_COERCION_PROTOS[trace.attr], (), {}, trace.return_)
+
     if trace.attr in _DUNDER_CAN_MAP:
         proto = _DUNDER_CAN_MAP[trace.attr]
         return _Op(proto, trace.args, trace.kwargs, trace.return_)
+
     msg = f"no protocol for {trace.attr!r}"
     raise InferError(msg)
 
@@ -124,6 +134,13 @@ def _resolve(trace: _TraceItem) -> _Op:
 def _or_object(node: _ir.Node | None) -> _ir.Node:
     """The node itself, or `object` for an unconstrained (`None`) one."""
     return _ir.Name(_OBJECT) if node is None else node
+
+
+def _sign_read(ret: _ir.Node) -> _ir.Node:
+    """Mark a read covariant; a callable signs its return type instead: a method."""
+    if isinstance(ret, _ir.Fn):
+        return _ir.Fn(ret.params, _sign_read(ret.ret))
+    return ret if ret == _ir.Name(_OBJECT) else _ir.Polarity(_READ, ret)
 
 
 def _analyze(
@@ -169,9 +186,13 @@ def _ret_keys(
             for value in (*item.args, *item.kwargs.values()):
                 if (arg := as_spy(value)) is not None:
                     args.add(id(arg))
+
             if isinstance(item.return_, _SpyObject):
-                key = id(owner), item.attr, len(item.args), tuple(sorted(item.kwargs))
+                # an attribute name replaces the fixed arity: `x.spam` is not `x.ham`
+                shape = item.args[0] if item.attr in _DUNDER_ATTR else len(item.args)
+                key = id(owner), item.attr, shape, tuple(sorted(item.kwargs))
                 keys[id(item.return_)] = key
+
     return keys, args
 
 
@@ -192,7 +213,7 @@ def _packed_uses(value: object, spy: _SpyObject, count: int) -> Generator[bool]:
             tup = cast("tuple[object, ...]", value)
             if runs := _spy_runs(tup, spy):
                 yield runs == [count]
-            items: Iterable[object] = (item for item in tup if item is not spy)
+            items = (item for item in tup if item is not spy)
         case _:
             items = _children(value)
     for item in items:
@@ -407,37 +428,56 @@ class _Renderer:
     def group(self, proto: _Proto, members: Sequence[_Op]) -> _ir.Node:
         if isinstance(proto, tuple):  # coercion protocols, which record no args
             return _ir.Union(tuple(map(_ir.Name, proto)))
+
         if proto == "CanArrayFunction":
             ret_str = _ir.render(_or_object(self.returns(members)))
             func = cast("_AnyFunc", members[0].args[0])
             return _ir.Name(_numpy.array_function_type(func, ret_str))
-        args: list[_ir.Node | _ir.Arg] = [
+
+        pos = [
             arg
             for i in range(len(members[0].args))
             if (arg := self.union(m.args[i] for m in members)) is not None
         ]
-        args += [
-            _ir.Arg(key, kw)
-            for key in members[0].kwargs
-            if (kw := self.union(m.kwargs[key] for m in members)) is not None
-        ]
+        args = (
+            *pos,
+            *(
+                _ir.Arg(key, kw)
+                for key in members[0].kwargs
+                if (kw := self.union(m.kwargs[key] for m in members)) is not None
+            ),
+        )
         ret = self.returns(members)
+
         if proto == "CanCall":
-            return _ir.Fn(tuple(args), _or_object(ret))
+            return _ir.Fn(args, _or_object(ret))
+
+        if (attr := members[0].attr) is not None:
+            # a read is covariant (a property suffices) and a write contravariant
+            # (the attribute only has to accept the value); existence renders bare
+            signed: tuple[_ir.Node, ...] = (
+                _ir.Name(repr(attr)),
+                *(_ir.Polarity(_WRITE, a) for a in pos),
+            )
+            if ret is not None and ret != _ir.Name(_OBJECT):
+                signed = *signed, _sign_read(ret)
+            return _ir.App(proto, signed)
+
         if ret is not None:
-            args.append(ret)
-        return _ir.App(proto, tuple(args))
+            args = *args, ret
+
+        return _ir.App(proto, args)
 
     def traces(self, items: Iterable[_TraceItem]) -> _ir.Node | None:
         items = list(items)
         # a surviving absence marker proves the dunder was only probed optionally
         optional = {item.args[0] for item in items if item.attr == _Marker.ABSENT}
-        groups: dict[tuple[_Proto, int, tuple[str, ...]], list[_Op]] = {}
+        groups: dict[tuple[_Proto, str | None, int, tuple[str, ...]], list[_Op]] = {}
         for item in items:
             if item.attr == _Marker.ABSENT or item.attr in optional:
                 continue
             op = _resolve(item)
-            key = op.proto, len(op.args), tuple(sorted(op.kwargs))
+            key = op.proto, op.attr, len(op.args), tuple(sorted(op.kwargs))
             groups.setdefault(key, []).append(op)
         parts = [self.group(key[0], group) for key, group in groups.items()]
         return _ir.inter(_merge_combined(parts))

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -22,6 +22,40 @@ def _type_of[T](x: T) -> type[T]:
     return type(x)
 
 
+def _set_attr(x: Any) -> object:
+    x.spam = 1
+    return x
+
+
+def _set_attr_twice(x: Any) -> None:
+    x.spam = 1
+    x.spam = 1.5
+
+
+def _del_attr(x: Any) -> None:
+    del x.spam
+
+
+def _get_attr(x: Any) -> None:
+    x.spam  # noqa: B018
+
+
+def _call_attr(x: Any) -> None:
+    x.spam()
+
+
+def _iadd_attr(x: Any) -> None:
+    x.spam += 1
+
+
+def _set_dunder(x: Any) -> None:
+    x.__name__ = 123
+
+
+def _del_dunder(x: Any) -> None:
+    del x.__name__
+
+
 UNARY_CASES: list[tuple[Callable[[Any], Any], str]] = [
     (lambda x: x + 1, "[R](x: CanAdd[Literal[1], R]) -> R"),
     (
@@ -210,6 +244,43 @@ UNARY_CASES: list[tuple[Callable[[Any], Any], str]] = [
     (lambda x: x.__match_args__, "[R](x: HasMatchArgs[R]) -> R"),
     (lambda x: x.__type_params__, "[R](x: HasTypeParams[R]) -> R"),
     (lambda x: x.__self__, "[R](x: HasSelf[R]) -> R"),
+    # an attribute without a shipped `Has*` protocol synthesizes the fictional
+    # inline `Has['name', T]` form, which is not valid Python, like `&` and `~`;
+    # a read requires only the covariant (read-only) `+T`, i.e. a property; on
+    # a callable the sigil sinks into the return type, i.e. a method
+    (lambda x: x.spam, "[R](x: Has['spam', +R]) -> R"),
+    (lambda x: x.spam(), "[R](x: Has['spam', () -> +R]) -> R"),
+    (lambda x: x.spam(1), "[R](x: Has['spam', (Literal[1]) -> +R]) -> R"),
+    (_call_attr, "(x: Has['spam', () -> object]) -> None"),
+    (lambda x: x.__wibble__, "[R](x: Has['__wibble__', +R]) -> R"),
+    (lambda x: getattr(x, "spam"), "[R](x: Has['spam', +R]) -> R"),  # noqa: B009
+    (lambda x: x.spam.ham, "[R](x: Has['spam', +Has['ham', +R]]) -> R"),
+    # distinct attributes get distinct typevars; repeated reads share one
+    (
+        lambda x: (x.spam, x.ham),
+        "[R, R2](x: Has['spam', +R] & Has['ham', +R2]) -> tuple[R, R2]",
+    ),
+    (lambda x: (x.spam, x.spam), "[R](x: Has['spam', +R]) -> tuple[R, R]"),
+    (
+        lambda x: (x.__name__, x.__qualname__),
+        "[R, R2](x: HasName[R] & HasQualname[R2]) -> tuple[R, R2]",
+    ),
+    # an assignment binds the contravariant (write-only) `-T`, which the attribute
+    # only has to accept, so merged writes union; a deletion or an unused read
+    # requires bare existence
+    (_set_attr, "[T: Has['spam', -Literal[1]]](x: T) -> T"),
+    (_set_attr_twice, "(x: Has['spam', -(Literal[1] | float)]) -> None"),
+    (_del_attr, "(x: Has['spam']) -> None"),
+    (_get_attr, "(x: Has['spam']) -> None"),
+    # an augmented assignment is both a read and a write
+    (
+        _iadd_attr,
+        "[T](x: Has['spam', +CanIAdd[Literal[1], T]] & Has['spam', -T]) -> None",
+    ),
+    # a write to an attribute with a shipped protocol synthesizes too: `HasName`
+    # declares `__name__: str`, which the assigned value need not satisfy
+    (_set_dunder, "(x: Has['__name__', -Literal[123]]) -> None"),
+    (_del_dunder, "(x: Has['__name__']) -> None"),
 ]
 
 BINARY_CASES: list[tuple[Callable[[Any, Any], Any], str]] = [
@@ -309,6 +380,8 @@ BINARY_CASES: list[tuple[Callable[[Any, Any], Any], str]] = [
             "[T: CanRAdd[U, R2], U: CanRAdd[T, R], R, R2](x: T, y: U) -> tuple[R, R2]"
         ),
     ),
+    # a synthesized attribute assignment binds the assigned value's type
+    (lambda x, y: setattr(x, "spam", y), "[T](x: Has['spam', -T], y: T) -> None"),
 ]
 
 
@@ -422,6 +495,10 @@ def _yield_default(x: Any = 0) -> Any:
     yield x
 
 
+def _set_attr_default(x: Any, y: Any = 1) -> None:
+    x.spam = y
+
+
 def _if_none(x: Any = None) -> Any:
     return [] if x is None else x
 
@@ -456,6 +533,7 @@ DEFAULT_CASES: list[tuple[Callable[..., Any], str]] = [
         ),
     ),
     (_getitem_default, "[R, T = Literal[1]](x: CanGetitem[T, R], y: T = 1) -> R"),
+    (_set_attr_default, "[T = Literal[1]](x: Has['spam', -T], y: T = 1) -> None"),
     (_yield_default, "[T = Literal[0]](x: T = 0) -> Generator[T]"),
     (_type_default, "[T = Literal[0]](x: T = 0) -> type[T]"),
     # a parameter whose typevar would only appear once shows the default inline
@@ -534,6 +612,10 @@ FUNCTION_CASES: list[tuple[Callable[..., Any], str]] = [
         ),
     ),
     (lambda x: lambda f: f(x), "[T, R](x: T) -> (f: (T) -> R) -> R"),
+    (
+        lambda x: lambda y: y.foo,  # noqa: ARG005  # pyright: ignore[reportUnknownMemberType]
+        "[R](x: object) -> (y: Has['foo', +R]) -> R",
+    ),
     # a failed inner run rolls back its traces on the closed-over parameter, so
     # an optionally probed `__len__` is no requirement, just like in a direct call
     (lambda x: lambda: len(x), "(x: CanLen) -> () -> int"),
@@ -1157,9 +1239,10 @@ def test_type() -> None:
     assert infer(type) == "[T](object: T) -> type[T]"
 
 
-def _set_attr(x: Any) -> object:
-    x.spam = 1
-    return x
+def test_dynamic_attr_name() -> None:
+    # a spy-derived attribute name is not statically known
+    with pytest.raises(InferError, match="no protocol"):
+        infer(lambda x, y: getattr(x, str(y)))
 
 
 def _set_name(x: Any) -> object:
@@ -1171,24 +1254,6 @@ def _set_name(x: Any) -> object:
 
 def test_set_name() -> None:
     assert infer(_set_name) == "(x: CanSetName[type, Literal['attr']]) -> type"
-
-
-NO_PROTOCOL_CASES: list[Callable[[Any], Any]] = [
-    lambda x: x.foo,
-    _set_attr,
-    # an inexpressible operation inside a returned function fails just as honestly
-    lambda x: lambda y: y.foo,  # noqa: ARG005  # pyright: ignore[reportUnknownMemberType]
-]
-
-
-@pytest.mark.parametrize(
-    "func",
-    NO_PROTOCOL_CASES,
-    ids=["getattr", "setattr", "returned"],
-)
-def test_no_protocol(func: Callable[[Any], Any]) -> None:
-    with pytest.raises(InferError, match="no protocol"):
-        infer(func)
 
 
 def _run_cli(*args: str) -> subprocess.CompletedProcess[str]:
@@ -1247,6 +1312,6 @@ def test_cli_usage() -> None:
 
 def test_cli_infer_error() -> None:
     # infer's own limitations exit cleanly, instead of with a traceback
-    out = _run_cli("-m", "optype", "infer", "lambda x: x.foo")
+    out = _run_cli("-m", "optype", "infer", "lambda x, y: getattr(x, str(y))")
     assert out.returncode == 1
     assert out.stderr.startswith("InferError: no protocol")


### PR DESCRIPTION
```console
$ optype infer "lambda x: x.spam"
[R](x: Has['spam', +R]) -> R

$ optype infer "lambda x: x.spam()"
[R](x: Has['spam', () -> +R]) -> R
```

closes #642