### PR TITLE
`infer`: non-deterministic literal rendering of concrete returns

### DIFF
--- a/optype/infer/_render.py
+++ b/optype/infer/_render.py
@@ -40,6 +40,7 @@ _TYPEVARS = "TUVWXYZ"
 _TYPEVAR_TUPLE = "*Ts"
 _NEVER = "Never"
 _OBJECT = "object"
+_TUPLE_LIMIT = 16
 
 # the attribute polarity sigils of the fictional inline `Has['name', T]` form
 _READ = "+"  # covariant: a read-only property suffices
@@ -666,6 +667,9 @@ class _Renderer:
 
             if all(item is spy for item in items):
                 return _ir.App("tuple", (self.return_type(spy), _ir.Name("...")))
+
+        if len(items) > _TUPLE_LIMIT:  # e.g. `random.getstate`
+            return _ir.App("tuple", (self._union_type(items), _ir.Name("...")))
 
         elems = (self.union((item,)) or _ir.Name(_NEVER) for item in items)
         return _ir.App("tuple", tuple(elems))

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -1280,6 +1280,14 @@ def test_target_exception_partial() -> None:
     assert infer(f) == "(x: CanBool) -> int"
 
 
+def test_large_tuple_widens() -> None:
+    # a long concrete tuple (like `random.getstate`) widens instead of listing literals
+    def f() -> tuple[int, ...]:
+        return tuple(range(50))
+
+    assert infer(f) == "() -> tuple[int, ...]"
+
+
 def test_self_referential_result() -> None:
     # a cyclic result is a recursive type, tied off with a self-bounded typevar
     def f() -> list[object]:


### PR DESCRIPTION
before (outputs ~13k chars and differs every run):

```console
$ optype infer "import random; random.getstate"
() -> tuple[Literal[3], tuple[Literal[2147483648], Literal[366576521], ...]]
```

after:

```console
$ optype infer "import random; random.getstate"
() -> tuple[Literal[3], tuple[int, ...], None]
```

closes #672