### PR TITLE
`infer`: target exceptions escape instead of `InferError`

### DIFF
--- a/optype/infer/_explore.py
+++ b/optype/infer/_explore.py
@@ -270,6 +270,11 @@ def _next(result: object) -> object:
     return out
 
 
+def _rollback(marks: Iterable[tuple[_SpyObject, int]]) -> None:
+    for spy, length in marks:
+        del spy.__optype_trace__[length:]
+
+
 def _explore[T](
     func: Callable[..., T] | Callable[..., Coroutine[Any, None, T]],
     args: Sequence[object],
@@ -298,8 +303,12 @@ def _explore[T](
                 dropped = True
         except _AbsentError:
             # the dunder is genuinely needed, so this run (and its marker) never was
-            for spy, length in marks:
-                del spy.__optype_trace__[length:]
+            _rollback(marks)
+        except (InferError, IndexError, KeyError, TypeError, ValueError):
+            raise  # signals the driver acts on, not a rejected run
+        except Exception:  # noqa: BLE001
+            # the target rejected these spy values (assert, zero-division, ...); skip
+            _rollback(marks)
         finally:
             _fork.reset(token)
     if not results:

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -1248,6 +1248,25 @@ def test_fork_truncation_warning() -> None:
         infer(f)
 
 
+def test_target_exception_skipped() -> None:
+    # a non-protocol error from the target marks a failed run; it never escapes
+    def f(x: Any) -> None:  # noqa: ARG001
+        raise AssertionError
+
+    with pytest.raises(InferError, match="completion"):
+        infer(f)
+
+
+def test_target_exception_partial() -> None:
+    # only the branch that raises is dropped; the surviving branch still infers
+    def f(x: Any) -> int:
+        if not x:
+            raise ZeroDivisionError
+        return 1
+
+    assert infer(f) == "(x: CanBool) -> int"
+
+
 def test_not_callable() -> None:
     not_callable: Any = 42
     with pytest.raises(InferError, match="not a callable"):


### PR DESCRIPTION
before:

```console
$ optype infer "import statistics; statistics.median_grouped"
...
ZeroDivisionError: division by zero
```

after:

```console
$ optype infer "import statistics; statistics.median_grouped"
[T: CanLt[T, CanBool] & (CanFloat | CanIndex)](data: CanIter[CanNext[T]], interval: CanFloat | CanIndex = 1.0) -> float
```

Exploration only caught the control-flow signals and the protocol-relevant `IndexError` / `KeyError` / `TypeError` / `ValueError`; anything else the target raised on the concrete spy values (`AssertionError`, `ZeroDivisionError`, `zlib.error`, `_csv.Error`, ...) escaped straight out of `infer`. Such a run is now rolled back and skipped, like an absent dunder, so surviving branches still infer and a function that never completes reports cleanly.

closes #666