### PR TITLE
`infer`: `KeyError` on `weakref.proxy`

### DIFF
--- a/optype/infer/_render.py
+++ b/optype/infer/_render.py
@@ -532,8 +532,8 @@ class _Renderer:
     def return_type(self, result: object) -> _ir.Node:
 
         match result:
-            case _SpyObject():
-                node: _ir.Node = _ir.Name(self._vars.get(id(_own_spy(result)), _OBJECT))
+            case _SpyObject() if (spy := as_spy(result)) is not None:
+                node: _ir.Node = _ir.Name(self._vars.get(id(spy), _OBJECT))
             case _SpyStr():
                 node = _ir.Type(str)
             case _SpyBytes():

--- a/optype/infer/_spy.py
+++ b/optype/infer/_spy.py
@@ -435,7 +435,10 @@ def _own_spy(spy: _SpyObject) -> _SpyObject:
 
 def as_spy(value: object) -> _SpyObject | None:
     """The (first-of-its-class) spy itself, or the spy whose class it is, if any."""
-    return _own_spy(value) if isinstance(value, _SpyObject) else _class_spy(value)
+    # a `weakref.proxy` forwards `__class__`, so verify its real class is a spy's
+    if isinstance(value, _SpyObject) and _class_spy(type(value)) is not None:
+        return _own_spy(value)
+    return _class_spy(value)
 
 
 def _element_of(spy: _SpyObject) -> _SpyObject:

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -9,6 +9,7 @@ import math
 import operator
 import subprocess  # noqa: S404
 import sys
+import weakref
 from collections.abc import Callable
 from typing import Any
 
@@ -1298,6 +1299,11 @@ def _set_name(x: Any) -> object:
 
 def test_set_name() -> None:
     assert infer(_set_name) == "(x: CanSetName[type, Literal['attr']]) -> type"
+
+
+def test_weakref_proxy() -> None:
+    # a `weakref.proxy` forwards `__class__`, so it must not be mistaken for a spy
+    assert infer(weakref.proxy) == "(object) -> CallableProxyType"
 
 
 def _run_cli(*args: str) -> subprocess.CompletedProcess[str]:


### PR DESCRIPTION
before:

```console
$ optype infer "import weakref; weakref.proxy"
...
  File ".../optype/infer/_render.py", line 396, in _name_results
KeyError: 134517639150496
```

after:

```console
$ optype infer "import weakref; weakref.proxy"
(object) -> CallableProxyType
```

A `weakref.proxy` forwards `__class__`, so `isinstance(proxy, _SpyObject)` is `True` and `as_spy` mistook it for a spy. The real runtime class is now the deciding check.

closes #668