### PR TITLE
`infer`: recursive container types

### DIFF
--- a/docs/reference/experimental/infer.md
+++ b/docs/reference/experimental/infer.md
@@ -473,6 +473,14 @@ $ optype infer "lambda x: frozendict({'k': x + 1})"
 [R](x: CanAdd[Literal[1], R]) -> frozendict[Literal['k'], R]
 ```
 
+A container that holds itself is a recursive type. The cycle is detected by identity
+and tied off as a typevar bounded by its own structure:
+
+```console
+$ optype infer "def f(): x = []; x.append(x); return x"
+[R: list[R]]() -> R
+```
+
 ## Unions
 
 A union member that is a subtype of another member is absorbed into it, following the

--- a/optype/infer/_api.py
+++ b/optype/infer/_api.py
@@ -18,7 +18,7 @@ from ._explore import (
 )
 from ._render import _Defaults, _Names, signatures
 from ._spy import _AnyFunc, _TraceItem
-from ._values import _Fn, _Gen
+from ._values import _Fn, _Gen, _Rec
 
 
 def _select(params: Iterable[str | int], names: _Names) -> _Names:
@@ -56,6 +56,8 @@ def _bind(value: object, binding: Mapping[int, object]) -> object:
         case _Fn():
             bound = [_bind(item, binding) for item in value.results]
             out = value._replace(results=bound)
+        case _Rec():
+            out = value._replace(body=_bind(value.body, binding))
         case tuple() if type(value) is tuple:  # pyright: ignore[reportUnknownArgumentType]
             tup = cast("tuple[object, ...]", value)
             out = tuple(_bind(item, binding) for item in tup)
@@ -144,19 +146,7 @@ def _defaults(
     return {}, False, overloads
 
 
-def infer(func: _AnyFunc, /, *params: str | int) -> str:
-    """Infer the `optype` protocol(s) required of `func`'s parameters.
-
-    Pass parameter names or positions to report only those parameters.
-
-    >>> print(infer(lambda x: x + 1))
-    [R](x: CanAdd[Literal[1], R]) -> R
-
-    Raises:
-        InferError: If `func` is not supported, such as a non-callable, an
-            operation without a matching protocol, or a parameter that requires
-            a value that no placeholder can provide.
-    """
+def _infer(func: _AnyFunc, params: tuple[str | int, ...]) -> str:
     if nin := _numpy.ufunc_nin(func):
         names = _numpy.ufunc_params(nin)
         return _numpy.infer_ufunc(func, names, _select(params, names))
@@ -174,3 +164,22 @@ def infer(func: _AnyFunc, /, *params: str | int) -> str:
     defaults, negate, overloads = _defaults(func, parameters, selected, recon)
     lines = signatures(recon, parameters, selected, defaults, negate=negate)
     return "\n".join(dict.fromkeys((*overloads, *lines)))
+
+
+def infer(func: _AnyFunc, /, *params: str | int) -> str:
+    """Infer the `optype` protocol(s) required of `func`'s parameters.
+
+    Pass parameter names or positions to report only those parameters.
+
+    >>> print(infer(lambda x: x + 1))
+    [R](x: CanAdd[Literal[1], R]) -> R
+
+    Raises:
+        InferError: If `func` is not supported, such as a non-callable, an
+            operation without a matching protocol, or a parameter that requires
+            a value that no placeholder can provide.
+    """
+    try:
+        return _infer(func, params)
+    except RecursionError as exc:
+        raise InferError("the result is nested too deeply") from exc

--- a/optype/infer/_explore.py
+++ b/optype/infer/_explore.py
@@ -39,7 +39,7 @@ from ._spy import (
     _SpyStr,
     _TraceItem,
 )
-from ._values import _Fn, _Gen, _walk, fn_spies
+from ._values import _Fn, _Gen, _Rec, _RecRef, _RecVar, _walk, fn_spies
 
 __all__ = (
     "_Recon",
@@ -240,34 +240,41 @@ def _explore_func(func: _AnyFunc) -> object:
     return _Fn(params, spies, fixed, _declared_defaults(params), results)
 
 
-def _next(result: object) -> object:
+def _next(result: object, path: dict[int, _RecVar | None] | None = None) -> object:
     # a function (or iterator) within the yields or a container is explored as well
+    path = {} if path is None else path
+    rid = id(result)
+    if rid in path:
+        # reuse this ancestor's binder, or create it on the first back-edge
+        path[rid] = var = path[rid] or _RecVar(object())
+        return _RecRef(var)
+    path[rid] = None  # marks the ancestor chain; a `_RecVar` once reached again
     cls = type(result)
     if isgenerator(result):
-        out = _Gen([_next(v) for v in _yields(result)], "Generator")
+        out = _Gen([_next(v, path) for v in _yields(result)], "Generator")
     elif isasyncgen(result):
-        out = _Gen([_next(v) for v in _yields(_sync(result))], "AsyncGenerator")
+        out = _Gen([_next(v, path) for v in _yields(_sync(result))], "AsyncGenerator")
     elif cls in _ITERATOR_TYPES:
         values = _yields(cast("Iterable[object]", result))
         if cls is enumerate:
             # `enumerate[R]` is parameterized by the element type, not the yields
             values = [item for _, item in cast("list[tuple[int, object]]", values)]
-        out = _Gen([_next(v) for v in values], cls.__name__)
+        out = _Gen([_next(v, path) for v in values], cls.__name__)
     elif isinstance(_unwrap(result), _FUNCTION_TYPES):
         out = _explore_func(cast("_AnyFunc", result))
     else:
         # pyright fails miserably here when narrowing types
         match result:
             case tuple():
-                out = tuple(map(_next, result))  # pyright:ignore[reportUnknownArgumentType]
+                out = tuple(_next(item, path) for item in result)  # pyright:ignore[reportUnknownArgumentType,reportUnknownVariableType]
             case list():
-                out = [_next(item) for item in result]  # pyright:ignore[reportUnknownArgumentType,reportUnknownVariableType]
+                out = [_next(item, path) for item in result]  # pyright:ignore[reportUnknownArgumentType,reportUnknownVariableType]
             case Mapping():
                 # the keys must stay hashable, so only the values recurse
-                out = cls({key: _next(value) for key, value in result.items()})  # type:ignore[call-arg] # pyright:ignore[reportCallIssue,reportUnknownVariableType]
+                out = cls({key: _next(value, path) for key, value in result.items()})  # type:ignore[call-arg] # pyright:ignore[reportCallIssue,reportUnknownVariableType]
             case _:
                 out = result
-    return out
+    return _Rec(var, out) if (var := path.pop(rid)) is not None else out
 
 
 def _rollback(marks: Iterable[tuple[_SpyObject, int]]) -> None:

--- a/optype/infer/_render.py
+++ b/optype/infer/_render.py
@@ -27,7 +27,7 @@ from ._spy import (
     _TraceItem,
     as_spy,
 )
-from ._values import _children, _Fn, _Gen, _walk, fn_spies
+from ._values import _children, _Fn, _Gen, _Rec, _RecRef, _RecVar, _walk, fn_spies
 from optype._core import _can, _has
 from optype.inspect import get_protocol_members
 
@@ -226,13 +226,14 @@ def _packed_uses(value: object, spy: _SpyObject, count: int) -> Generator[bool]:
             if value is spy:
                 yield False
             return
-        case tuple() if not isinstance(value, _Gen | _Fn):
+        case tuple() if not isinstance(value, _Gen | _Fn | _Rec | _RecRef):
             tup = cast("tuple[object, ...]", value)
             if runs := _spy_runs(tup, spy):
                 yield runs == [count]
             items = (item for item in tup if item is not spy)
         case _:
             items = _children(value)
+
     for item in items:
         yield from _packed_uses(item, spy, count)
 
@@ -324,9 +325,33 @@ def _merge_combined(parts: list[_ir.Node]) -> list[_ir.Node]:
     return parts
 
 
+def _result_var(index: int) -> str:
+    """The `index`-th return typevar name: `R`, `R2`, `R3`, ..."""
+    return "R" if not index else f"R{index + 1}"
+
+
 @final
 class _Renderer:
     """Render an inferred `def` signature from the recorded spy traces."""
+
+    _spies: Mapping[str, _SpyObject]
+    _fixed: Mapping[str, object]
+    _results: list[object]
+    _traces: _Traces
+
+    _prefix: dict[str, str]
+    _nameless: set[str]
+    _optional: set[str]
+    _varpos: _SpyObject | None
+
+    _vars: _Vars
+
+    _result_spies: list[_SpyObject]
+
+    _rec_vars: dict[_RecVar, str]
+    _rec_body: dict[_RecVar, object]
+
+    _pool: list[_SpyObject]
 
     def __init__(
         self,
@@ -348,7 +373,7 @@ class _Renderer:
             for name, p in params.items()
             if p.default is not Parameter.empty or p.kind in _PARAM_PREFIX
         }
-        self._varpos = next(
+        self._varpos = next(  # ty:ignore[invalid-assignment]
             (
                 spies[name]
                 for name, p in params.items()
@@ -362,12 +387,25 @@ class _Renderer:
         order, appear = _analyze(param_spies, results, traces)
         param_ids = {id(spy) for spy in param_spies}
 
-        self._vars: _Vars = {}
+        self._vars = {}
         varpos = self._varpos
         if varpos is not None and _all_packed(varpos, results, traces, count):
             self._vars[id(varpos)] = _TYPEVAR_TUPLE
-        self._result_spies: list[_SpyObject] = []
+
+        self._result_spies = []
         self._name_results(order, param_ids)
+
+        self._rec_body = {
+            node.var: node.body
+            for result in results
+            for node in _walk(result)
+            if isinstance(node, _Rec)
+        }
+        base = len(self._result_spies)
+        self._rec_vars = {
+            var: _result_var(base + i) for i, var in enumerate(self._rec_body)
+        }
+
         self._pool = [
             spy for spy in param_spies if appear[id(spy)] >= 2 or id(spy) in self._vars
         ]
@@ -378,6 +416,7 @@ class _Renderer:
             and id(spy) not in param_ids
             and id(spy) not in self._vars
         ]
+
         unnamed = [spy for spy in self._pool if id(spy) not in self._vars]
         for i, spy in enumerate(unnamed):
             self._vars[id(spy)] = _TYPEVARS[i] if i < len(_TYPEVARS) else f"T{i}"
@@ -399,8 +438,7 @@ class _Renderer:
                 if key is not None and key in shared:
                     self._vars[id(spy)] = shared[key]
                     continue
-                n = len(self._result_spies)
-                var = "R" if not n else f"R{n + 1}"
+                var = _result_var(len(self._result_spies))
                 self._vars[id(spy)] = var
                 self._result_spies.append(spy)
                 if key is not None:
@@ -530,10 +568,12 @@ class _Renderer:
         return decl
 
     def return_type(self, result: object) -> _ir.Node:
-
+        node: _ir.Node
         match result:
+            case _RecRef() | _Rec():
+                node = _ir.Name(self._rec_vars[result.var])
             case _SpyObject() if (spy := as_spy(result)) is not None:
-                node: _ir.Node = _ir.Name(self._vars.get(id(spy), _OBJECT))
+                node = _ir.Name(self._vars.get(id(spy), _OBJECT))
             case _SpyStr():
                 node = _ir.Type(str)
             case _SpyBytes():
@@ -653,6 +693,15 @@ class _Renderer:
             # PEP 696 requires defaulted type parameters to come last
             ordered.sort(key=lambda spy: id(spy) in defaulted)
         typevars = [self.typevar(spy, defaulted, negate=negate) for spy in ordered]
+
+        # a recursive typevar carries no default, so it precedes the defaulted tail
+        deferred = 0 if negate else sum(id(spy) in defaulted for spy in ordered)
+        cut = len(ordered) - deferred
+        typevars[cut:cut] = [
+            f"{name}: {_ir.render(self.return_type(self._rec_body[var]))}"
+            for var, name in self._rec_vars.items()
+        ]
+
         generics = f"[{', '.join(typevars)}]" if typevars else ""
         params = ", ".join(
             decl

--- a/optype/infer/_values.py
+++ b/optype/infer/_values.py
@@ -3,7 +3,7 @@
 from collections.abc import Collection, Generator, Iterable, Mapping
 from inspect import Parameter
 from itertools import chain
-from typing import NamedTuple, cast
+from typing import NamedTuple, NewType, cast
 
 from ._spy import _SpyObject
 
@@ -25,20 +25,41 @@ class _Fn(NamedTuple):
     results: list[object]
 
 
+# the shared identity of a recursive `_Rec` binder and its `_RecRef` uses
+_RecVar = NewType("_RecVar", object)
+
+
+class _Rec(NamedTuple):
+    """A result that reaches itself, rendered as a recursive typevar bound."""
+
+    var: _RecVar  # the identity shared with this binder's `_RecRef` uses
+    body: object
+
+
+class _RecRef(NamedTuple):
+    """A reference to the enclosing `_Rec` binder of the same `var`."""
+
+    var: _RecVar
+
+
 def _children(value: object) -> Iterable[object]:
     """The values directly contained in an explored result."""
     match value:
         case _Gen():
-            return value.yielded
+            out: Iterable[object] = value.yielded
         case _Fn():
-            return value.results
+            out = value.results
+        case _Rec():
+            out = (value.body,)
+        case _RecRef():
+            out = ()
         case tuple() | list() | set() | frozenset():
-            return cast("Collection[object]", value)
+            out = cast("Collection[object]", value)
         case Mapping():  # `dict`, and the `frozendict` builtin on Python 3.15+
-            mapping = cast("Mapping[object, object]", value)
-            return chain.from_iterable(mapping.items())
+            out = chain.from_iterable(cast("Mapping[object, object]", value).items())
         case _:
-            return ()
+            out = ()
+    return out
 
 
 def _walk(value: object) -> Generator[object]:

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -1267,6 +1267,59 @@ def test_target_exception_partial() -> None:
     assert infer(f) == "(x: CanBool) -> int"
 
 
+def test_self_referential_result() -> None:
+    # a cyclic result is a recursive type, tied off with a self-bounded typevar
+    def f() -> list[object]:
+        a: list[object] = []
+        a.append(a)
+        return a
+
+    assert infer(f) == "[R: list[R]]() -> R"
+
+
+def test_self_referential_result_nested() -> None:
+    # the cycle is detected by identity through any depth of intermediate containers
+    def f() -> list[object]:
+        a: list[object] = []
+        b: list[object] = [a]
+        a.append(b)
+        return a
+
+    assert infer(f) == "[R: list[list[R]]]() -> R"
+
+
+def test_self_referential_result_mixed() -> None:
+    # a recursive container alongside a parameter and a result typevar
+    def f(x: Any) -> list[object]:
+        a: list[object] = []
+        a.extend((a, x + 1))
+        return a
+
+    assert infer(f) == "[R, R2: list[R2 | R]](x: CanAdd[Literal[1], R]) -> R2"
+
+
+def test_self_referential_result_defaulted() -> None:
+    # PEP 696: the defaultless recursive typevar must precede the defaulted one
+    def f(x: Any = 1) -> list[object]:
+        a: list[object] = []
+        a.extend((a, x))
+        return a
+
+    assert infer(f) == "[R: list[R | T], T = Literal[1]](x: T = 1) -> R"
+
+
+def test_deeply_nested_result() -> None:
+    # a finite result too deep for the call stack is reported, not crashed on
+    def f() -> list[object]:
+        x: list[object] = []
+        for _ in range(sys.getrecursionlimit() * 2):
+            x = [x]
+        return x
+
+    with pytest.raises(InferError, match="deeply"):
+        infer(f)
+
+
 def test_not_callable() -> None:
     not_callable: Any = 42
     with pytest.raises(InferError, match="not a callable"):


### PR DESCRIPTION
before:

```console
$ optype infer "def f(): x = []; x.append(x); return x"
Traceback (most recent call last):
[...]
RecursionError: maximum recursion depth exceeded
```

after:

```console
$ optype infer "def f(): x = []; x.append(x); return x"
[R: list[R]]() -> R
```

closes #670