### PR TITLE
`infer`: collapse repeated subexpressions

### DIFF
--- a/optype/infer/_ir.py
+++ b/optype/infer/_ir.py
@@ -179,8 +179,63 @@ def _absorb(nodes: list[Node]) -> list[Node]:
     return merged
 
 
-def union(parts: Iterable[Node]) -> Node | None:
-    """The simplified flat union of `parts`, unwrapped if singular, or `None`."""
+_UNION_TUPLE_LIMIT = 8  # keep positional correlation below this; collapse a wider union
+
+
+def _fixed_tuple_arity(node: Node) -> int | None:
+    """The arity of a fixed-length `tuple[...]`, or `None` if not one."""
+    if not isinstance(node, App) or node.base != "tuple" or not node.args:
+        return None
+    if any(
+        isinstance(arg, Arg)
+        or (isinstance(arg, Name) and (arg.name == "..." or arg.name.startswith("*")))
+        for arg in node.args
+    ):
+        return None  # a variadic `tuple[X, ...]` or `tuple[*Ts]` has no fixed arity
+    return len(node.args)
+
+
+def _collapse_tuples(nodes: list[Node]) -> list[Node]:
+    """Merge each large group of same-arity tuples into one per-position union.
+
+    `tuple[A, B] | tuple[C, D]` widens to `tuple[A | C, B | D]`; only a group wider
+    than `_UNION_TUPLE_LIMIT` collapses, so a small union keeps its positional
+    correlation (e.g. `tuple[int, str] | tuple[str, int]`).
+    """
+    groups: dict[int, list[App]] = {}
+    for node in nodes:
+        if isinstance(node, App) and (arity := _fixed_tuple_arity(node)) is not None:
+            groups.setdefault(arity, []).append(node)
+    collapse = {a for a, group in groups.items() if len(group) > _UNION_TUPLE_LIMIT}
+    if not collapse:
+        return nodes
+
+    out: list[Node] = []
+    done: set[int] = set()
+    for node in nodes:
+        arity = _fixed_tuple_arity(node)
+        if arity is None or arity not in collapse:
+            out.append(node)
+            continue
+        if arity in done:
+            continue
+        done.add(arity)
+        group = groups[arity]
+        # `_fixed_tuple_arity` already excluded any `Arg`, so `_param_type` is a no-op
+        columns = (
+            union([_param_type(g.args[i]) for g in group], tuples=True) or Name("Never")
+            for i in range(arity)
+        )
+        out.append(App("tuple", tuple(columns)))
+    return out
+
+
+def union(parts: Iterable[Node], *, tuples: bool = False) -> Node | None:
+    """The simplified flat union of `parts`, unwrapped if singular, or `None`.
+
+    With `tuples=True`, a wide union of same-arity tuples collapses per position;
+    pass it only in covariant positions, where widening a tuple stays sound.
+    """
     flat: dict[Node, None] = {}
     for part in parts:
         if isinstance(part, Union):
@@ -190,6 +245,8 @@ def union(parts: Iterable[Node]) -> Node | None:
     if not flat:
         return None
     nodes = _absorb(list(flat))
+    if tuples:
+        nodes = _collapse_tuples(nodes)
     return nodes[0] if len(nodes) == 1 else Union(tuple(nodes))
 
 

--- a/optype/infer/_render.py
+++ b/optype/infer/_render.py
@@ -97,7 +97,6 @@ _COERCION_PROTOS = {
 }
 
 type _Vars = dict[int, str]
-type _RetKey = tuple[int, str, object, tuple[str, ...]]
 type _Proto = str | tuple[str, ...]  # a tuple is rendered as a union of protocols
 
 type _Names = Sequence[str]
