### PR TITLE
`infer`: runaway typevar explosion on numeric loops

### DIFF
--- a/optype/infer/_render.py
+++ b/optype/infer/_render.py
@@ -40,6 +40,7 @@ _TYPEVARS = "TUVWXYZ"
 _TYPEVAR_TUPLE = "*Ts"
 _NEVER = "Never"
 _OBJECT = "object"
+_TYPEVAR_LIMIT = 26  # a signature needing more typevars is unreadable, not useful
 
 # the attribute polarity sigils of the fictional inline `Has['name', T]` form
 _READ = "+"  # covariant: a read-only property suffices
@@ -649,6 +650,9 @@ class _Renderer:
             if (node := self.union((value,))) is not None
         }
         ordered = self._pool + self._result_spies
+        if len(ordered) > _TYPEVAR_LIMIT:  # a numeric loop can spawn thousands
+            msg = f"more than {_TYPEVAR_LIMIT} type parameters"
+            raise InferError(msg)
         if not negate:
             # PEP 696 requires defaulted type parameters to come last
             ordered.sort(key=lambda spy: id(spy) in defaulted)

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -1248,6 +1248,15 @@ def test_fork_truncation_warning() -> None:
         infer(f)
 
 
+def test_typevar_limit() -> None:
+    # thousands of typevars (as numeric loops in e.g. colorsys produce) report cleanly
+    def f(x: Any) -> tuple[Any, ...]:
+        return tuple(getattr(x, f"a{i}") for i in range(30))
+
+    with pytest.raises(InferError, match="type parameters"):
+        infer(f)
+
+
 def test_not_callable() -> None:
     not_callable: Any = 42
     with pytest.raises(InferError, match="not a callable"):


### PR DESCRIPTION
before:

```console
$ optype infer "import colorsys; colorsys.hls_to_rgb"
[T: CanLe[float, CanBool] & CanMul[T1169 | T1168 | T1167 | ...   # 72_913 chars, ~5600 typevars
```

after:

```console
$ optype infer "import colorsys; colorsys.hls_to_rgb"
InferError: more than 26 type parameters
```

A loop over a spy result (`colorsys.hls_to_rgb`, `base64.encode`, `random.vonmisesvariate`, `difflib.get_close_matches`, ...) can spawn thousands of distinct result spies, each rendered as its own typevar, yielding a valid-but-useless multi-thousand-character signature. Beyond `_TYPEVAR_LIMIT` (26) typevars the signature reports cleanly instead.

The limit is a judgement call (open to tuning); 26 clears every legitimate case in the test suite (max 3) with wide margin while catching all the runaway ones.

closes #671