### PR TITLE
`infer`: invalid parameter names from docstring examples

### DIFF
--- a/optype/infer/_explore.py
+++ b/optype/infer/_explore.py
@@ -1,5 +1,6 @@
 """Run a function against spy placeholders and record what happens."""
 
+import keyword
 import re
 import warnings
 from collections.abc import (
@@ -108,9 +109,13 @@ def _doc_params(func: _AnyFunc) -> list[str] | None:
     if not name:
         return None
     for match in _RE_DOC_SIGNATURE.finditer(func.__doc__ or ""):
-        if match[1] == name:
-            params = match[2].replace("[", "").replace("]", "")
-            return _RE_DOC_PARAM.findall(params) or None
+        if match[1] != name:
+            continue
+        params = match[2].replace("[", "").replace("]", "")
+        names = _RE_DOC_PARAM.findall(params)
+        # a usage example like `reduce(lambda x, y: ...)` yields keywords, not params
+        if names and not any(map(keyword.iskeyword, names)):
+            return names
     return None
 
 

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -1262,6 +1262,10 @@ def test_doc_params() -> None:
     f.__doc__ = "no signature line here"
     assert _doc_params(f) is None
 
+    # a usage example, not a signature: its keyword arg is no parameter name
+    f.__doc__ = "Apply f. For example, f(lambda x, y: x + y, [1, 2, 3])."
+    assert _doc_params(f) is None
+
 
 def test_doc_signature() -> None:
     # builtins like `int` have no signature; fall back to the docstring


### PR DESCRIPTION
before:

```console
$ optype infer "import functools; functools.reduce"
ValueError: 'lambda' is not a valid parameter name
```

after:

```console
$ optype infer "import functools; functools.reduce"
InferError: <built-in function reduce> builtin has invalid signature
```

`reduce` has no real signature, so its docstring is parsed as a fallback. The only `reduce(...)` match is the usage example `reduce(lambda x, y: ...)`, which yielded the keyword `lambda` as a parameter name and crashed `Parameter()`. Doc matches whose "parameters" contain a keyword are now skipped.

closes #669