### PR TITLE
`infer`: class attributes

### DIFF
--- a/docs/reference/experimental/infer.md
+++ b/docs/reference/experimental/infer.md
@@ -201,6 +201,20 @@ $ optype infer "lambda x: type(x)()"
 [T](x: T) -> T
 ```
 
+An attribute access on the class itself renders inside `ClassVar`, mirroring a protocol
+member declared as `spam: ClassVar[...]`.
+
+```console
+$ optype infer "lambda x: type(x).spam"
+[R](x: Has['spam', ClassVar[+R]]) -> R
+
+$ optype infer "def f(x): type(x).spam = 1"
+(x: Has['spam', ClassVar[-Literal[1]]]) -> None
+
+$ optype infer "def f(x): del type(x).spam"
+(x: Has['spam', ClassVar]) -> None
+```
+
 A concrete class renders parameterized when it resolves by name (a local class stays
 a bare `type`), and `type` is covariant, so a subclass is absorbed by its parent:
 

--- a/optype/infer/_render.py
+++ b/optype/infer/_render.py
@@ -45,8 +45,14 @@ _OBJECT = "object"
 _READ = "+"  # covariant: a read-only property suffices
 _WRITE = "-"  # contravariant: the attribute only has to accept the value
 
+_DUNDER_ATTR_READ = frozenset({"__getattr__", "__getattribute__"})
 _DUNDER_ATTR_WRITE = frozenset({"__delattr__", "__setattr__"})
-_DUNDER_ATTR = _DUNDER_ATTR_WRITE | {"__getattr__", "__getattribute__"}
+_DUNDER_ATTR = _DUNDER_ATTR_READ | _DUNDER_ATTR_WRITE
+_DUNDER_CLASS_ATTR = frozenset({
+    _Marker.CLASS_DELATTR,
+    _Marker.CLASS_GETATTR,
+    _Marker.CLASS_SETATTR,
+})
 
 
 def _get_dunder_can_map() -> dict[str, str]:
@@ -103,14 +109,21 @@ class _Op(NamedTuple):
     kwargs: _Kwargs
     ret: object
     attr: str | None = None  # the subject of a synthesized `Has[...]` form
+    classvar: bool = False  # a class-level attribute, i.e. a `ClassVar` member
 
 
 def _resolve(trace: _TraceItem) -> _Op:
-    if trace.attr in _DUNDER_ATTR:
+    if trace.attr in _DUNDER_ATTR or trace.attr in _DUNDER_CLASS_ATTR:
         name = trace.args[0]
         if not isinstance(name, str) or isinstance(name, _Spy):
             msg = "no protocol for a dynamic attribute name"
             raise InferError(msg)
+
+        # a class-level attribute mirrors a `ClassVar` protocol member, which no
+        # shipped instance-member `Has*` protocol declares
+        if trace.attr in _DUNDER_CLASS_ATTR:
+            return _Op("Has", trace.args[1:], {}, trace.return_, name, classvar=True)
+
         # a read of an attribute with a shipped single-member `Has*` protocol
         if name in _DUNDER_HAS_MAP and trace.attr not in _DUNDER_ATTR_WRITE:
             return _Op(_DUNDER_HAS_MAP[name], (), {}, trace.return_)
@@ -189,7 +202,11 @@ def _ret_keys(
 
             if isinstance(item.return_, _SpyObject):
                 # an attribute name replaces the fixed arity: `x.spam` is not `x.ham`
-                shape = item.args[0] if item.attr in _DUNDER_ATTR else len(item.args)
+                shape = (
+                    item.args[0]
+                    if item.attr in _DUNDER_ATTR or item.attr in _DUNDER_CLASS_ATTR
+                    else len(item.args)
+                )
                 key = id(owner), item.attr, shape, tuple(sorted(item.kwargs))
                 keys[id(item.return_)] = key
 
@@ -455,13 +472,12 @@ class _Renderer:
         if (attr := members[0].attr) is not None:
             # a read is covariant (a property suffices) and a write contravariant
             # (the attribute only has to accept the value); existence renders bare
-            signed: tuple[_ir.Node, ...] = (
-                _ir.Name(repr(attr)),
-                *(_ir.Polarity(_WRITE, a) for a in pos),
-            )
+            signed: tuple[_ir.Node, ...] = tuple(_ir.Polarity(_WRITE, a) for a in pos)
             if ret is not None and ret != _ir.Name(_OBJECT):
                 signed = *signed, _sign_read(ret)
-            return _ir.App(proto, signed)
+            if members[0].classvar:
+                signed = (_ir.App("ClassVar", signed),)
+            return _ir.App(proto, (_ir.Name(repr(attr)), *signed))
 
         if ret is not None:
             args = *args, ret
@@ -472,12 +488,15 @@ class _Renderer:
         items = list(items)
         # a surviving absence marker proves the dunder was only probed optionally
         optional = {item.args[0] for item in items if item.attr == _Marker.ABSENT}
-        groups: dict[tuple[_Proto, str | None, int, tuple[str, ...]], list[_Op]] = {}
+        groups: dict[
+            tuple[_Proto, str | None, bool, int, tuple[str, ...]],
+            list[_Op],
+        ] = {}
         for item in items:
             if item.attr == _Marker.ABSENT or item.attr in optional:
                 continue
             op = _resolve(item)
-            key = op.proto, op.attr, len(op.args), tuple(sorted(op.kwargs))
+            key = op.proto, op.attr, op.classvar, len(op.args), tuple(sorted(op.kwargs))
             groups.setdefault(key, []).append(op)
         parts = [self.group(key[0], group) for key, group in groups.items()]
         return _ir.inter(_merge_combined(parts))

--- a/optype/infer/_spy.py
+++ b/optype/infer/_spy.py
@@ -23,6 +23,10 @@ class _Marker(StrEnum):
     ABSENT = "__absent__"  # a simulated-missing dunder
     SIBLING = "__sibling__"  # a `type(spy)(...)` instantiation
 
+    CLASS_DELATTR = "__class_delattr__"
+    CLASS_GETATTR = "__class_getattr__"
+    CLASS_SETATTR = "__class_setattr__"
+
 
 _fork: ContextVar[Iterator[bool] | None] = ContextVar("_fork", default=None)
 
@@ -69,7 +73,38 @@ class _SpyBytes(bytes, _Spy):
     __slots__ = ()  # pyrefly:ignore[implicit-any-attribute]
 
 
-class _SpyObject(_Spy):
+class _SpyType(type):
+    """The metaclass of every spy's unique class, so class attribute access records."""
+
+    def __getattr__(cls, attr: str, /) -> "_SpyObject | None":
+        if attr.startswith("__optype"):
+            return None
+
+        if (owner := _class_spy(cls)) is None:
+            msg = f"type object {cls.__name__!r} has no attribute {attr!r}"
+            raise AttributeError(msg)
+
+        out = _SpyObject()
+        return owner.__optype_trace_add__(_Marker.CLASS_GETATTR, (attr,), {}, out)
+
+    @override
+    def __setattr__(cls, attr: str, value: object, /) -> None:
+        # recorded without mutating, so forked reruns stay clean
+        if attr.startswith("__optype") or (owner := _class_spy(cls)) is None:
+            return super().__setattr__(attr, value)
+
+        args = attr, value
+        return owner.__optype_trace_add__(_Marker.CLASS_SETATTR, args, {}, None)
+
+    @override
+    def __delattr__(cls, attr: str, /) -> None:
+        if attr.startswith("__optype") or (owner := _class_spy(cls)) is None:
+            return super().__delattr__(attr)
+
+        return owner.__optype_trace_add__(_Marker.CLASS_DELATTR, (attr,), {}, None)
+
+
+class _SpyObject(_Spy, metaclass=_SpyType):
     __optype_element__: "_SpyObject | None" = None
     __optype_iterator__: bool = False
     # spies are descriptors (`__get__`), so only ever read through the class `__dict__`

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -1,6 +1,7 @@
 # ruff: noqa: FURB118, PLW0108
 # pyright: reportUnknownArgumentType=false, reportUnknownLambdaType=false
-# pyright: reportUnknownVariableType=false, reportUnusedParameter=false
+# pyright: reportUnknownMemberType=false, reportUnknownVariableType=false
+# pyright: reportUnusedParameter=false
 
 import builtins
 import functools
@@ -54,6 +55,18 @@ def _set_dunder(x: Any) -> None:
 
 def _del_dunder(x: Any) -> None:
     del x.__name__
+
+
+def _set_class_attr(x: Any) -> None:
+    type(x).spam = 1
+
+
+def _del_class_attr(x: Any) -> None:
+    del type(x).spam
+
+
+def _get_class_attr(x: Any) -> None:
+    type(x).spam  # noqa: B018
 
 
 UNARY_CASES: list[tuple[Callable[[Any], Any], str]] = [
@@ -281,6 +294,26 @@ UNARY_CASES: list[tuple[Callable[[Any], Any], str]] = [
     # declares `__name__: str`, which the assigned value need not satisfy
     (_set_dunder, "(x: Has['__name__', -Literal[123]]) -> None"),
     (_del_dunder, "(x: Has['__name__']) -> None"),
+    # an attribute on the class itself mirrors a `ClassVar` protocol member
+    (lambda x: type(x).spam, "[R](x: Has['spam', ClassVar[+R]]) -> R"),
+    (lambda x: x.__class__.spam, "[R](x: Has['spam', ClassVar[+R]]) -> R"),
+    (lambda x: type(x).spam(), "[R](x: Has['spam', ClassVar[() -> +R]]) -> R"),
+    (
+        lambda x: type(x).spam(1),
+        "[R](x: Has['spam', ClassVar[(Literal[1]) -> +R]]) -> R",
+    ),
+    (lambda x: type(x).spam.ham, "[R](x: Has['spam', ClassVar[+Has['ham', +R]]]) -> R"),
+    (
+        lambda x: (type(x).spam, type(x).spam),
+        "[R](x: Has['spam', ClassVar[+R]]) -> tuple[R, R]",
+    ),
+    (
+        lambda x: (x.spam, type(x).spam),
+        "[R, R2](x: Has['spam', +R] & Has['spam', ClassVar[+R2]]) -> tuple[R, R2]",
+    ),
+    (_set_class_attr, "(x: Has['spam', ClassVar[-Literal[1]]]) -> None"),
+    (_del_class_attr, "(x: Has['spam', ClassVar]) -> None"),
+    (_get_class_attr, "(x: Has['spam', ClassVar]) -> None"),
 ]
 
 BINARY_CASES: list[tuple[Callable[[Any, Any], Any], str]] = [
@@ -613,7 +646,7 @@ FUNCTION_CASES: list[tuple[Callable[..., Any], str]] = [
     ),
     (lambda x: lambda f: f(x), "[T, R](x: T) -> (f: (T) -> R) -> R"),
     (
-        lambda x: lambda y: y.foo,  # noqa: ARG005  # pyright: ignore[reportUnknownMemberType]
+        lambda x: lambda y: y.foo,  # noqa: ARG005
         "[R](x: object) -> (y: Has['foo', +R]) -> R",
     ),
     # a failed inner run rolls back its traces on the closed-over parameter, so
@@ -630,7 +663,7 @@ FUNCTION_CASES: list[tuple[Callable[..., Any], str]] = [
         "() -> (str, sep: None = None, maxsplit: CanIndex = -1) -> list[Never]",
     ),
     (
-        lambda: dict.get,  # pyright: ignore[reportUnknownMemberType]
+        lambda: dict.get,
         "[T]() -> (dict, CanHash, T = None) -> T",
     ),
     # a `functools.partial` explores with its bound arguments in place


### PR DESCRIPTION
```console
$ optype infer "lambda x: type(x).spam"
[R](x: Has['spam', ClassVar[+R]]) -> R

$ optype infer "def f(x): type(x).spam = 1"
(x: Has['spam', ClassVar[-Literal[1]]]) -> None

$ optype infer "def f(x): del type(x).spam"
(x: Has['spam', ClassVar]) -> None
```

closes #657