@@ -188,30 +187,62 @@ def _analyze(
     return order, appear
 
 
-def _ret_keys(
-    order: Iterable[_SpyObject],
-    traces: _Traces,
-) -> tuple[dict[int, _RetKey], set[int]]:
-    """The shape of the op that returned each spy, and the spies used as args."""
-    keys: dict[int, _RetKey] = {}
-    args: set[int] = set()
+type _Producer = Mapping[int, tuple[_SpyObject, _TraceItem]]
+
+
+def _shape(spy: _SpyObject, made_by: _Producer, keys: dict[int, object]) -> object:
+    """A structural key over op-shape, not operands: `x[y]` and `x[z]` share one."""
+    sid = id(spy)
+    if sid in keys:
+        return keys[sid]
+    keys[sid] = sid  # a parameter or leaf is its own key
+    if (made := made_by.get(sid)) is not None:
+        owner, item = made
+        # an attribute name replaces the fixed arity: `x.spam` is not `x.ham`
+        attr = item.attr
+        arity: object = (
+            item.args[0]
+            if attr in _DUNDER_ATTR or attr in _DUNDER_CLASS_ATTR
+            else len(item.args)
+        )
+        owner_key = _shape(owner, made_by, keys)
+        keys[sid] = "op", owner_key, attr, arity, tuple(sorted(item.kwargs))
+    return keys[sid]
+
+
+def _representatives(order: Sequence[_SpyObject], traces: _Traces) -> dict[int, int]:
+    """Map each spy to a representative: the same operation on an owner of the same
+    shape shares one, so the fresh placeholder each forked run allocates for a
+    repeated subexpression collapses onto it instead of spawning a type parameter.
+    """
+    # a result is always a fresh spy, so a parameter never appears here and stays a leaf
+    made_by: dict[int, tuple[_SpyObject, _TraceItem]] = {}
     for owner in order:
         for item in traces[id(owner)]:
-            for value in (*item.args, *item.kwargs.values()):
-                if (arg := as_spy(value)) is not None:
-                    args.add(id(arg))
-
             if isinstance(item.return_, _SpyObject):
-                # an attribute name replaces the fixed arity: `x.spam` is not `x.ham`
-                shape = (
-                    item.args[0]
-                    if item.attr in _DUNDER_ATTR or item.attr in _DUNDER_CLASS_ATTR
-                    else len(item.args)
-                )
-                key = id(owner), item.attr, shape, tuple(sorted(item.kwargs))
-                keys[id(item.return_)] = key
+                made_by.setdefault(id(item.return_), (owner, item))
 
-    return keys, args
+    keys: dict[int, object] = {}
+    rep: dict[object, int] = {}  # structural key -> the first spy that had it
+    reps: dict[int, int] = {}
+    for spy in order:
+        reps[id(spy)] = rep.setdefault(_shape(spy, made_by, keys), id(spy))
+    return reps
+
+
+def _group_traces(
+    named: Iterable[int],
+    reps: dict[int, int],
+    traces: _Traces,
+) -> _Traces:
+    """Each representative's bound: the traces of every named spy that shares it.
+
+    Only named spies merge; an inline one still renders its constraints where used.
+    """
+    merged: _Traces = {}
+    for spy_id in named:
+        merged.setdefault(reps.get(spy_id, spy_id), []).extend(traces.get(spy_id, ()))
+    return merged
 
 
 def _spy_runs(items: Iterable[object], spy: _SpyObject) -> list[int]:
@@ -345,7 +376,9 @@ class _Renderer:
     _optional: set[str]
     _varpos: _SpyObject | None
 
+    _reps: dict[int, int]
     _vars: _Vars
+    _named: dict[int, str]
 
     _result_spies: list[_SpyObject]
 
@@ -353,6 +386,7 @@ class _Renderer:
     _rec_body: dict[_RecVar, object]
 
     _pool: list[_SpyObject]
+    _group_traces: _Traces
 
     def __init__(
         self,
@@ -387,14 +421,16 @@ class _Renderer:
         param_spies = [*spies.values(), *fn_spies(results)]
         order, appear = _analyze(param_spies, results, traces)
         param_ids = {id(spy) for spy in param_spies}
+        self._reps = reps = _representatives(order, traces)
 
         self._vars = {}
+        self._named = {}  # representative id -> name
         varpos = self._varpos
         if varpos is not None and _all_packed(varpos, results, traces, count):
             self._vars[id(varpos)] = _TYPEVAR_TUPLE
 
         self._result_spies = []
-        self._name_results(order, param_ids)
+        self._name_results(param_ids, reps)
 
         self._rec_body = {
             node.var: node.body
@@ -418,34 +454,44 @@ class _Renderer:
             and id(spy) not in self._vars
         ]
 
-        unnamed = [spy for spy in self._pool if id(spy) not in self._vars]
-        for i, spy in enumerate(unnamed):
-            self._vars[id(spy)] = _TYPEVARS[i] if i < len(_TYPEVARS) else f"T{i}"
+        # one type parameter per distinct expression: duplicates reuse its name
+        pool: list[_SpyObject] = []
+        n = 0
+        for spy in self._pool:
+            rep = reps.get(id(spy), id(spy))
+            if (var := self._named.get(rep)) is None:
+                var = self._vars.get(id(spy))  # a `*Ts` variadic keeps its name
+                if var is None:
+                    var = _TYPEVARS[n] if n < len(_TYPEVARS) else f"T{n}"
+                    n += 1
+                self._named[rep] = var
+                pool.append(spy)
+            self._vars[id(spy)] = var
+        self._pool = pool
+        self._group_traces = _group_traces(self._vars, reps, traces)
 
-    def _name_results(self, order: Iterable[_SpyObject], param_ids: set[int]) -> None:
-        ret_keys, arg_ids = _ret_keys(order, self._traces)
-        shared: dict[_RetKey, str] = {}
+    def _name_results(self, param_ids: set[int], reps: dict[int, int]) -> None:
         for result in self._results:
             for spy in _return_spies(result):
-                if id(spy) in param_ids or id(spy) in self._vars:
+                sid = id(spy)
+                if sid in param_ids or sid in self._vars:
                     continue
-                # untraced results of same-shaped ops that are never passed as an
-                # argument are interchangeable, so they share a typevar
-                key = (
-                    ret_keys.get(id(spy))
-                    if not self._traces[id(spy)] and id(spy) not in arg_ids
-                    else None
-                )
-                if key is not None and key in shared:
-                    self._vars[id(spy)] = shared[key]
+                # results of one op-shape share a type parameter, even traced or reused
+                rep = reps.get(sid, sid)
+                if (var := self._named.get(rep)) is not None:
+                    self._vars[sid] = var
                     continue
                 var = _result_var(len(self._result_spies))
-                self._vars[id(spy)] = var
+                self._vars[sid] = var
                 self._result_spies.append(spy)
-                if key is not None:
-                    shared[key] = var
+                self._named[rep] = var
 
-    def union(self, values: Iterable[object]) -> _ir.Node | None:
+    def union(
+        self,
+        values: Iterable[object],
+        *,
+        tuples: bool = False,
+    ) -> _ir.Node | None:
         literals: list[object] = []
         parts: list[_ir.Node] = []
         for value in values:
@@ -458,7 +504,7 @@ class _Renderer:
         if literals:
             nodes.append(_ir.Lit(tuple(literals)))
         nodes.extend(dict.fromkeys(parts))
-        return _ir.union(nodes)
+        return _ir.union(nodes, tuples=tuples)
 
     def returns(self, members: Iterable[_Op]) -> _ir.Node | None:
         named: list[str] = []
@@ -559,7 +605,8 @@ class _Renderer:
         negate: bool = False,
     ) -> str:
         var = self._vars[id(spy)]
-        node = self.spy(spy)
+        rep = self._reps.get(id(spy), id(spy))
+        node = self.traces(self._group_traces.get(rep, ()))
         default = defaulted.get(id(spy))
         if negate and default is not None:
             node = _ir.exclude(node, default)
@@ -592,7 +639,7 @@ class _Renderer:
     def _union_type(self, values: Iterable[object]) -> _ir.Node:
         """The deduplicated union of the types of `values`, or `Never` if empty."""
         parts = dict.fromkeys(map(self.return_type, values))
-        return _ir.union(parts) or _ir.Name(_NEVER)
+        return _ir.union(parts, tuples=True) or _ir.Name(_NEVER)
 
     def _function(self, fn: _Fn) -> _ir.Node:
         """The signature-syntax type of an explored function result."""
@@ -636,11 +683,11 @@ class _Renderer:
                 return _ir.App("type", (inner,))
             case Mapping():
                 mapping = cast("Mapping[object, object]", result)
-                key = self.union(mapping) or _ir.Name(_NEVER)
-                val = self.union(mapping.values()) or _ir.Name(_NEVER)
+                key = self.union(mapping, tuples=True) or _ir.Name(_NEVER)
+                val = self.union(mapping.values(), tuples=True) or _ir.Name(_NEVER)
                 return _ir.App(cls.__name__, (key, val))
             case list() | set() | frozenset():
-                inner = self.union(cast("Collection[object]", result))
+                inner = self.union(cast("Collection[object]", result), tuples=True)
                 return _ir.App(cls.__name__, (inner or _ir.Name(_NEVER),))
             case tuple() if cls is tuple:
                 return (

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -19,7 +19,7 @@ import pytest
 
 from optype.infer import InferError, InferWarning, infer
 from optype.infer._explore import _doc_params
-from optype.infer._ir import App, Arg, Fn, Lit, Name, Type, subtype
+from optype.infer._ir import App, Arg, Fn, Lit, Name, Node, Type, render, subtype, union
 
 
 def _type_of[T](x: T) -> type[T]:
@@ -1288,6 +1288,41 @@ def test_large_tuple_widens() -> None:
     assert infer(f) == "() -> tuple[int, ...]"
 
 
+def test_union_tuple_collapse() -> None:
+    # a wide union of same-arity tuples (like `colorsys.hls_to_rgb`) collapses per
+    # position; a small one keeps its correlation
+    def pair(i: int) -> App:
+        return App("tuple", (Name(f"A{i}"), Name(f"B{i}")))
+
+    def triple(i: int) -> App:
+        return App("tuple", (Name(f"C{i}"), Name(f"D{i}"), Name(f"E{i}")))
+
+    def rendered(nodes: list[Node], *, tuples: bool) -> str:
+        node = union(nodes, tuples=tuples)
+        assert node is not None
+        return render(node)
+
+    cols2 = " | ".join(f"A{i}" for i in range(9)), " | ".join(f"B{i}" for i in range(9))
+    wide2 = f"tuple[{cols2[0]}, {cols2[1]}]"
+
+    small: list[Node] = [pair(0), pair(1)]
+    assert rendered(small, tuples=True) == "tuple[A0, B0] | tuple[A1, B1]"
+
+    wide: list[Node] = [pair(i) for i in range(9)]
+    assert rendered(wide, tuples=True) == wide2
+    assert rendered(wide, tuples=False).count("tuple[") == 9
+
+    # each arity collapses on its own; a wider triple group folds independently
+    cols3 = tuple(" | ".join(f"{p}{i}" for i in range(9)) for p in "CDE")
+    mixed = wide + [triple(i) for i in range(9)]
+    assert rendered(mixed, tuples=True) == f"{wide2} | tuple[{', '.join(cols3)}]"
+
+    # a non-tuple member and a variadic tuple stay untouched beside the collapse
+    assert rendered([*wide, Name("X")], tuples=True) == f"{wide2} | X"
+    variadic = App("tuple", (Name("V"), Name("...")))
+    assert rendered([*wide, variadic], tuples=True) == f"{wide2} | tuple[V, ...]"
+
+
 def test_self_referential_result() -> None:
     # a cyclic result is a recursive type, tied off with a self-bounded typevar
     def f() -> list[object]:
@@ -1339,6 +1374,37 @@ def test_deeply_nested_result() -> None:
 
     with pytest.raises(InferError, match="deeply"):
         infer(f)
+
+
+def test_structural_dedup() -> None:
+    # every forked run re-derives `a = x * 2` and then `a + 1` / `a + 2`; the fresh
+    # placeholders for these repeated subexpressions collapse onto one type parameter
+    # each, not one per run (which is what made e.g. `colorsys.hls_to_rgb` explode)
+    def f(x: Any) -> object:
+        a = x * 2
+        return (a + 1) if x else (a + 2) if a else a
+
+    assert infer(f) == (
+        "[R, R2: CanBool](x: CanMul[Literal[2], R2 & CanAdd[Literal[1, 2], R]"
+        " & CanBool] & CanBool) -> R | R2"
+    )
+
+
+def test_dedup_different_operands() -> None:
+    # `x[y]` and `x[z]` share an op-shape, so they collapse onto one return typevar
+    def f(x: Any, y: Any, z: Any) -> object:
+        return x[y] if x else x[z]
+
+    assert infer(f) == "[T, U, R](x: CanBool & CanGetitem[T | U, R], y: T, z: U) -> R"
+
+    # merged results may be traced (`.foo`), which the old untraced-only guard blocked
+    def g(x: Any, y: Any, z: Any) -> object:
+        p = x[y] if x else x[z]
+        return p.foo
+
+    assert infer(g) == (
+        "[T, U, R](x: CanBool & CanGetitem[T | U, Has['foo', +R]], y: T, z: U) -> R"
+    )
 
 
 def test_not_callable() -> None:


### PR DESCRIPTION
before:

```console
$ optype infer "import colorsys; colorsys.hls_to_rgb"
/home/joren/Workspace/optype/optype/infer/_explore.py:430: InferWarning: not every branch was explored
  return _explore_spies(func, params), {}
[T: CanLe[float, CanBool] & CanMul[T1169 | T1168 | T1167 | T1166 | T1165 | T1164 | T1163 | T1162 | T1161 | T1160 | T1159 | T1158 | T1157 | T1156 | T1155 | T1154 | T1153 | T1152 | T1151 | T1150 | T1149 | T1148 | T1147 | T1146 | T1145 | T1144 | T1143 | T1142 | T1141 | T1140 | T1139 | T1138 | T1137 | T1136 | T1135 | T1134 | T1133 | T1132 | T1131 | T1130 | T1129 | T1128 | T1127 | T1126 | T1125 | T1124 | T1123 | T1122 | T1121 | T1120 | T1119 | T1118 | T1117 | T1116 | T1115 | T1114 | T1113 | T1112 | T1111 | T1110 | T1109 | T1108 | T1107 | T1106 | T1105 | T1104 | T1103 | T1102 | T1101 | T1100 | T1099 | T1098 | T1097 | T1096 | T1095 | T1094 | T1093 | T1092 | T1091 | T1090 | T1089 | T1088 | T1087 | T1086 | T1085 | T1084 | T1083 | T1082 | T1081 | T1080 | T1079 | T1078 | T1077 | T1076 | T1075 | T1074 | T1073 | T1072 | T1071 | T1070 | T1069 | T1068 | T1067 | T1066 | T1065 | T1064 | T1063 | T1062 | T1061 | T1060 | T1059 | T1058 | T1057 | T1056 | T1055 | T1054 | T1053 | T1052 | T1051 | T1050 | T1049 | T1048 | T1047 | T1046 | T1045 | T1044 | T1043 | U, T1042 & T1040 & T1036 & T1031 & T1027 & R3 & T1020 & T1015 & T1011 & T1009 & T1006 & R8 & T1000 & R10 & T995 & R12 & R14 & T988 & T984 & T979 & T975 & R18 & T968 & T963 & T959 & T957 & T953 & T951 & R26 & T947 & T943 & T941 & T940 & T939 & T937 & R31 & T931 & R33 & T926 & R35 & R37 & T920 & T919 & R40 & T916 & R42 & T915 & R43 & R45 & T912 & T910 & R47 & T904 & R49 & T899 & R51 & R53 & T893 & R56 & T891 & R59 & T890 & R61 & R64 & T888 & T886 & T882 & T877 & T873 & R68 & T866 & T861 & T857 & T855 & T852 & R73 & T846 & R75 & T841 & R77 & R79 & T834 & T830 & T825 & T821 & R83 & T814 & T809 & T805 & T803 & T799 & T797 & R91 & T793 & T789 & T787 & T786 & T784 & T780 & T778 & R100 & T774 & T770 & T768 & T767 & T766 & R106 & T764 & R109 & T763 & R111 & R114 & T761 & T759 & T755 & T753 & R119 & T749 & T745 & T743 & T742 & T740 & T739 & R127 & T738 & T736 & T735 & T733 & T730 & T725 & T719 & T714 & T710 & T705 & T699 & T694 & T691 & T687 & T683 & T679 & T676 & T672 & T668 & T665 & T662 & T657 & T651 & T646 & T642 & T637 & T631 & T626 & T623 & T618 & T615 & T612 & T609 & T604 & T601 & T599 & T597 & T594 & T590 & T586 & T583 & T579 & T575 & T572 & T570 & T568 & T566 & T563 & T562 & T560 & T558 & T556 & T554 & T551 & T547 & T543 & T540 & T536 & T532 & T529 & T527 & T525 & T523 & T522 & T520 & T518 & T517 & T515 & T512 & T507 & T501 & T496 & T492 & T487 & T481 & T476 & T473 & T469 & T465 & T461 & T458 & T454 & T450 & T447 & T444 & T439 & T433 & T428 & T424 & T419 & T413 & T408 & T405 & T400 & T397 & T394 & T391 & T386 & T383 & T381 & T378 & T373 & T370 & T367 & T364 & T359 & T356 & T354 & T352 & T350 & T348 & T347 & T345 & T343 & T342 & T340 & T337 & T332 & T329 & T326 & T323 & T318 & T315 & T313 & T310 & T308 & T307 & T305 & T302] & CanRMul[float, CanSub[T1042 | T1040 | T1036 | T1031 | T1027 | R3 | T1020 | T1015 | T1011 | T1009 | T1006 | R8 | T1000 | R10 | T995 | R12 | R14 | T988 | T984 | T979 | T975 | R18 | T968 | T963 | T959 | T957 | T953 | T951 | R26 | T947 | T943 | T941 | T940 | T939 | T937 | R31 | T931 | R33 | T926 | R35 | R37 | T920 | T919 | R40 | T916 | R42 | T915 | R43 | R45 | T912 | T910 | R47 | T904 | R49 | T899 | R51 | R53 | T893 | R56 | T891 | R59 | T890 | R61 | R64 | T888 | T886 | T882 | T877 | T873 | R68 | T866 | T861 | T857 | T855 | T852 | R73 | T846 | R75 | T841 | R77 | R79 | T834 | T830 | T825 | T821 | R83 | T814 | T809 | T805 | T803 | T799 | T797 | R91 | T793 | T789 | T787 | T786 | T784 | T780 | T778 | R100 | T774 | T770 | T768 | T767 | T766 | R106 | T764 | R109 | T763 | R111 | R114 | T761 | T759 | T755 | T753 | R119 | T749 | T745 | T743 | T742 | T740 | T739 | R127 | T738 | T736 | T735 | T734 | T731 | T726 | T720 | T715 | R133 | T706 | T700 | T695 | T692 | T688 | R138 | T680 | R140 | T673 | R142 | R144 | T663 | T658 | T652 | T647 | R148 | T638 | T632 | T627 | T624 | T619 | T616 | R156 | T610 | T605 | T602 | T600 | T598 | T595 | R161 | T587 | R163 | T580 | R165 | R167 | T571 | T569 | R170 | T564 | R172 | T561 | R173 | R175 | T555 | T552 | R177 | T544 | R179 | T537 | R181 | R183 | T528 | R186 | T524 | R189 | T521 | R191 | R194 | T516 | T513 | T508 | T502 | T497 | R198 | T488 | T482 | T477 | T474 | T470 | R203 | T462 | R205 | T455 | R207 | R209 | T445 | T440 | T434 | T429 | R213 | T420 | T414 | T409 | T406 | T401 | T398 | R221 | T392 | T387 | T384 | T382 | T379 | T374 | T371 | R230 | T365 | T360 | T357 | T355 | T353 | R236 | T349 | R239 | T346 | R241 | R244 | T341 | T338 | T333 | T330 | R249 | T324 | T319 | T316 | T314 | T311 | T309 | R257 | T306 | T303, T1039 & T1035 & T1030 & T1026 & T1023 & T1019 & T1014 & R6 & T1008 & T1005 & T1002 & T999 & T997 & T994 & T991 & R15 & T987 & T983 & T978 & T974 & T971 & T967 & T962 & R21 & T956 & R23 & T950 & R25 & T946 & R28 & R30 & T936 & T933 & T930 & T928 & T925 & T922 & R39 & T917 & T913 & R46 & T909 & T906 & T903 & T901 & T898 & T895 & R55 & R57 & R60 & R62 & R65 & T885 & T881 & T876 & T872 & T869 & T865 & T860 & R71 & T854 & T851 & T848 & T845 & T843 & T840 & T837 & R80 & T833 & T829 & T824 & T820 & T817 & T813 & T808 & R86 & T802 & R88 & T796 & R90 & T792 & R93 & R95 & T783 & R96 & T777 & R98 & T773 & R101 & R103 & R105 & R108 & R110 & R113 & T758 & R115 & T752 & R117 & T748 & R120 & R122 & R124 & R126 & R128 & R130 & T729 & T724 & T718 & T713 & T709 & T704 & T698 & R136 & T690 & T686 & T682 & T678 & T675 & T671 & T667 & R145 & T661 & T656 & T650 & T645 & T641 & T636 & T630 & R151 & T622 & R153 & T614 & R155 & T608 & R158 & R160 & T593 & T589 & T585 & T582 & T578 & T574 & R169 & T565 & T557 & R176 & T550 & T546 & T542 & T539 & T535 & T531 & R185 & R187 & R190 & R192 & R195 & T511 & T506 & T500 & T495 & T491 & T486 & T480 & R201 & T472 & T468 & T464 & T460 & T457 & T453 & T449 & R210 & T443 & T438 & T432 & T427 & T423 & T418 & T412 & R216 & T404 & R218 & T396 & R220 & T390 & R223 & R225 & T377 & R226 & T369 & R228 & T363 & R231 & R233 & R235 & R238 & R240 & R243 & T336 & R245 & T328 & R247 & T322 & R250 & R252 & R254 & R256 & R258]] & CanAdd[U, CanSub[T733 | T730 | T725 | T719 | T714 | T710 | T705 | T699 | T694 | T691 | T687 | T683 | T679 | T676 | T672 | T668 | T665 | T662 | T657 | T651 | T646 | T642 | T637 | T631 | T626 | T623 | T618 | T615 | T612 | T609 | T604 | T601 | T599 | T597 | T594 | T590 | T586 | T583 | T579 | T575 | T572 | T570 | T568 | T566 | T563 | T562 | T560 | T558 | T556 | T554 | T551 | T547 | T543 | T540 | T536 | T532 | T529 | T527 | T525 | T523 | T522 | T520 | T518 | T517 | T515 | T512 | T507 | T501 | T496 | T492 | T487 | T481 | T476 | T473 | T469 | T465 | T461 | T458 | T454 | T450 | T447 | T444 | T439 | T433 | T428 | T424 | T419 | T413 | T408 | T405 | T400 | T397 | T394 | T391 | T386 | T383 | T381 | T378 | T373 | T370 | T367 | T364 | T359 | T356 | T354 | T352 | T350 | T348 | T347 | T345 | T343 | T342 | T340 | T337 | T332 | T329 | T326 | T323 | T318 | T315 | T313 | T310 | T308 | T307 | T305 | T302, T734 & T731 & T726 & T720 & T715 & R133 & T706 & T700 & T695 & T692 & T688 & R138 & T680 & R140 & T673 & R142 & R144 & T663 & T658 & T652 & T647 & R148 & T638 & T632 & T627 & T624 & T619 & T616 & R156 & T610 & T605 & T602 & T600 & T598 & T595 & R161 & T587 & R163 & T580 & R165 & R167 & T571 & T569 & R170 & T564 & R172 & T561 & R173 & R175 & T555 & T552 & R177 & T544 & R179 & T537 & R181 & R183 & T528 & R186 & T524 & R189 & T521 & R191 & R194 & T516 & T513 & T508 & T502 & T497 & R198 & T488 & T482 & T477 & T474 & T470 & R203 & T462 & R205 & T455 & R207 & R209 & T445 & T440 & T434 & T429 & R213 & T420 & T414 & T409 & T406 & T401 & T398 & R221 & T392 & T387 & T384 & T382 & T379 & T374 & T371 & R230 & T365 & T360 & T357 & T355 & T353 & R236 & T349 & R239 & T346 & R241 & R244 & T341 & T338 & T333 & T330 & R249 & T324 & T319 & T316 & T314 & T311 & T309 & R257 & T306 & T303]], U: CanEq[float, CanBool] & CanRAdd[float, T1169 & T1168 & T1167 & T1166 & T1165 & T1164 & T1163 & T1162 & T1161 & T1160 & T1159 & T1158 & T1157 & T1156 & T1155 & T1154 & T1153 & T1152 & T1151 & T1150 & T1149 & T1148 & T1147 & T1146 & T1145 & T1144 & T1143 & T1142 & T1141 & T1140 & T1139 & T1138 & T1137 & T1136 & T1135 & T1134 & T1133 & T1132 & T1131 & T1130 & T1129 & T1128 & T1127 & T1126 & T1125 & T1124 & T1123 & T1122 & T1121 & T1120 & T1119 & T1118 & T1117 & T1116 & T1115 & T1114 & T1113 & T1112 & T1111 & T1110 & T1109 & T1108 & T1107 & T1106 & T1105 & T1104 & T1103 & T1102 & T1101 & T1100 & T1099 & T1098 & T1097 & T1096 & T1095 & T1094 & T1093 & T1092 & T1091 & T1090 & T1089 & T1088 & T1087 & T1086 & T1085 & T1084 & T1083 & T1082 & T1081 & T1080 & T1079 & T1078 & T1077 & T1076 & T1075 & T1074 & T1073 & T1072 & T1071 & T1070 & T1069 & T1068 & T1067 & T1066 & T1065 & T1064 & T1063 & T1062 & T1061 & T1060 & T1059 & T1058 & T1057 & T1056 & T1055 & T1054 & T1053 & T1052 & T1051 & T1050 & T1049 & T1048 & T1047 & T1046 & T1045 & T1044 & T1043], V, W: CanLt[float, CanBool], X, Y, Z, T7, T8, T9, T10: CanLt[float, CanBool], T11, T12, T13, T14: CanLt[float, CanBool], T15: CanLt[float, CanBool], T16, T17: CanLt[float, CanBool], T18: CanLt[float, CanBool], T19: CanLt[float, CanBool], T20: CanLt[float, CanBool], T21: CanLt[float, CanBool], T22: CanLt[float, CanBool], T23: CanLt[float, CanBool], T24, T25, T26, T27, T28, T29, T30: CanLt[float, CanBool], T31, T32, T33, T34, T35, T36, T37, T38, T39, T40, T41, T42, T43, T44: CanLt[float, CanBool], T45, T46, T47, T48, T49, T50, T51, T52, T53, T54, T55, T56: CanLt[float, CanBool], T57, T58, T59, T60: CanLt[float, CanBool], T61, T62, T63: CanLt[float, CanBool], T64, T65: CanLt[float, CanBool], T66, T67: CanLt[float, CanBool], T68, T69: CanLt[float, CanBool], T70, T71: CanLt[float, CanBool], T72: CanLt[float, CanBool], T73, T74: CanLt[float, CanBool], T75, T76, T77, T78: CanLt[float, CanBool], T79, T80, T81, T82, T83, T84, T85: CanLt[float, CanBool], T86, T87, T88, T89: CanLt[float, CanBool], T90: CanLt[float, CanBool], T91, T92: CanLt[float, CanBool], T93: CanLt[float, CanBool], T94: CanLt[float, CanBool], T95: CanLt[float, CanBool], T96: CanLt[float, CanBool], T97: CanLt[float, CanBool], T98: CanLt[float, CanBool], T99: CanLt[float, CanBool], T100, T101: CanLt[float, CanBool], T102: CanLt[float, CanBool], T103: CanLt[float, CanBool], T104: CanLt[float, CanBool], T105: CanLt[float, CanBool], T106: CanLt[float, CanBool], T107: CanLt[float, CanBool], T108, T109: CanLt[float, CanBool], T110, T111, T112: CanLt[float, CanBool], T113, T114: CanLt[float, CanBool], T115, T116: CanLt[float, CanBool], T117, T118: CanLt[float, CanBool], T119: CanLt[float, CanBool], T120, T121: CanLt[float, CanBool], T122, T123: CanLt[float, CanBool], T124: CanLt[float, CanBool], T125: CanLt[float, CanBool], T126, T127: CanLt[float, CanBool], T128: CanLt[float, CanBool], T129: CanLt[float, CanBool], T130: CanLt[float, CanBool], T131: CanLt[float, CanBool], T132: CanLt[float, CanBool], T133: CanLt[float, CanBool], T134: CanLt[float, CanBool], T135: CanLt[float, CanBool], T136: CanLt[float, CanBool], T137, T138: CanLt[float, CanBool], T139: CanLt[float, CanBool], T140: CanLt[float, CanBool], T141: CanLt[float, CanBool], T142: CanLt[float, CanBool], T143: CanLt[float, CanBool], T144: CanLt[float, CanBool], T145: CanLt[float, CanBool], T146: CanLt[float, CanBool], T147: CanLt[float, CanBool], T148: CanLt[float, CanBool], T149: CanLt[float, CanBool], T150: CanLt[float, CanBool], T151: CanLt[float, CanBool], T152, T153: CanLt[float, CanBool], T154, T155, T156, T157, T158, T159, T160: CanLt[float, CanBool], T161, T162, T163, T164: CanLt[float, CanBool], T165: CanLt[float, CanBool], T166, T167: CanLt[float, CanBool], T168: CanLt[float, CanBool], T169: CanLt[float, CanBool], T170: CanLt[float, CanBool], T171: CanLt[float, CanBool], T172: CanLt[float, CanBool], T173: CanLt[float, CanBool], T174, T175, T176, T177, T178, T179, T180: CanLt[float, CanBool], T181, T182, T183, T184, T185, T186, T187, T188, T189, T190, T191, T192, T193, T194: CanLt[float, CanBool], T195, T196, T197, T198, T199, T200, T201, T202, T203, T204, T205, T206: CanLt[float, CanBool], T207, T208, T209, T210: CanLt[float, CanBool], T211, T212, T213: CanLt[float, CanBool], T214, T215: CanLt[float, CanBool], T216, T217: CanLt[float, CanBool], T218, T219: CanLt[float, CanBool], T220, T221: CanLt[float, CanBool], T222: CanLt[float, CanBool], T223, T224: CanLt[float, CanBool], T225, T226, T227, T228: CanLt[float, CanBool], T229, T230, T231, T232, T233, T234, T235: CanLt[float, CanBool], T236, T237, T238, T239: CanLt[float, CanBool], T240: CanLt[float, CanBool], T241, T242: CanLt[float, CanBool], T243: CanLt[float, CanBool], T244: CanLt[float, CanBool], T245: CanLt[float, CanBool], T246: CanLt[float, CanBool], T247: CanLt[float, CanBool], T248: CanLt[float, CanBool], T249: CanLt[float, CanBool], T250, T251: CanLt[float, CanBool], T252: CanLt[float, CanBool], T253: CanLt[float, CanBool], T254: CanLt[float, CanBool], T255: CanLt[float, CanBool], T256: CanLt[float, CanBool], T257: CanLt[float, CanBool], T258, T259: CanLt[float, CanBool], T260, T261, T262: CanLt[float, CanBool], T263, T264: CanLt[float, CanBool], T265, T266: CanLt[float, CanBool], T267, T268: CanLt[float, CanBool], T269: CanLt[float, CanBool], T270, T271: CanLt[float, CanBool], T272, T273: CanLt[float, CanBool], T274: CanLt[float, CanBool], T275: CanLt[float, CanBool], T276, T277: CanLt[float, CanBool], T278: CanLt[float, CanBool], T279: CanLt[float, CanBool], T280: CanLt[float, CanBool], T281: CanLt[float, CanBool], T282: CanLt[float, CanBool], T283: CanLt[float, CanBool], T284: CanLt[float, CanBool], T285: CanLt[float, CanBool], T286: CanLt[float, CanBool], T287, T288: CanLt[float, CanBool], T289: CanLt[float, CanBool], T290: CanLt[float, CanBool], T291: CanLt[float, CanBool], T292: CanLt[float, CanBool], T293: CanLt[float, CanBool], T294: CanLt[float, CanBool], T295: CanLt[float, CanBool], T296: CanLt[float, CanBool], T297: CanLt[float, CanBool], T298: CanLt[float, CanBool], T299: CanLt[float, CanBool], T300: CanLt[float, CanBool], T301: CanLt[float, CanBool], T302, T303: CanSub[R258, CanMul[V, CanMul[float, T304]]], T304, T305, T306, T307, T308, T309, T310, T311: CanSub[R254, CanMul[W, CanMul[float, T312]]], T312, T313, T314, T315, T316: CanSub[R252, CanMul[X, CanMul[float, T317]]], T317, T318, T319: CanSub[R250, CanMul[Z | Y, CanMul[float, T321 & T320]]], T320, T321, T322: CanAdd[T325, object], T323, T324: CanSub[T322, CanMul[T7, CanMul[float, T325]]], T325, T326, T327, T328: CanAdd[T331, object], T329, T330: CanSub[T328, CanMul[T9, CanMul[float, T331]]], T331, T332, T333: CanSub[R245, CanMul[T11 | T10, CanMul[float, T335 & T334]]], T334, T335, T336: CanAdd[T339, object], T337, T338: CanSub[T336, CanMul[T12, CanMul[float, T339]]], T339, T340, T341, T342, T343, T344, T345, T346, T347, T348, T349, T350, T351, T352, T353, T354, T355, T356, T357: CanSub[R233, CanMul[T15, CanMul[float, T358]]], T358, T359, T360: CanSub[R231, CanMul[T17 | T16, CanMul[float, T362 & T361]]], T361, T362, T363: CanAdd[T366, object], T364, T365: CanSub[T363, CanMul[T18, CanMul[float, T366]]], T366, T367, T368, T369: CanAdd[T372, object], T370, T371: CanSub[T369, CanMul[T20, CanMul[float, T372]]], T372, T373, T374: CanSub[R226, CanMul[T22 | T21, CanMul[float, T376 & T375]]], T375, T376, T377: CanAdd[T380, object], T378, T379: CanSub[T377, CanMul[T23, CanMul[float, T380]]], T380, T381, T382, T383, T384: CanSub[R225, CanMul[T24, CanMul[float, T385]]], T385, T386, T387: CanSub[R223, CanMul[T26 | T25, CanMul[float, T389 & T388]]], T388, T389, T390: CanAdd[T393, object], T391, T392: CanSub[T390, CanMul[T27, CanMul[float, T393]]], T393, T394, T395, T396: CanAdd[T399, object], T397, T398: CanSub[T396, CanMul[T29, CanMul[float, T399]]], T399, T400, T401: CanSub[R218, CanMul[T31 | T30, CanMul[float, T403 & T402]]], T402, T403, T404: CanAdd[T407, object], T405, T406: CanSub[T404, CanMul[T32, CanMul[float, T407]]], T407, T408, T409: CanSub[R216, CanMul[T34 | T33, CanMul[float, T411 & T410]]], T410, T411, T412: CanAdd[T417 | T416 | T415, R214], T413, T414: CanSub[T412, CanMul[T37 | T36 | T35, CanMul[float, T417 & T416 & T415]]], T415, T416, T417, T418: CanAdd[T422 | T421, object], T419, T420: CanSub[T418, CanMul[T39 | T38, CanMul[float, T422 & T421]]], T421, T422, T423: CanAdd[T426 | T425, R212], T424, T425, T426, T427: CanAdd[T431 | T430, object], T428, T429: CanSub[T427, CanMul[T43 | T42, CanMul[float, T431 & T430]]], T430, T431, T432: CanAdd[T437 | T436 | T435, R211], T433, T434: CanSub[T432, CanMul[T46 | T45 | T44, CanMul[float, T437 & T436 & T435]]], T435, T436, T437, T438: CanAdd[T442 | T441, object], T439, T440: CanSub[T438, CanMul[T48 | T47, CanMul[float, T442 & T441]]], T441, T442, T443: CanAdd[T446, object], T444, T445: CanSub[T443, CanMul[T49, CanMul[float, T446]]], T446, T447, T448, T449: CanAdd[T452 | T451, R206], T450, T451, T452, T453: CanAdd[T456, object], T454, T455: CanSub[T453, CanMul[T53, CanMul[float, T456]]], T456, T457: CanAdd[T459, R204], T458, T459, T460: CanAdd[T463, object], T461, T462: CanSub[T460, CanMul[T55, CanMul[float, T463]]], T463, T464: CanAdd[T467 | T466, R202], T465, T466, T467, T468: CanAdd[T471, object], T469, T470: CanSub[T468, CanMul[T58, CanMul[float, T471]]], T471, T472: CanAdd[T475, object], T473, T474: CanSub[T472, CanMul[T59, CanMul[float, T475]]], T475, T476, T477: CanSub[R201, CanMul[T61 | T60, CanMul[float, T479 & T478]]], T478, T479, T480: CanAdd[T485 | T484 | T483, R199], T481, T482: CanSub[T480, CanMul[T64 | T63 | T62, CanMul[float, T485 & T484 & T483]]], T483, T484, T485, T486: CanAdd[T490 | T489, object], T487, T488: CanSub[T486, CanMul[T66 | T65, CanMul[float, T490 & T489]]], T489, T490, T491: CanAdd[T494 | T493, R197], T492, T493, T494, T495: CanAdd[T499 | T498, object], T496, T497: CanSub[T495, CanMul[T70 | T69, CanMul[float, T499 & T498]]], T498, T499, T500: CanAdd[T505 | T504 | T503, R196], T501, T502: CanSub[T500, CanMul[T73 | T72 | T71, CanMul[float, T505 & T504 & T503]]], T503, T504, T505, T506: CanAdd[T510 | T509, object], T507, T508: CanSub[T506, CanMul[T75 | T74, CanMul[float, T510 & T509]]], T509, T510, T511: CanAdd[T514, object], T512, T513: CanSub[T511, CanMul[T76, CanMul[float, T514]]], T514, T515, T516, T517, T518, T519, T520, T521, T522, T523, T524, T525, T526, T527, T528, T529, T530, T531: CanAdd[T534 | T533, R182], T532, T533, T534, T535: CanAdd[T538, object], T536, T537: CanSub[T535, CanMul[T82, CanMul[float, T538]]], T538, T539: CanAdd[T541, R180], T540, T541, T542: CanAdd[T545, object], T543, T544: CanSub[T542, CanMul[T84, CanMul[float, T545]]], T545, T546: CanAdd[T549 | T548, R178], T547, T548, T549, T550: CanAdd[T553, object], T551, T552: CanSub[T550, CanMul[T87, CanMul[float, T553]]], T553, T554, T555, T556, T557: CanAdd[T559, R174], T558, T559, T560, T561, T562, T563, T564, T565: CanAdd[T567, R171], T566, T567, T568, T569, T570, T571, T572, T573, T574: CanAdd[T577 | T576, R166], T575, T576, T577, T578: CanAdd[T581, object], T579, T580: CanSub[T578, CanMul[T93, CanMul[float, T581]]], T581, T582: CanAdd[T584, R164], T583, T584, T585: CanAdd[T588, object], T586, T587: CanSub[T585, CanMul[T95, CanMul[float, T588]]], T588, T589: CanAdd[T592 | T591, R162], T590, T591, T592, T593: CanAdd[T596, object], T594, T595: CanSub[T593, CanMul[T98, CanMul[float, T596]]], T596, T597, T598, T599, T600, T601, T602: CanSub[R160, CanMul[T99, CanMul[float, T603]]], T603, T604, T605: CanSub[R158, CanMul[T101 | T100, CanMul[float, T607 & T606]]], T606, T607, T608: CanAdd[T611, object], T609, T610: CanSub[T608, CanMul[T102, CanMul[float, T611]]], T611, T612, T613, T614: CanAdd[T617, object], T615, T616: CanSub[T614, CanMul[T104, CanMul[float, T617]]], T617, T618, T619: CanSub[R153, CanMul[T106 | T105, CanMul[float, T621 & T620]]], T620, T621, T622: CanAdd[T625, object], T623, T624: CanSub[T622, CanMul[T107, CanMul[float, T625]]], T625, T626, T627: CanSub[R151, CanMul[T109 | T108, CanMul[float, T629 & T628]]], T628, T629, T630: CanAdd[T635 | T634 | T633, R149], T631, T632: CanSub[T630, CanMul[T112 | T111 | T110, CanMul[float, T635 & T634 & T633]]], T633, T634, T635, T636: CanAdd[T640 | T639, object], T637, T638: CanSub[T636, CanMul[T114 | T113, CanMul[float, T640 & T639]]], T639, T640, T641: CanAdd[T644 | T643, R147], T642, T643, T644, T645: CanAdd[T649 | T648, object], T646, T647: CanSub[T645, CanMul[T118 | T117, CanMul[float, T649 & T648]]], T648, T649, T650: CanAdd[T655 | T654 | T653, R146], T651, T652: CanSub[T650, CanMul[T121 | T120 | T119, CanMul[float, T655 & T654 & T653]]], T653, T654, T655, T656: CanAdd[T660 | T659, object], T657, T658: CanSub[T656, CanMul[T123 | T122, CanMul[float, T660 & T659]]], T659, T660, T661: CanAdd[T664, object], T662, T663: CanSub[T661, CanMul[T124, CanMul[float, T664]]], T664, T665, T666, T667: CanAdd[T670 | T669, R141], T668, T669, T670, T671: CanAdd[T674, object], T672, T673: CanSub[T671, CanMul[T128, CanMul[float, T674]]], T674, T675: CanAdd[T677, R139], T676, T677, T678: CanAdd[T681, object], T679, T680: CanSub[T678, CanMul[T130, CanMul[float, T681]]], T681, T682: CanAdd[T685 | T684, R137], T683, T684, T685, T686: CanAdd[T689, object], T687, T688: CanSub[T686, CanMul[T133, CanMul[float, T689]]], T689, T690: CanAdd[T693, object], T691, T692: CanSub[T690, CanMul[T134, CanMul[float, T693]]], T693, T694, T695: CanSub[R136, CanMul[T136 | T135, CanMul[float, T697 & T696]]], T696, T697, T698: CanAdd[T703 | T702 | T701, R134], T699, T700: CanSub[T698, CanMul[T139 | T138 | T137, CanMul[float, T703 & T702 & T701]]], T701, T702, T703, T704: CanAdd[T708 | T707, object], T705, T706: CanSub[T704, CanMul[T141 | T140, CanMul[float, T708 & T707]]], T707, T708, T709: CanAdd[T712 | T711, R132], T710, T711, T712, T713: CanAdd[T717 | T716, object], T714, T715: CanSub[T713, CanMul[T145 | T144, CanMul[float, T717 & T716]]], T716, T717, T718: CanAdd[T723 | T722 | T721, R131], T719, T720: CanSub[T718, CanMul[T148 | T147 | T146, CanMul[float, T723 & T722 & T721]]], T721, T722, T723, T724: CanAdd[T728 | T727, object], T725, T726: CanSub[T724, CanMul[T150 | T149, CanMul[float, T728 & T727]]], T727, T728, T729: CanAdd[T732, object], T730, T731: CanSub[T729, CanMul[T151, CanMul[float, T732]]], T732, T733, T734, T735, T736: CanSub[R128, CanMul[T152, CanMul[float, T737]]], T737, T738, T739, T740: CanSub[R124, CanMul[T153, CanMul[float, T741]]], T741, T742, T743: CanSub[R122, CanMul[T154, CanMul[float, T744]]], T744, T745: CanSub[R120, CanMul[T156 | T155, CanMul[float, T747 & T746]]], T746, T747, T748: CanAdd[T750, object], T749: CanSub[T748, CanMul[T157, CanMul[float, T750]]], T750, T751, T752: CanAdd[T754, object], T753: CanSub[T752, CanMul[T159, CanMul[float, T754]]], T754, T755: CanSub[R115, CanMul[T161 | T160, CanMul[float, T757 & T756]]], T756, T757, T758: CanAdd[T760, object], T759: CanSub[T758, CanMul[T162, CanMul[float, T760]]], T760, T761, T762, T763, T764, T765, T766, T767, T768: CanSub[R103, CanMul[T165, CanMul[float, T769]]], T769, T770: CanSub[R101, CanMul[T167 | T166, CanMul[float, T772 & T771]]], T771, T772, T773: CanAdd[T775, object], T774: CanSub[T773, CanMul[T168, CanMul[float, T775]]], T775, T776, T777: CanAdd[T779, object], T778: CanSub[T777, CanMul[T170, CanMul[float, T779]]], T779, T780: CanSub[R96, CanMul[T172 | T171, CanMul[float, T782 & T781]]], T781, T782, T783: CanAdd[T785, object], T784: CanSub[T783, CanMul[T173, CanMul[float, T785]]], T785, T786, T787: CanSub[R95, CanMul[T174, CanMul[float, T788]]], T788, T789: CanSub[R93, CanMul[T176 | T175, CanMul[float, T791 & T790]]], T790, T791, T792: CanAdd[T794, object], T793: CanSub[T792, CanMul[T177, CanMul[float, T794]]], T794, T795, T796: CanAdd[T798, object], T797: CanSub[T796, CanMul[T179, CanMul[float, T798]]], T798, T799: CanSub[R88, CanMul[T181 | T180, CanMul[float, T801 & T800]]], T800, T801, T802: CanAdd[T804, object], T803: CanSub[T802, CanMul[T182, CanMul[float, T804]]], T804, T805: CanSub[R86, CanMul[T184 | T183, CanMul[float, T807 & T806]]], T806, T807, T808: CanAdd[T812 | T811 | T810, R84], T809: CanSub[T808, CanMul[T187 | T186 | T185, CanMul[float, T812 & T811 & T810]]], T810, T811, T812, T813: CanAdd[T816 | T815, object], T814: CanSub[T813, CanMul[T189 | T188, CanMul[float, T816 & T815]]], T815, T816, T817: CanAdd[T819 | T818, R82], T818, T819, T820: CanAdd[T823 | T822, object], T821: CanSub[T820, CanMul[T193 | T192, CanMul[float, T823 & T822]]], T822, T823, T824: CanAdd[T828 | T827 | T826, R81], T825: CanSub[T824, CanMul[T196 | T195 | T194, CanMul[float, T828 & T827 & T826]]], T826, T827, T828, T829: CanAdd[T832 | T831, object], T830: CanSub[T829, CanMul[T198 | T197, CanMul[float, T832 & T831]]], T831, T832, T833: CanAdd[T835, object], T834: CanSub[T833, CanMul[T199, CanMul[float, T835]]], T835, T836, T837: CanAdd[T839 | T838, R76], T838, T839, T840: CanAdd[T842, object], T841: CanSub[T840, CanMul[T203, CanMul[float, T842]]], T842, T843: CanAdd[T844, R74], T844, T845: CanAdd[T847, object], T846: CanSub[T845, CanMul[T205, CanMul[float, T847]]], T847, T848: CanAdd[T850 | T849, R72], T849, T850, T851: CanAdd[T853, object], T852: CanSub[T851, CanMul[T208, CanMul[float, T853]]], T853, T854: CanAdd[T856, object], T855: CanSub[T854, CanMul[T209, CanMul[float, T856]]], T856, T857: CanSub[R71, CanMul[T211 | T210, CanMul[float, T859 & T858]]], T858, T859, T860: CanAdd[T864 | T863 | T862, R69], T861: CanSub[T860, CanMul[T214 | T213 | T212, CanMul[float, T864 & T863 & T862]]], T862, T863, T864, T865: CanAdd[T868 | T867, object], T866: CanSub[T865, CanMul[T216 | T215, CanMul[float, T868 & T867]]], T867, T868, T869: CanAdd[T871 | T870, R67], T870, T871, T872: CanAdd[T875 | T874, object], T873: CanSub[T872, CanMul[T220 | T219, CanMul[float, T875 & T874]]], T874, T875, T876: CanAdd[T880 | T879 | T878, R66], T877: CanSub[T876, CanMul[T223 | T222 | T221, CanMul[float, T880 & T879 & T878]]], T878, T879, T880, T881: CanAdd[T884 | T883, object], T882: CanSub[T881, CanMul[T225 | T224, CanMul[float, T884 & T883]]], T883, T884, T885: CanAdd[T887, object], T886: CanSub[T885, CanMul[T226, CanMul[float, T887]]], T887, T888, T889, T890, T891, T892, T893, T894, T895: CanAdd[T897 | T896, R52], T896, T897, T898: CanAdd[T900, object], T899: CanSub[T898, CanMul[T232, CanMul[float, T900]]], T900, T901: CanAdd[T902, R50], T902, T903: CanAdd[T905, object], T904: CanSub[T903, CanMul[T234, CanMul[float, T905]]], T905, T906: CanAdd[T908 | T907, R48], T907, T908, T909: CanAdd[T911, object], T910: CanSub[T909, CanMul[T237, CanMul[float, T911]]], T911, T912, T913: CanAdd[T914, R44], T914, T915, T916, T917: CanAdd[T918, R41], T918, T919, T920, T921, T922: CanAdd[T924 | T923, R36], T923, T924, T925: CanAdd[T927, object], T926: CanSub[T925, CanMul[T243, CanMul[float, T927]]], T927, T928: CanAdd[T929, R34], T929, T930: CanAdd[T932, object], T931: CanSub[T930, CanMul[T245, CanMul[float, T932]]], T932, T933: CanAdd[T935 | T934, R32], T934, T935, T936: CanAdd[T938, object], T937: CanSub[T936, CanMul[T248, CanMul[float, T938]]], T938, T939, T940, T941: CanSub[R30, CanMul[T249, CanMul[float, T942]]], T942, T943: CanSub[R28, CanMul[T251 | T250, CanMul[float, T945 & T944]]], T944, T945, T946: CanAdd[T948, object], T947: CanSub[T946, CanMul[T252, CanMul[float, T948]]], T948, T949, T950: CanAdd[T952, object], T951: CanSub[T950, CanMul[T254, CanMul[float, T952]]], T952, T953: CanSub[R23, CanMul[T256 | T255, CanMul[float, T955 & T954]]], T954, T955, T956: CanAdd[T958, object], T957: CanSub[T956, CanMul[T257, CanMul[float, T958]]], T958, T959: CanSub[R21, CanMul[T259 | T258, CanMul[float, T961 & T960]]], T960, T961, T962: CanAdd[T966 | T965 | T964, R19], T963: CanSub[T962, CanMul[T262 | T261 | T260, CanMul[float, T966 & T965 & T964]]], T964, T965, T966, T967: CanAdd[T970 | T969, object], T968: CanSub[T967, CanMul[T264 | T263, CanMul[float, T970 & T969]]], T969, T970, T971: CanAdd[T973 | T972, R17], T972, T973, T974: CanAdd[T977 | T976, object], T975: CanSub[T974, CanMul[T268 | T267, CanMul[float, T977 & T976]]], T976, T977, T978: CanAdd[T982 | T981 | T980, R16], T979: CanSub[T978, CanMul[T271 | T270 | T269, CanMul[float, T982 & T981 & T980]]], T980, T981, T982, T983: CanAdd[T986 | T985, object], T984: CanSub[T983, CanMul[T273 | T272, CanMul[float, T986 & T985]]], T985, T986, T987: CanAdd[T989, object], T988: CanSub[T987, CanMul[T274, CanMul[float, T989]]], T989, T990, T991: CanAdd[T993 | T992, R11], T992, T993, T994: CanAdd[T996, object], T995: CanSub[T994, CanMul[T278, CanMul[float, T996]]], T996, T997: CanAdd[T998, R9], T998, T999: CanAdd[T1001, object], T1000: CanSub[T999, CanMul[T280, CanMul[float, T1001]]], T1001, T1002: CanAdd[T1004 | T1003, R7], T1003, T1004, T1005: CanAdd[T1007, object], T1006: CanSub[T1005, CanMul[T283, CanMul[float, T1007]]], T1007, T1008: CanAdd[T1010, object], T1009: CanSub[T1008, CanMul[T284, CanMul[float, T1010]]], T1010, T1011: CanSub[R6, CanMul[T286 | T285, CanMul[float, T1013 & T1012]]], T1012, T1013, T1014: CanAdd[T1018 | T1017 | T1016, R4], T1015: CanSub[T1014, CanMul[T289 | T288 | T287, CanMul[float, T1018 & T1017 & T1016]]], T1016, T1017, T1018, T1019: CanAdd[T1022 | T1021, object], T1020: CanSub[T1019, CanMul[T291 | T290, CanMul[float, T1022 & T1021]]], T1021, T1022, T1023: CanAdd[T1025 | T1024, R2], T1024, T1025, T1026: CanAdd[T1029 | T1028, object], T1027: CanSub[T1026, CanMul[T295 | T294, CanMul[float, T1029 & T1028]]], T1028, T1029, T1030: CanAdd[T1034 | T1033 | T1032, R], T1031: CanSub[T1030, CanMul[T298 | T297 | T296, CanMul[float, T1034 & T1033 & T1032]]], T1032, T1033, T1034, T1035: CanAdd[T1038 | T1037, object], T1036: CanSub[T1035, CanMul[T300 | T299, CanMul[float, T1038 & T1037]]], T1037, T1038, T1039: CanAdd[T1041, object], T1040: CanSub[T1039, CanMul[T301, CanMul[float, T1041]]], T1041, T1042, T1043, T1044, T1045, T1046, T1047, T1048, T1049, T1050, T1051, T1052, T1053, T1054, T1055, T1056, T1057, T1058, T1059, T1060, T1061, T1062, T1063, T1064, T1065, T1066, T1067, T1068, T1069, T1070, T1071, T1072, T1073, T1074, T1075, T1076, T1077, T1078, T1079, T1080, T1081, T1082, T1083, T1084, T1085, T1086, T1087, T1088, T1089, T1090, T1091, T1092, T1093, T1094, T1095, T1096, T1097, T1098, T1099, T1100, T1101, T1102, T1103, T1104, T1105, T1106, T1107, T1108, T1109, T1110, T1111, T1112, T1113, T1114, T1115, T1116, T1117, T1118, T1119, T1120, T1121, T1122, T1123, T1124, T1125, T1126, T1127, T1128, T1129, T1130, T1131, T1132, T1133, T1134, T1135, T1136, T1137, T1138, T1139, T1140, T1141, T1142, T1143, T1144, T1145, T1146, T1147, T1148, T1149, T1150, T1151, T1152, T1153, T1154, T1155, T1156, T1157, T1158, T1159, T1160, T1161, T1162, T1163, T1164, T1165, T1166, T1167, T1168, T1169, R, R2, R3: CanSub[T1023, CanMul[T293 | T292, CanMul[float, T1025 & T1024]]], R4, R5, R6: CanAdd[T1013 | T1012, R5], R7, R8: CanSub[T1002, CanMul[T282 | T281, CanMul[float, T1004 & T1003]]], R9, R10: CanSub[T997, CanMul[T279, CanMul[float, T998]]], R11, R12: CanSub[T991, CanMul[T277 | T276, CanMul[float, T993 & T992]]], R13, R14: CanSub[R15, CanMul[T275, CanMul[float, T990]]], R15: CanAdd[T990, R13], R16, R17, R18: CanSub[T971, CanMul[T266 | T265, CanMul[float, T973 & T972]]], R19, R20, R21: CanAdd[T961 | T960, R20], R22, R23: CanAdd[T955 | T954, R22], R24, R25: CanAdd[T949, R24], R26: CanSub[R25, CanMul[T253, CanMul[float, T949]]], R27, R28: CanAdd[T945 | T944, R27], R29, R30: CanAdd[T942, R29], R31: CanSub[T933, CanMul[T247 | T246, CanMul[float, T935 & T934]]], R32, R33: CanSub[T928, CanMul[T244, CanMul[float, T929]]], R34, R35: CanSub[T922, CanMul[T242 | T241, CanMul[float, T924 & T923]]], R36, R37: CanSub[R39, CanMul[T240, CanMul[float, T921]]], R38, R39: CanAdd[T921, R38], R40: CanSub[T917, CanMul[T239, CanMul[float, T918]]], R41, R42, R43: CanSub[T913, CanMul[T238, CanMul[float, T914]]], R44, R45, R46, R47: CanSub[T906, CanMul[T236 | T235, CanMul[float, T908 & T907]]], R48, R49: CanSub[T901, CanMul[T233, CanMul[float, T902]]], R50, R51: CanSub[T895, CanMul[T231 | T230, CanMul[float, T897 & T896]]], R52, R53: CanSub[R55, CanMul[T229, CanMul[float, T894]]], R54, R55: CanAdd[T894, R54], R56: CanSub[R57, CanMul[T228, CanMul[float, T892]]], R57: CanAdd[T892, R58], R58, R59, R60, R61: CanSub[R62, CanMul[T227, CanMul[float, T889]]], R62: CanAdd[T889, R63], R63, R64, R65, R66, R67, R68: CanSub[T869, CanMul[T218 | T217, CanMul[float, T871 & T870]]], R69, R70, R71: CanAdd[T859 | T858, R70], R72, R73: CanSub[T848, CanMul[T207 | T206, CanMul[float, T850 & T849]]], R74, R75: CanSub[T843, CanMul[T204, CanMul[float, T844]]], R76, R77: CanSub[T837, CanMul[T202 | T201, CanMul[float, T839 & T838]]], R78, R79: CanSub[R80, CanMul[T200, CanMul[float, T836]]], R80: CanAdd[T836, R78], R81, R82, R83: CanSub[T817, CanMul[T191 | T190, CanMul[float, T819 & T818]]], R84, R85, R86: CanAdd[T807 | T806, R85], R87, R88: CanAdd[T801 | T800, R87], R89, R90: CanAdd[T795, R89], R91: CanSub[R90, CanMul[T178, CanMul[float, T795]]], R92, R93: CanAdd[T791 | T790, R92], R94, R95: CanAdd[T788, R94], R96: CanAdd[T782 | T781, R97], R97, R98: CanAdd[T776, R99], R99, R100: CanSub[R98, CanMul[T169, CanMul[float, T776]]], R101: CanAdd[T772 | T771, R102], R102, R103: CanAdd[T769, R104], R104, R105: CanAdd[T765, R107], R106: CanSub[R105, CanMul[T164, CanMul[float, T765]]], R107, R108, R109, R110: CanAdd[T762, R112], R111: CanSub[R110, CanMul[T163, CanMul[float, T762]]], R112, R113, R114, R115: CanAdd[T757 | T756, R116], R116, R117: CanAdd[T751, R118], R118, R119: CanSub[R117, CanMul[T158, CanMul[float, T751]]], R120: CanAdd[T747 | T746, R121], R121, R122: CanAdd[T744, R123], R123, R124: CanAdd[T741, R125], R125, R126, R127, R128: CanAdd[T737, R129], R129, R130, R131, R132, R133: CanSub[T709, CanMul[T143 | T142, CanMul[float, T712 & T711]]], R134, R135, R136: CanAdd[T697 | T696, R135], R137, R138: CanSub[T682, CanMul[T132 | T131, CanMul[float, T685 & T684]]], R139, R140: CanSub[T675, CanMul[T129, CanMul[float, T677]]], R141, R142: CanSub[T667, CanMul[T127 | T126, CanMul[float, T670 & T669]]], R143, R144: CanSub[R145, CanMul[T125, CanMul[float, T666]]], R145: CanAdd[T666, R143], R146, R147, R148: CanSub[T641, CanMul[T116 | T115, CanMul[float, T644 & T643]]], R149, R150, R151: CanAdd[T629 | T628, R150], R152, R153: CanAdd[T621 | T620, R152], R154, R155: CanAdd[T613, R154], R156: CanSub[R155, CanMul[T103, CanMul[float, T613]]], R157, R158: CanAdd[T607 | T606, R157], R159, R160: CanAdd[T603, R159], R161: CanSub[T589, CanMul[T97 | T96, CanMul[float, T592 & T591]]], R162, R163: CanSub[T582, CanMul[T94, CanMul[float, T584]]], R164, R165: CanSub[T574, CanMul[T92 | T91, CanMul[float, T577 & T576]]], R166, R167: CanSub[R169, CanMul[T90, CanMul[float, T573]]], R168, R169: CanAdd[T573, R168], R170: CanSub[T565, CanMul[T89, CanMul[float, T567]]], R171, R172, R173: CanSub[T557, CanMul[T88, CanMul[float, T559]]], R174, R175, R176, R177: CanSub[T546, CanMul[T86 | T85, CanMul[float, T549 & T548]]], R178, R179: CanSub[T539, CanMul[T83, CanMul[float, T541]]], R180, R181: CanSub[T531, CanMul[T81 | T80, CanMul[float, T534 & T533]]], R182, R183: CanSub[R185, CanMul[T79, CanMul[float, T530]]], R184, R185: CanAdd[T530, R184], R186: CanSub[R187, CanMul[T78, CanMul[float, T526]]], R187: CanAdd[T526, R188], R188, R189, R190, R191: CanSub[R192, CanMul[T77, CanMul[float, T519]]], R192: CanAdd[T519, R193], R193, R194, R195, R196, R197, R198: CanSub[T491, CanMul[T68 | T67, CanMul[float, T494 & T493]]], R199, R200, R201: CanAdd[T479 | T478, R200], R202, R203: CanSub[T464, CanMul[T57 | T56, CanMul[float, T467 & T466]]], R204, R205: CanSub[T457, CanMul[T54, CanMul[float, T459]]], R206, R207: CanSub[T449, CanMul[T52 | T51, CanMul[float, T452 & T451]]], R208, R209: CanSub[R210, CanMul[T50, CanMul[float, T448]]], R210: CanAdd[T448, R208], R211, R212, R213: CanSub[T423, CanMul[T41 | T40, CanMul[float, T426 & T425]]], R214, R215, R216: CanAdd[T411 | T410, R215], R217, R218: CanAdd[T403 | T402, R217], R219, R220: CanAdd[T395, R219], R221: CanSub[R220, CanMul[T28, CanMul[float, T395]]], R222, R223: CanAdd[T389 | T388, R222], R224, R225: CanAdd[T385, R224], R226: CanAdd[T376 | T375, R227], R227, R228: CanAdd[T368, R229], R229, R230: CanSub[R228, CanMul[T19, CanMul[float, T368]]], R231: CanAdd[T362 | T361, R232], R232, R233: CanAdd[T358, R234], R234, R235: CanAdd[T351, R237], R236: CanSub[R235, CanMul[T14, CanMul[float, T351]]], R237, R238, R239, R240: CanAdd[T344, R242], R241: CanSub[R240, CanMul[T13, CanMul[float, T344]]], R242, R243, R244, R245: CanAdd[T335 | T334, R246], R246, R247: CanAdd[T327, R248], R248, R249: CanSub[R247, CanMul[T8, CanMul[float, T327]]], R250: CanAdd[T321 | T320, R251], R251, R252: CanAdd[T317, R253], R253, R254: CanAdd[T312, R255], R255, R256, R257, R258: CanAdd[T304, R259], R259](h: CanAdd[float, CanMod[float, T301 & T300 & T298 & T295 & T293 & T291 & T289 & T286 & T284 & T283 & T282 & T280 & T279 & T278 & T277 & T275 & T274 & T273 & T271 & T268 & T266 & T264 & T262 & T259 & T257 & T256 & T254 & T253 & T252 & T251 & T249 & T151 & T150 & T148 & T145 & T143 & T141 & T139 & T136 & T134 & T133 & T132 & T130 & T129 & T128 & T127 & T125 & T124 & T123 & T121 & T118 & T116 & T114 & T112 & T109 & T107 & T106 & T104 & T103 & T102 & T101 & T99 & CanLt[float, CanBool] & CanRSub[float, T226 & T225 & T223 & T220 & T218 & T216 & T214 & T211 & T209 & T208 & T207 & T205 & T204 & T203 & T202 & T200 & T199 & T198 & T196 & T193 & T191 & T189 & T187 & T184 & T182 & T181 & T179 & T178 & T177 & T176 & T174 & T76 & T75 & T73 & T70 & T68 & T66 & T64 & T61 & T59 & T58 & T57 & T55 & T54 & T53 & T52 & T50 & T49 & T48 & T46 & T43 & T41 & T39 & T37 & T34 & T32 & T31 & T29 & T28 & T27 & T26 & T24]]] & CanMod[float, T299 & T297 & T294 & T292 & T290 & T288 & T285 & T248 & T247 & T245 & T244 & T243 & T242 & T240 & T224 & T222 & T219 & T217 & T215 & T213 & T210 & T173 & T172 & T170 & T169 & T168 & T167 & T165 & T149 & T147 & T144 & T142 & T140 & T138 & T135 & T98 & T97 & T95 & T94 & T93 & T92 & T90 & T74 & T72 & T69 & T67 & T65 & T63 & T60 & T23 & T22 & T20 & T19 & T18 & T17 & T15 & CanLt[float, CanBool] & CanRSub[float, T272 & T270 & T267 & T265 & T263 & T261 & T258 & T237 & T236 & T234 & T233 & T232 & T231 & T229 & T197 & T195 & T192 & T190 & T188 & T186 & T183 & T162 & T161 & T159 & T158 & T157 & T156 & T154 & T122 & T120 & T117 & T115 & T113 & T111 & T108 & T87 & T86 & T84 & T83 & T82 & T81 & T79 & T47 & T45 & T42 & T40 & T38 & T36 & T33 & T12 & T11 & T9 & T8 & T7 & Z & X]] & CanSub[float, CanMod[float, T296 & T281 & T269 & T255 & T246 & T239 & T235 & T228 & T221 & T206 & T194 & T180 & T171 & T164 & T160 & T153 & T146 & T131 & T119 & T105 & T96 & T89 & T85 & T78 & T71 & T56 & T44 & T30 & T21 & T14 & T10 & W & CanLt[float, CanBool] & CanRSub[float, T287 & T276 & T260 & T250 & T241 & T238 & T230 & T227 & T212 & T201 & T185 & T175 & T166 & T163 & T155 & T152 & T137 & T126 & T110 & T100 & T91 & T88 & T80 & T77 & T62 & T51 & T35 & T25 & T16 & T13 & Y & V]]], l: T, s: U) -> tuple[T, T, T] | tuple[R, R, R] | tuple[R2, R2, R3] | tuple[R4, R4, R4] | tuple[R5, R5, R6] | tuple[R7, R8, R7] | tuple[R9, R10, R10] | tuple[R11, R12, R11] | tuple[R13, R14, R15] | tuple[R16, R16, R16] | tuple[R17, R17, R18] | tuple[R19, R19, R19] | tuple[R20, R20, R21] | tuple[R22, R23, R22] | tuple[R24, R25, R26] | tuple[R27, R28, R27] | tuple[R29, R30, R30] | tuple[R31, R32, R32] | tuple[R33, R34, R33] | tuple[R35, R36, R36] | tuple[R37, R38, R39] | tuple[R40, R40, R41] | tuple[R42, R42, R42] | tuple[R43, R43, R44] | tuple[R45, R45, R46] | tuple[R47, R48, R48] | tuple[R49, R50, R49] | tuple[R51, R52, R52] | tuple[R53, R54, R55] | tuple[R56, R57, R58] | tuple[R59, R60, R59] | tuple[R61, R62, R63] | tuple[R64, R65, R65] | tuple[R66, R66, R66] | tuple[R67, R67, R68] | tuple[R69, R69, R69] | tuple[R70, R70, R71] | tuple[R72, R73, R72] | tuple[R74, R75, R75] | tuple[R76, R77, R76] | tuple[R78, R79, R80] | tuple[R81, R81, R81] | tuple[R82, R82, R83] | tuple[R84, R84, R84] | tuple[R85, R85, R86] | tuple[R87, R88, R87] | tuple[R89, R90, R91] | tuple[R92, R93, R92] | tuple[R94, R95, R95] | tuple[R96, R97, R97] | tuple[R98, R99, R100] | tuple[R101, R102, R102] | tuple[R103, R104, R103] | tuple[R105, R106, R107] | tuple[R108, R109, R109] | tuple[R110, R111, R112] | tuple[R113, R114, R113] | tuple[R115, R116, R116] | tuple[R117, R118, R119] | tuple[R120, R121, R121] | tuple[R122, R123, R122] | tuple[R124, R124, R125] | tuple[R126, R126, R127] | tuple[R128, R128, R129] | tuple[R130, R130, R130] | tuple[R131, R131, R131] | tuple[R132, R132, R133] | tuple[R134, R134, R134] | tuple[R135, R135, R136] | tuple[R137, R138, R137] | tuple[R139, R140, R140] | tuple[R141, R142, R141] | tuple[R143, R144, R145] | tuple[R146, R146, R146] | tuple[R147, R147, R148] | tuple[R149, R149, R149] | tuple[R150, R150, R151] | tuple[R152, R153, R152] | tuple[R154, R155, R156] | tuple[R157, R158, R157] | tuple[R159, R160, R160] | tuple[R161, R162, R162] | tuple[R163, R164, R163] | tuple[R165, R166, R166] | tuple[R167, R168, R169] | tuple[R170, R170, R171] | tuple[R172, R172, R172] | tuple[R173, R173, R174] | tuple[R175, R175, R176] | tuple[R177, R178, R178] | tuple[R179, R180, R179] | tuple[R181, R182, R182] | tuple[R183, R184, R185] | tuple[R186, R187, R188] | tuple[R189, R190, R189] | tuple[R191, R192, R193] | tuple[R194, R195, R195] | tuple[R196, R196, R196] | tuple[R197, R197, R198] | tuple[R199, R199, R199] | tuple[R200, R200, R201] | tuple[R202, R203, R202] | tuple[R204, R205, R205] | tuple[R206, R207, R206] | tuple[R208, R209, R210] | tuple[R211, R211, R211] | tuple[R212, R212, R213] | tuple[R214, R214, R214] | tuple[R215, R215, R216] | tuple[R217, R218, R217] | tuple[R219, R220, R221] | tuple[R222, R223, R222] | tuple[R224, R225, R225] | tuple[R226, R227, R227] | tuple[R228, R229, R230] | tuple[R231, R232, R232] | tuple[R233, R234, R233] | tuple[R235, R236, R237] | tuple[R238, R239, R239] | tuple[R240, R241, R242] | tuple[R243, R244, R243] | tuple[R245, R246, R246] | tuple[R247, R248, R249] | tuple[R250, R251, R251] | tuple[R252, R253, R252] | tuple[R254, R254, R255] | tuple[R256, R256, R257] | tuple[R258, R258, R259]
[T: CanLe[float, CanBool] & CanRMul[float, T253 & T252 & T251 & T250 & T249 & T248 & T247 & T246 & T245 & T244 & T243 & T242 & T241 & T240 & T239 & T238 & T237 & T236 & T235 & T234 & T233 & T232 & T231 & T230 & T229 & T228 & T227 & T226 & T225 & T224 & T223 & T222 & T221 & T220 & T219 & T218 & T217 & T216 & T215 & T214 & T213 & T212 & T211 & T210 & T209 & T208 & T207 & T206 & T205 & T204 & T203 & T202 & T201 & T200 & T199 & T198 & T197 & T196 & T195 & T194 & T193 & T192 & T191 & T190 & T189 & T188 & T187 & T186 & T185 & T184 & T183 & T182 & T181 & T180 & T179 & T178 & T177 & T176 & T175 & T174 & T173 & T172 & T171 & T170 & T169 & T168 & T167 & T166 & T165 & T164 & T163 & T162 & T161 & T160 & T159 & T158 & T157 & T156 & T155 & T154 & T153 & T152 & T151 & T150 & T149 & T148 & T147 & T146 & T145 & T144 & T143 & T142 & T141 & T140 & T139 & T138 & T137 & T136 & T135 & T134 & T133 & T132 & T131 & T130 & T129 & T128 & T127 & T126 & T125 & T124 & T123 & T122 & T121 & T120 & T119 & T118 & T117 & T116 & T115 & T114 & T113 & T112 & T111 & T110 & T109 & T108 & T107 & T106 & T105 & T104 & T103 & T102 & T101 & T100 & T99 & T98 & T97 & T96 & T95 & T94 & T93 & T92 & T91 & T90 & T89 & T88 & T87 & T86 & T85 & T84 & T83 & T82 & T81 & T80 & T79 & T78 & T77 & T76 & T75 & T74 & T73 & T72 & T71 & T70 & T69 & T68 & T67 & T66 & T65 & T64 & T63 & T62 & T61 & T60 & T59 & T58 & T57 & T56 & T55 & T54 & T53 & T52 & T51 & T50 & T49 & T48 & T47 & T46 & T45 & T44 & T43 & T42 & T41 & T40 & T39 & T38 & T37 & T36 & T35 & T34 & T33 & T32 & T31 & T30 & T29 & T28 & T27 & T26 & T25 & T24 & T23 & T22 & T21 & T20 & T19 & T18 & T17 & T16 & T15 & T14 & T13 & T12 & T11 & T10 & T9 & T8 & T7 & Z & Y & X & W & V & U], U, V, W, X, Y, Z, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31, T32, T33, T34, T35, T36, T37, T38, T39, T40, T41, T42, T43, T44, T45, T46, T47, T48, T49, T50, T51, T52, T53, T54, T55, T56, T57, T58, T59, T60, T61, T62, T63, T64, T65, T66, T67, T68, T69, T70, T71, T72, T73, T74, T75, T76, T77, T78, T79, T80, T81, T82, T83, T84, T85, T86, T87, T88, T89, T90, T91, T92, T93, T94, T95, T96, T97, T98, T99, T100, T101, T102, T103, T104, T105, T106, T107, T108, T109, T110, T111, T112, T113, T114, T115, T116, T117, T118, T119, T120, T121, T122, T123, T124, T125, T126, T127, T128, T129, T130, T131, T132, T133, T134, T135, T136, T137, T138, T139, T140, T141, T142, T143, T144, T145, T146, T147, T148, T149, T150, T151, T152, T153, T154, T155, T156, T157, T158, T159, T160, T161, T162, T163, T164, T165, T166, T167, T168, T169, T170, T171, T172, T173, T174, T175, T176, T177, T178, T179, T180, T181, T182, T183, T184, T185, T186, T187, T188, T189, T190, T191, T192, T193, T194, T195, T196, T197, T198, T199, T200, T201, T202, T203, T204, T205, T206, T207, T208, T209, T210, T211, T212, T213, T214, T215, T216, T217, T218, T219, T220, T221, T222, T223, T224, T225, T226, T227, T228, T229, T230, T231, T232, T233, T234, T235, T236, T237, T238, T239, T240, T241, T242, T243, T244, T245, T246, T247, T248, T249, T250, T251, T252, T253, T254: CanRSub[U, R338], T255, T256, T257, T258, T259, T260: CanRSub[Y, R334], T261, T262, T263, T264: CanRSub[T7, R332], T265, T266, T267: CanRSub[T8, R329], T268, T269, T270, T271: CanRSub[T9, T272], T272: CanRSub[T271, T273], T273, T274, T275, T276, T277: CanRSub[T11, T278], T278: CanRSub[T277, T279], T279, T280, T281: CanRSub[T12, R323], T282, T283, T284, T285: CanRSub[T13, T286], T286: CanRSub[T285, T287], T287, T288, T289, T290, T291, T292, T293, T294, T295, T296, T297, T298, T299, T300: CanRSub[T23, R311], T301, T302, T303: CanRSub[T24, R308], T304, T305, T306, T307: CanRSub[T25, T308], T308: CanRSub[T307, T309], T309, T310, T311, T312, T313: CanRSub[T27, T314], T314: CanRSub[T313, T315], T315, T316, T317: CanRSub[T28, R302], T318, T319, T320, T321: CanRSub[T29, T322], T322: CanRSub[T321, T323], T323, T324, T325, T326: CanRSub[T31, R301], T327, T328, T329: CanRSub[T32, R298], T330, T331, T332, T333: CanRSub[T33, T334], T334: CanRSub[T333, T335], T335, T336, T337, T338, T339: CanRSub[T35, T340], T340: CanRSub[T339, T341], T341, T342, T343: CanRSub[T36, R292], T344, T345, T346, T347: CanRSub[T37, T348], T348: CanRSub[T347, T349], T349, T350, T351: CanRSub[T38, R290], T352, T353, T354, T355: CanRSub[T39, T356], T356: CanRSub[T355, T359 & T358 & T357], T357, T358, T359, T360, T361: CanRSub[T40, T362], T362: CanRSub[T361, T364 & T363], T363, T364, T365, T366: CanRSub[R284, T368 & T367], T367, T368, T369, T370: CanRSub[T42, T371], T371: CanRSub[T370, T373 & T372], T372, T373, T374, T375: CanRSub[T43, T376], T376: CanRSub[T375, T379 & T378 & T377], T377, T378, T379, T380, T381: CanRSub[T44, T382], T382: CanRSub[T381, T384 & T383], T383, T384, T385, T386: CanRSub[T45, T387], T387: CanRSub[T386, T388], T388, T389, T390, T391, T392: CanRSub[R274, T394 & T393], T393, T394, T395, T396: CanRSub[T48, T397], T397: CanRSub[T396, T398], T398, T399, T400: CanRSub[R272, T401], T401, T402, T403: CanRSub[T50, T404], T404: CanRSub[T403, T405], T405, T406, T407: CanRSub[R269, T409 & T408], T408, T409, T410, T411: CanRSub[T52, T412], T412: CanRSub[T411, T413], T413, T414, T415: CanRSub[T53, T416], T416: CanRSub[T415, T417], T417, T418, T419: CanRSub[T54, R267], T420, T421, T422, T423: CanRSub[T55, T424], T424: CanRSub[T423, T427 & T426 & T425], T425, T426, T427, T428, T429: CanRSub[T56, T430], T430: CanRSub[T429, T432 & T431], T431, T432, T433, T434: CanRSub[R261, T436 & T435], T435, T436, T437, T438: CanRSub[T58, T439], T439: CanRSub[T438, T441 & T440], T440, T441, T442, T443: CanRSub[T59, T444], T444: CanRSub[T443, T447 & T446 & T445], T445, T446, T447, T448, T449: CanRSub[T60, T450], T450: CanRSub[T449, T452 & T451], T451, T452, T453, T454: CanRSub[T61, T455], T455: CanRSub[T454, T456], T456, T457, T458, T459, T460, T461, T462, T463, T464, T465, T466, T467, T468, T469, T470: CanRSub[R240, T472 & T471], T471, T472, T473, T474: CanRSub[T72, T475], T475: CanRSub[T474, T476], T476, T477, T478: CanRSub[R238, T479], T479, T480, T481: CanRSub[T74, T482], T482: CanRSub[T481, T483], T483, T484, T485: CanRSub[R235, T487 & T486], T486, T487, T488, T489: CanRSub[T76, T490], T490: CanRSub[T489, T491], T491, T492, T493, T494, T495: CanRSub[R231, T496], T496, T497, T498, T499, T500, T501: CanRSub[R228, T502], T502, T503, T504, T505, T506, T507, T508: CanRSub[R222, T510 & T509], T509, T510, T511, T512: CanRSub[T88, T513], T513: CanRSub[T512, T514], T514, T515, T516: CanRSub[R220, T517], T517, T518, T519: CanRSub[T90, T520], T520: CanRSub[T519, T521], T521, T522, T523: CanRSub[R217, T525 & T524], T524, T525, T526, T527: CanRSub[T92, T528], T528: CanRSub[T527, T529], T529, T530, T531, T532, T533: CanRSub[T95, R216], T534, T535, T536: CanRSub[T96, R213], T537, T538, T539, T540: CanRSub[T97, T541], T541: CanRSub[T540, T542], T542, T543, T544, T545, T546: CanRSub[T99, T547], T547: CanRSub[T546, T548], T548, T549, T550: CanRSub[T100, R207], T551, T552, T553, T554: CanRSub[T101, T555], T555: CanRSub[T554, T556], T556, T557, T558: CanRSub[T102, R205], T559, T560, T561, T562: CanRSub[T103, T563], T563: CanRSub[T562, T566 & T565 & T564], T564, T565, T566, T567, T568: CanRSub[T104, T569], T569: CanRSub[T568, T571 & T570], T570, T571, T572, T573: CanRSub[R199, T575 & T574], T574, T575, T576, T577: CanRSub[T106, T578], T578: CanRSub[T577, T580 & T579], T579, T580, T581, T582: CanRSub[T107, T583], T583: CanRSub[T582, T586 & T585 & T584], T584, T585, T586, T587, T588: CanRSub[T108, T589], T589: CanRSub[T588, T591 & T590], T590, T591, T592, T593: CanRSub[T109, T594], T594: CanRSub[T593, T595], T595, T596, T597, T598, T599: CanRSub[R189, T601 & T600], T600, T601, T602, T603: CanRSub[T112, T604], T604: CanRSub[T603, T605], T605, T606, T607: CanRSub[R187, T608], T608, T609, T610: CanRSub[T114, T611], T611: CanRSub[T610, T612], T612, T613, T614: CanRSub[R184, T616 & T615], T615, T616, T617, T618: CanRSub[T116, T619], T619: CanRSub[T618, T620], T620, T621, T622: CanRSub[T117, T623], T623: CanRSub[T622, T624], T624, T625, T626: CanRSub[T118, R182], T627, T628, T629, T630: CanRSub[T119, T631], T631: CanRSub[T630, T634 & T633 & T632], T632, T633, T634, T635, T636: CanRSub[T120, T637], T637: CanRSub[T636, T639 & T638], T638, T639, T640, T641: CanRSub[R176, T643 & T642], T642, T643, T644, T645: CanRSub[T122, T646], T646: CanRSub[T645, T648 & T647], T647, T648, T649, T650: CanRSub[T123, T651], T651: CanRSub[T650, T654 & T653 & T652], T652, T653, T654, T655, T656: CanRSub[T124, T657], T657: CanRSub[T656, T659 & T658], T658, T659, T660, T661: CanRSub[T125, T662], T662: CanRSub[T661, T663], T663, T664, T665, T666: CanRSub[T128, R168], T667, T668: CanRSub[T132, R164], T669, T670: CanRSub[T134, R162], T671, T672: CanRSub[T135, R159], T673, T674, T675: CanRSub[T136, T676], T676: CanRSub[T675, T677], T677, T678, T679: CanRSub[T138, T680], T680: CanRSub[T679, T681], T681, T682: CanRSub[T139, R153], T683, T684, T685: CanRSub[T140, T686], T686: CanRSub[T685, T687], T687, T688, T689, T690: CanRSub[T150, R141], T691, T692: CanRSub[T151, R138], T693, T694, T695: CanRSub[T152, T696], T696: CanRSub[T695, T697], T697, T698, T699: CanRSub[T154, T700], T700: CanRSub[T699, T701], T701, T702: CanRSub[T155, R132], T703, T704, T705: CanRSub[T156, T706], T706: CanRSub[T705, T707], T707, T708: CanRSub[T158, R131], T709, T710: CanRSub[T159, R128], T711, T712, T713: CanRSub[T160, T714], T714: CanRSub[T713, T715], T715, T716, T717: CanRSub[T162, T718], T718: CanRSub[T717, T719], T719, T720: CanRSub[T163, R122], T721, T722, T723: CanRSub[T164, T724], T724: CanRSub[T723, T725], T725, T726: CanRSub[T165, R120], T727, T728, T729: CanRSub[T166, T730], T730: CanRSub[T729, T733 & T732 & T731], T731, T732, T733, T734: CanRSub[T167, T735], T735: CanRSub[T734, T737 & T736], T736, T737, T738: CanRSub[R114, T740 & T739], T739, T740, T741: CanRSub[T169, T742], T742: CanRSub[T741, T744 & T743], T743, T744, T745: CanRSub[T170, T746], T746: CanRSub[T745, T749 & T748 & T747], T747, T748, T749, T750: CanRSub[T171, T751], T751: CanRSub[T750, T753 & T752], T752, T753, T754: CanRSub[T172, T755], T755: CanRSub[T754, T756], T756, T757, T758: CanRSub[R104, T760 & T759], T759, T760, T761: CanRSub[T175, T762], T762: CanRSub[T761, T763], T763, T764: CanRSub[R102, T765], T765, T766: CanRSub[T177, T767], T767: CanRSub[T766, T768], T768, T769: CanRSub[R99, T771 & T770], T770, T771, T772: CanRSub[T179, T773], T773: CanRSub[T772, T774], T774, T775: CanRSub[T180, T776], T776: CanRSub[T775, T777], T777, T778: CanRSub[T181, R97], T779, T780, T781: CanRSub[T182, T782], T782: CanRSub[T781, T785 & T784 & T783], T783, T784, T785, T786: CanRSub[T183, T787], T787: CanRSub[T786, T789 & T788], T788, T789, T790: CanRSub[R91, T792 & T791], T791, T792, T793: CanRSub[T185, T794], T794: CanRSub[T793, T796 & T795], T795, T796, T797: CanRSub[T186, T798], T798: CanRSub[T797, T801 & T800 & T799], T799, T800, T801, T802: CanRSub[T187, T803], T803: CanRSub[T802, T805 & T804], T804, T805, T806: CanRSub[T188, T807], T807: CanRSub[T806, T808], T808, T809, T810, T811, T812: CanRSub[R70, T814 & T813], T813, T814, T815: CanRSub[T199, T816], T816: CanRSub[T815, T817], T817, T818: CanRSub[R68, T819], T819, T820: CanRSub[T201, T821], T821: CanRSub[T820, T822], T822, T823: CanRSub[R65, T825 & T824], T824, T825, T826: CanRSub[T203, T827], T827: CanRSub[T826, T828], T828, T829: CanRSub[R61, T830], T830, T831: CanRSub[R58, T832], T832, T833, T834: CanRSub[R52, T836 & T835], T835, T836, T837: CanRSub[T215, T838], T838: CanRSub[T837, T839], T839, T840: CanRSub[R50, T841], T841, T842: CanRSub[T217, T843], T843: CanRSub[T842, T844], T844, T845: CanRSub[R47, T847 & T846], T846, T847, T848: CanRSub[T219, T849], T849: CanRSub[T848, T850], T850, T851: CanRSub[T222, R46], T852, T853: CanRSub[T223, R43], T854, T855, T856: CanRSub[T224, T857], T857: CanRSub[T856, T858], T858, T859, T860: CanRSub[T226, T861], T861: CanRSub[T860, T862], T862, T863: CanRSub[T227, R37], T864, T865, T866: CanRSub[T228, T867], T867: CanRSub[T866, T868], T868, T869: CanRSub[T229, R35], T870, T871, T872: CanRSub[T230, T873], T873: CanRSub[T872, T876 & T875 & T874], T874, T875, T876, T877: CanRSub[T231, T878], T878: CanRSub[T877, T880 & T879], T879, T880, T881: CanRSub[R29, T883 & T882], T882, T883, T884: CanRSub[T233, T885], T885: CanRSub[T884, T887 & T886], T886, T887, T888: CanRSub[T234, T889], T889: CanRSub[T888, T892 & T891 & T890], T890, T891, T892, T893: CanRSub[T235, T894], T894: CanRSub[T893, T896 & T895], T895, T896, T897: CanRSub[T236, T898], T898: CanRSub[T897, T899], T899, T900, T901: CanRSub[R19, T903 & T902], T902, T903, T904: CanRSub[T239, T905], T905: CanRSub[T904, T906], T906, T907: CanRSub[R17, T908], T908, T909: CanRSub[T241, T910], T910: CanRSub[T909, T911], T911, T912: CanRSub[R14, T914 & T913], T913, T914, T915: CanRSub[T243, T916], T916: CanRSub[T915, T917], T917, T918: CanRSub[T244, T919], T919: CanRSub[T918, T920], T920, T921: CanRSub[T245, R12], T922, T923, T924: CanRSub[T246, T925], T925: CanRSub[T924, T928 & T927 & T926], T926, T927, T928, T929: CanRSub[T247, T930], T930: CanRSub[T929, T932 & T931], T931, T932, T933: CanRSub[R6, T935 & T934], T934, T935, T936: CanRSub[T249, T937], T937: CanRSub[T936, T939 & T938], T938, T939, T940: CanRSub[T250, T941], T941: CanRSub[T940, T944 & T943 & T942], T942, T943, T944, T945: CanRSub[T251, T946], T946: CanRSub[T945, T948 & T947], T947, T948, T949: CanRSub[T252, T950], T950: CanRSub[T949, T951], T951, R, R2, R3, R4, R5, R6: CanRSub[T248, T933], R7, R8, R9, R10, R11, R12: CanRSub[T921, T923 & T922], R13, R14: CanRSub[T242, T912], R15, R16, R17: CanRSub[T240, T907], R18, R19: CanRSub[T238, T901], R20, R21, R22: CanRSub[T237, R23], R23: CanRSub[R22, T900], R24, R25, R26, R27, R28, R29: CanRSub[T232, T881], R30, R31, R32, R33, R34, R35: CanRSub[T869, T871 & T870], R36, R37: CanRSub[T863, T865 & T864], R38, R39, R40: CanRSub[R41, T859], R41: CanRSub[T225, R40], R42, R43: CanRSub[T853, T855 & T854], R44, R45, R46: CanRSub[T851, T852], R47: CanRSub[T218, T845], R48, R49, R50: CanRSub[T216, T840], R51, R52: CanRSub[T214, T834], R53, R54, R55: CanRSub[T213, R57], R56, R57: CanRSub[R55, T833], R58: CanRSub[T210, T831], R59, R60: CanRSub[T208, object], R61: CanRSub[T206, T829], R62, R63: CanRSub[T205, R64], R64, R65: CanRSub[T202, T823], R66, R67, R68: CanRSub[T200, T818], R69, R70: CanRSub[T198, T812], R71, R72, R73: CanRSub[T197, R75], R74, R75: CanRSub[R73, T811], R76: CanRSub[T195, R77], R77: CanRSub[R76, T810], R78, R79: CanRSub[T193, R80], R80, R81: CanRSub[T191, R82], R82: CanRSub[R81, T809], R83, R84: CanRSub[T190, R85], R85, R86, R87, R88, R89, R90, R91: CanRSub[T184, T790], R92, R93, R94, R95, R96, R97: CanRSub[T778, T780 & T779], R98, R99: CanRSub[T178, T769], R100, R101, R102: CanRSub[T176, T764], R103, R104: CanRSub[T174, T758], R105, R106, R107: CanRSub[T173, R108], R108: CanRSub[R107, T757], R109, R110, R111, R112, R113, R114: CanRSub[T168, T738], R115, R116, R117, R118, R119, R120: CanRSub[T726, T728 & T727], R121, R122: CanRSub[T720, T722 & T721], R123, R124, R125: CanRSub[R126, T716], R126: CanRSub[T161, R125], R127, R128: CanRSub[T710, T712 & T711], R129, R130, R131: CanRSub[T708, T709], R132: CanRSub[T702, T704 & T703], R133, R134, R135: CanRSub[R137, T698], R136, R137: CanRSub[T153, R135], R138: CanRSub[T692, T694 & T693], R139, R140, R141: CanRSub[T690, T691], R142, R143: CanRSub[R144, T689], R144: CanRSub[T147, R143], R145, R146, R147: CanRSub[T145, R146], R148: CanRSub[R149, T688], R149: CanRSub[T143, R148], R150, R151, R152: CanRSub[T142, R151], R153: CanRSub[T682, T684 & T683], R154, R155, R156: CanRSub[R158, T678], R157, R158: CanRSub[T137, R156], R159: CanRSub[T672, T674 & T673], R160, R161, R162: CanRSub[T670, T671], R163, R164: CanRSub[T668, T669], R165, R166, R167: CanRSub[T130, R166], R168: CanRSub[T666, T667], R169, R170, R171, R172, R173, R174, R175, R176: CanRSub[T121, T641], R177, R178, R179, R180, R181, R182: CanRSub[T626, T628 & T627], R183, R184: CanRSub[T115, T614], R185, R186, R187: CanRSub[T113, T607], R188, R189: CanRSub[T111, T599], R190, R191, R192: CanRSub[T110, R193], R193: CanRSub[R192, T597], R194, R195, R196, R197, R198, R199: CanRSub[T105, T573], R200, R201, R202, R203, R204, R205: CanRSub[T558, T560 & T559], R206, R207: CanRSub[T550, T552 & T551], R208, R209, R210: CanRSub[R211, T544], R211: CanRSub[T98, R210], R212, R213: CanRSub[T536, T538 & T537], R214, R215, R216: CanRSub[T533, T534], R217: CanRSub[T91, T523], R218, R219, R220: CanRSub[T89, T516], R221, R222: CanRSub[T87, T508], R223, R224, R225: CanRSub[T86, R227], R226, R227: CanRSub[R225, T506], R228: CanRSub[T83, T501], R229, R230: CanRSub[T81, object], R231: CanRSub[T79, T495], R232, R233: CanRSub[T78, R234], R234, R235: CanRSub[T75, T485], R236, R237, R238: CanRSub[T73, T478], R239, R240: CanRSub[T71, T470], R241, R242, R243: CanRSub[T70, R245], R244, R245: CanRSub[R243, T468], R246: CanRSub[T68, R247], R247: CanRSub[R246, T465], R248, R249: CanRSub[T66, R250], R250, R251: CanRSub[T64, R252], R252: CanRSub[R251, T460], R253, R254: CanRSub[T63, R255], R255, R256, R257, R258, R259, R260, R261: CanRSub[T57, T434], R262, R263, R264, R265, R266, R267: CanRSub[T419, T421 & T420], R268, R269: CanRSub[T51, T407], R270, R271, R272: CanRSub[T49, T400], R273, R274: CanRSub[T47, T392], R275, R276, R277: CanRSub[T46, R278], R278: CanRSub[R277, T390], R279, R280, R281, R282, R283, R284: CanRSub[T41, T366], R285, R286, R287, R288, R289, R290: CanRSub[T351, T353 & T352], R291, R292: CanRSub[T343, T345 & T344], R293, R294, R295: CanRSub[R296, T337], R296: CanRSub[T34, R295], R297, R298: CanRSub[T329, T331 & T330], R299, R300, R301: CanRSub[T326, T327], R302: CanRSub[T317, T319 & T318], R303, R304, R305: CanRSub[R307, T311], R306, R307: CanRSub[T26, R305], R308: CanRSub[T303, T305 & T304], R309, R310, R311: CanRSub[T300, T301], R312, R313: CanRSub[R314, T296], R314: CanRSub[T20, R313], R315, R316, R317: CanRSub[T18, R316], R318: CanRSub[R319, T291], R319: CanRSub[T16, R318], R320, R321, R322: CanRSub[T15, R321], R323: CanRSub[T281, T283 & T282], R324, R325, R326: CanRSub[R328, T275], R327, R328: CanRSub[T10, R326], R329: CanRSub[T267, T269 & T268], R330, R331, R332: CanRSub[T264, T265], R333, R334: CanRSub[T260, T261], R335, R336, R337: CanRSub[W, R336], R338: CanRSub[T254, T255], R339](h: CanAdd[float, CanMod[float, CanLt[float, CanBool] & CanRMul[T951 | T948 | T944 | T939 | T935 | T932 | T928 | T923 | T920 | T917 | T914 | T911 | T908 | T906 | T903 | T900 | T899 | T896 | T892 | T887 | T883 | T880 | T876 | T871 | T868 | T865 | T862 | T859 | T858 | T855 | T852 | T663 | T659 | T654 | T648 | T643 | T639 | T634 | T628 | T624 | T620 | T616 | T612 | T608 | T605 | T601 | T597 | T595 | T591 | T586 | T580 | T575 | T571 | T566 | T560 | T556 | T552 | T548 | T544 | T542 | T538 | T534, CanMul[float, CanRAdd[T950 | T946 | T941 | T937 | T933 | T930 | T925 | R12 | T919 | T916 | T912 | T910 | T907 | T905 | T901 | R23 | T898 | T894 | T889 | T885 | T881 | T878 | T873 | R35 | T867 | R37 | T861 | R40 | T857 | R43 | R46 | T662 | T657 | T651 | T646 | T641 | T637 | T631 | R182 | T623 | T619 | T614 | T611 | T607 | T604 | T599 | R193 | T594 | T589 | T583 | T578 | T573 | T569 | T563 | R205 | T555 | R207 | T547 | R210 | T541 | R213 | R216, R & R4 & R7 & R10 & R13 & R16 & R18 & R21 & R24 & R27 & R30 & R33 & R36 & R39 & R42 & R45 & R171 & R174 & R177 & R180 & R183 & R186 & R188 & R191 & R194 & R197 & R200 & R203 & R206 & R209 & R212 & R215]]] & CanRSub[float, CanRMul[T808 | T805 | T801 | T796 | T792 | T789 | T785 | T780 | T777 | T774 | T771 | T768 | T765 | T763 | T760 | T757 | T756 | T753 | T749 | T744 | T740 | T737 | T733 | T728 | T725 | T722 | T719 | T716 | T715 | T712 | T709 | T456 | T452 | T447 | T441 | T436 | T432 | T427 | T421 | T417 | T413 | T409 | T405 | T401 | T398 | T394 | T390 | T388 | T384 | T379 | T373 | T368 | T364 | T359 | T353 | T349 | T345 | T341 | T337 | T335 | T331 | T327, CanMul[float, CanRAdd[T807 | T803 | T798 | T794 | T790 | T787 | T782 | R97 | T776 | T773 | T769 | T767 | T764 | T762 | T758 | R108 | T755 | T751 | T746 | T742 | T738 | T735 | T730 | R120 | T724 | R122 | T718 | R125 | T714 | R128 | R131 | T455 | T450 | T444 | T439 | T434 | T430 | T424 | R267 | T416 | T412 | T407 | T404 | T400 | T397 | T392 | R278 | T387 | T382 | T376 | T371 | T366 | T362 | T356 | R290 | T348 | R292 | T340 | R295 | T334 | R298 | R301, R86 & R89 & R92 & R95 & R98 & R101 & R103 & R106 & R109 & R112 & R115 & R118 & R121 & R124 & R127 & R130 & R256 & R259 & R262 & R265 & R268 & R271 & R273 & R276 & R279 & R282 & R285 & R288 & R291 & R294 & R297 & R300]]]]]] & CanMod[float, CanLt[float, CanBool] & CanRMul[T947 | T943 | T938 | T934 | T931 | T927 | T922 | T850 | T847 | T844 | T841 | T839 | T836 | T833 | T804 | T800 | T795 | T791 | T788 | T784 | T779 | T707 | T704 | T701 | T698 | T697 | T694 | T691 | T658 | T653 | T647 | T642 | T638 | T633 | T627 | T529 | T525 | T521 | T517 | T514 | T510 | T506 | T451 | T446 | T440 | T435 | T431 | T426 | T420 | T323 | T319 | T315 | T311 | T309 | T305 | T301, CanMul[float, CanRAdd[T946 | T941 | T937 | T933 | T930 | T925 | R12 | T849 | T845 | T843 | T840 | T838 | T834 | R57 | T803 | T798 | T794 | T790 | T787 | T782 | R97 | T706 | R132 | T700 | R135 | T696 | R138 | R141 | T657 | T651 | T646 | T641 | T637 | T631 | R182 | T528 | T523 | T520 | T516 | T513 | T508 | R227 | T450 | T444 | T439 | T434 | T430 | T424 | R267 | T322 | R302 | T314 | R305 | T308 | R308 | R311, R2 & R5 & R8 & R11 & R48 & R51 & R53 & R56 & R87 & R90 & R93 & R96 & R133 & R136 & R139 & R142 & R172 & R175 & R178 & R181 & R218 & R221 & R223 & R226 & R257 & R260 & R263 & R266 & R303 & R306 & R309 & R312]]] & CanRSub[float, CanRMul[T895 | T891 | T886 | T882 | T879 | T875 | T870 | T828 | T825 | T822 | T819 | T817 | T814 | T811 | T752 | T748 | T743 | T739 | T736 | T732 | T727 | T687 | T684 | T681 | T678 | T677 | T674 | T671 | T590 | T585 | T579 | T574 | T570 | T565 | T559 | T491 | T487 | T483 | T479 | T476 | T472 | T468 | T383 | T378 | T372 | T367 | T363 | T358 | T352 | T287 | T283 | T279 | T275 | T273 | T269 | T265, CanMul[float, CanRAdd[T894 | T889 | T885 | T881 | T878 | T873 | R35 | T827 | T823 | T821 | T818 | T816 | T812 | R75 | T751 | T746 | T742 | T738 | T735 | T730 | R120 | T686 | R153 | T680 | R156 | T676 | R159 | R162 | T589 | T583 | T578 | T573 | T569 | T563 | R205 | T490 | T485 | T482 | T478 | T475 | T470 | R245 | T382 | T376 | T371 | T366 | T362 | T356 | R290 | T286 | R323 | T278 | R326 | T272 | R329 | R332, R25 & R28 & R31 & R34 & R66 & R69 & R71 & R74 & R110 & R113 & R116 & R119 & R154 & R157 & R160 & R163 & R195 & R198 & R201 & R204 & R236 & R239 & R241 & R244 & R280 & R283 & R286 & R289 & R324 & R327 & R330 & R333]]]]] & CanSub[float, CanMod[float, CanLt[float, CanBool] & CanRMul[T942 | T913 | T890 | T864 | T846 | T832 | T824 | T810 | T799 | T770 | T747 | T721 | T703 | T689 | T683 | T669 | T652 | T615 | T584 | T551 | T524 | T502 | T486 | T465 | T445 | T408 | T377 | T344 | T318 | T296 | T282 | T261, CanMul[float, CanRAdd[T941 | T912 | T889 | R37 | T845 | T831 | T823 | R77 | T798 | T769 | T746 | R122 | R132 | R143 | R153 | R164 | T651 | T614 | T583 | R207 | T523 | T501 | T485 | R247 | T444 | T407 | T376 | R292 | R302 | R313 | R323 | R334, R3 & R15 & R26 & R38 & R49 & R59 & R67 & R78 & R88 & R100 & R111 & R123 & R134 & R145 & R155 & R165 & R173 & R185 & R196 & R208 & R219 & R229 & R237 & R248 & R258 & R270 & R281 & R293 & R304 & R315 & R325 & R335]]] & CanRSub[float, CanRMul[T926 | T902 | T874 | T854 | T835 | T830 | T813 | T809 | T783 | T759 | T731 | T711 | T693 | T688 | T673 | T667 | T632 | T600 | T564 | T537 | T509 | T496 | T471 | T460 | T425 | T393 | T357 | T330 | T304 | T291 | T268 | T255, CanMul[float, CanRAdd[T925 | T901 | T873 | R43 | T834 | T829 | T812 | R82 | T782 | T758 | T730 | R128 | R138 | R148 | R159 | R168 | T631 | T599 | T563 | R213 | T508 | T495 | T470 | R252 | T424 | T392 | T356 | R298 | R308 | R318 | R329 | R338, R9 & R20 & R32 & R44 & R54 & R62 & R72 & R83 & R94 & R105 & R117 & R129 & R140 & R150 & R161 & R169 & R179 & R190 & R202 & R214 & R224 & R232 & R242 & R253 & R264 & R275 & R287 & R299 & R310 & R320 & R331 & R339]]]]]], l: T, s: CanEq[float, CanBool] & CanRAdd[float | T, T665 & T664 & T660 & T655 & T649 & T644 & T640 & T635 & T629 & T625 & T621 & T617 & T613 & T609 & T606 & T602 & T598 & T596 & T592 & T587 & T581 & T576 & T572 & T567 & T561 & T557 & T553 & T549 & T545 & T543 & T539 & T535 & T532 & T531 & T530 & T526 & T522 & T518 & T515 & T511 & T507 & T505 & T504 & T503 & T500 & T499 & T498 & T497 & T494 & T493 & T492 & T488 & T484 & T480 & T477 & T473 & T469 & T467 & T466 & T464 & T463 & T462 & T461 & T459 & T458 & T457 & T453 & T448 & T442 & T437 & T433 & T428 & T422 & T418 & T414 & T410 & T406 & T402 & T399 & T395 & T391 & T389 & T385 & T380 & T374 & T369 & T365 & T360 & T354 & T350 & T346 & T342 & T338 & T336 & T332 & T328 & T325 & T324 & T320 & T316 & T312 & T310 & T306 & T302 & T299 & T298 & T297 & T295 & T294 & T293 & T292 & T290 & T289 & T288 & T284 & T280 & T276 & T274 & T270 & T266 & T263 & T262 & T259 & T258 & T257 & T256 & CanRMul[T, T949 & T945 & T940 & T936 & R6 & T929 & T924 & T921 & T918 & T915 & R14 & T909 & R17 & T904 & R19 & R22 & T897 & T893 & T888 & T884 & R29 & T877 & T872 & T869 & T866 & T863 & T860 & R41 & T856 & T853 & T851 & T848 & R47 & T842 & R50 & T837 & R52 & R55 & R58 & R60 & R61 & R63 & T826 & R65 & T820 & R68 & T815 & R70 & R73 & R76 & R79 & R81 & R84 & T806 & T802 & T797 & T793 & R91 & T786 & T781 & T778 & T775 & T772 & R99 & T766 & R102 & T761 & R104 & R107 & T754 & T750 & T745 & T741 & R114 & T734 & T729 & T726 & T723 & T720 & T717 & R126 & T713 & T710 & T708 & T705 & T702 & T699 & R137 & T695 & T692 & T690 & R144 & R147 & R149 & R152 & T685 & T682 & T679 & R158 & T675 & T672 & T670 & T668 & R167 & T666 & CanRSub[T253 | T221 | T220 | T212 | T211 | T209 | T207 | T204 | T196 | T194 | T192 | T189 | T157 | T149 | T148 | T146 | T144 | T141 | T133 | T131 | T129 | T127, R170]]] & CanRMul[T, CanRSub[T665 | T664 | T660 | T655 | T649 | T644 | T640 | T635 | T629 | T625 | T621 | T617 | T613 | T609 | T606 | T602 | T598 | T596 | T592 | T587 | T581 | T576 | T572 | T567 | T561 | T557 | T553 | T549 | T545 | T543 | T539 | T535 | T532 | T531 | T530 | T526 | T522 | T518 | T515 | T511 | T507 | T505 | T504 | T503 | T500 | T499 | T498 | T497 | T494 | T493 | T492 | T488 | T484 | T480 | T477 | T473 | T469 | T467 | T466 | T464 | T463 | T462 | T461 | T459 | T458 | T457 | T453 | T448 | T442 | T437 | T433 | T428 | T422 | T418 | T414 | T410 | T406 | T402 | T399 | T395 | T391 | T389 | T385 | T380 | T374 | T369 | T365 | T360 | T354 | T350 | T346 | T342 | T338 | T336 | T332 | T328 | T325 | T324 | T320 | T316 | T312 | T310 | T306 | T302 | T299 | T298 | T297 | T295 | T294 | T293 | T292 | T290 | T289 | T288 | T284 | T280 | T276 | T274 | T270 | T266 | T263 | T262 | T259 | T258 | T257 | T256, T661 & T656 & T650 & T645 & R176 & T636 & T630 & T626 & T622 & T618 & R184 & T610 & R187 & T603 & R189 & R192 & T593 & T588 & T582 & T577 & R199 & T568 & T562 & T558 & T554 & T550 & T546 & R211 & T540 & T536 & T533 & T527 & R217 & T519 & R220 & T512 & R222 & R225 & R228 & R230 & R231 & R233 & T489 & R235 & T481 & R238 & T474 & R240 & R243 & R246 & R249 & R251 & R254 & T454 & T449 & T443 & T438 & R261 & T429 & T423 & T419 & T415 & T411 & R269 & T403 & R272 & T396 & R274 & R277 & T386 & T381 & T375 & T370 & R284 & T361 & T355 & T351 & T347 & T343 & T339 & R296 & T333 & T329 & T326 & T321 & T317 & T313 & R307 & T307 & T303 & T300 & R314 & R317 & R319 & R322 & T285 & T281 & T277 & R328 & T271 & T267 & T264 & T260 & R337 & T254 & CanRSub[T126 | T94 | T93 | T85 | T84 | T82 | T80 | T77 | T69 | T67 | T65 | T62 | T30 | T22 | T21 | T19 | T17 | T14 | Z | X | V, object]]]) -> tuple[T, T, T] | tuple[R, R2, R3] | tuple[R4, R5, R6] | tuple[R7, R8, R9] | tuple[R10, R11, R12] | tuple[R13, R14, R15] | tuple[R16, R17, R17] | tuple[R18, R19, R20] | tuple[R21, R22, R23] | tuple[R24, R25, R26] | tuple[R27, R28, R29] | tuple[R30, R31, R32] | tuple[R33, R34, R35] | tuple[R36, R37, R38] | tuple[R39, R40, R41] | tuple[R42, R43, R44] | tuple[R45, R46, R46] | tuple[R47, R48, R49] | tuple[R50, R51, R50] | tuple[R52, R53, R54] | tuple[R55, R56, R57] | tuple[R58, R58, R59] | tuple[R60, R60, R60] | tuple[R61, R61, R62] | tuple[R63, R63, R64] | tuple[R65, R66, R67] | tuple[R68, R69, R68] | tuple[R70, R71, R72] | tuple[R73, R74, R75] | tuple[R76, R77, R78] | tuple[R79, R80, R79] | tuple[R81, R82, R83] | tuple[R84, R85, R85] | tuple[R86, R87, R88] | tuple[R89, R90, R91] | tuple[R92, R93, R94] | tuple[R95, R96, R97] | tuple[R98, R99, R100] | tuple[R101, R102, R102] | tuple[R103, R104, R105] | tuple[R106, R107, R108] | tuple[R109, R110, R111] | tuple[R112, R113, R114] | tuple[R115, R116, R117] | tuple[R118, R119, R120] | tuple[R121, R122, R123] | tuple[R124, R125, R126] | tuple[R127, R128, R129] | tuple[R130, R131, R131] | tuple[R132, R133, R134] | tuple[R135, R136, R137] | tuple[R138, R139, R140] | tuple[R141, R142, R141] | tuple[R143, R144, R145] | tuple[R146, R147, R147] | tuple[R148, R149, R150] | tuple[R151, R152, R151] | tuple[R153, R154, R155] | tuple[R156, R157, R158] | tuple[R159, R160, R161] | tuple[R162, R163, R162] | tuple[R164, R164, R165] | tuple[R166, R166, R167] | tuple[R168, R168, R169] | tuple[R170, R170, R170] | tuple[R171, R172, R173] | tuple[R174, R175, R176] | tuple[R177, R178, R179] | tuple[R180, R181, R182] | tuple[R183, R184, R185] | tuple[R186, R187, R187] | tuple[R188, R189, R190] | tuple[R191, R192, R193] | tuple[R194, R195, R196] | tuple[R197, R198, R199] | tuple[R200, R201, R202] | tuple[R203, R204, R205] | tuple[R206, R207, R208] | tuple[R209, R210, R211] | tuple[R212, R213, R214] | tuple[R215, R216, R216] | tuple[R217, R218, R219] | tuple[R220, R221, R220] | tuple[R222, R223, R224] | tuple[R225, R226, R227] | tuple[R228, R228, R229] | tuple[R230, R230, R230] | tuple[R231, R231, R232] | tuple[R233, R233, R234] | tuple[R235, R236, R237] | tuple[R238, R239, R238] | tuple[R240, R241, R242] | tuple[R243, R244, R245] | tuple[R246, R247, R248] | tuple[R249, R250, R249] | tuple[R251, R252, R253] | tuple[R254, R255, R255] | tuple[R256, R257, R258] | tuple[R259, R260, R261] | tuple[R262, R263, R264] | tuple[R265, R266, R267] | tuple[R268, R269, R270] | tuple[R271, R272, R272] | tuple[R273, R274, R275] | tuple[R276, R277, R278] | tuple[R279, R280, R281] | tuple[R282, R283, R284] | tuple[R285, R286, R287] | tuple[R288, R289, R290] | tuple[R291, R292, R293] | tuple[R294, R295, R296] | tuple[R297, R298, R299] | tuple[R300, R301, R301] | tuple[R302, R303, R304] | tuple[R305, R306, R307] | tuple[R308, R309, R310] | tuple[R311, R312, R311] | tuple[R313, R314, R315] | tuple[R316, R317, R317] | tuple[R318, R319, R320] | tuple[R321, R322, R321] | tuple[R323, R324, R325] | tuple[R326, R327, R328] | tuple[R329, R330, R331] | tuple[R332, R333, R332] | tuple[R334, R334, R335] | tuple[R336, R336, R337] | tuple[R338, R338, R339]
```

after:

```console
$ optype infer "import colorsys; colorsys.hls_to_rgb"
/home/joren/Workspace/optype/optype/infer/_explore.py:430: InferWarning: not every branch was explored
  return _explore_spies(func, params), {}
[T: CanLe[float, CanBool] & CanMul[T10 | U, R2] & CanRMul[float, CanSub[R2 | R4, R3]] & CanAdd[U, CanSub[R2, R4]], U: CanEq[float, CanBool] & CanRAdd[float, T10], V, W: CanLt[float, CanBool], X, Y: CanLt[float, CanBool], Z, T7: CanLt[float, CanBool], T8, T9, T10, R, R2: CanSub[R3, CanMul[T7 | Y | W | V | X | Z, CanMul[float, T9]]], R3: CanAdd[T9 | T8, R], R4: CanSub[R3, CanMul[T7 | Y | W | V | X | Z, CanMul[float, T8]]]](h: CanAdd[float, CanMod[float, T7 & CanLt[float, CanBool] & CanRSub[float, Z]]] & CanMod[float, Y & CanLt[float, CanBool] & CanRSub[float, X]] & CanSub[float, CanMod[float, W & CanLt[float, CanBool] & CanRSub[float, V]]], l: T, s: U) -> tuple[T | R | R2 | R3 | R4, T | R | R2 | R3 | R4, T | R | R2 | R3 | R4]
[T: CanLe[float, CanBool] & CanRMul[float, U], U, V, W, X, R, R2, R3, R4: CanRSub[U, R6], R5, R6: CanRSub[R4, X], R7, R8, R9: CanRSub[U, R10], R10: CanRSub[R9, V]](h: CanAdd[float, CanMod[float, CanLt[float, CanBool] & CanRMul[X | V, CanMul[float, CanRAdd[R6 | R10, R]]] & CanRSub[float, CanRMul[X | V, CanMul[float, CanRAdd[R6 | R10, R8]]]]]] & CanMod[float, CanLt[float, CanBool] & CanRMul[X | V, CanMul[float, CanRAdd[R6 | R10, R2]]] & CanRSub[float, CanRMul[X | V, CanMul[float, CanRAdd[R6 | R10, R7]]]]] & CanSub[float, CanMod[float, CanLt[float, CanBool] & CanRMul[X | V, CanMul[float, CanRAdd[R6 | R10, R3]]] & CanRSub[float, CanRMul[X | V, CanMul[float, CanRAdd[R6 | R10, R5]]]]]], l: T, s: CanEq[float, CanBool] & CanRAdd[float | T, W & CanRMul[T, R4 & CanRSub[U, R6]]] & CanRMul[T, CanRSub[W, R9 & CanRSub[U, object]]]) -> tuple[T | R | R4 | R8 | R6 | R9 | R10, T | R2 | R4 | R7 | R6 | R9 | R10, T | R3 | R4 | R5 | R6 | R9 | R10]
```

closes #671
