### PR TITLE
`infer`: variadic unpacking

### DIFF
--- a/docs/reference/experimental/infer.md
+++ b/docs/reference/experimental/infer.md
@@ -408,6 +408,22 @@ $ optype infer "lambda f, x: map(f, x)"
 [T, R](f: (T) -> R, x: CanIter[CanNext[T]]) -> map[R]
 ```
 
+## Unpacking
+
+An unpacking iterates the parameter, and every target shares one element type, like
+`*args`; a starred target collects the rest into a `list`:
+
+```console
+$ optype infer "def f(x): a, b = x; return a, b"
+[R](x: CanIter[CanNext[R]]) -> tuple[R, R]
+
+$ optype infer "def f(x): a, *b = x; return a, b"
+[R](x: CanIter[CanNext[R]]) -> tuple[R, list[R]]
+
+$ optype infer "lambda x: {k: v for k, v in x}"
+[R: CanHash](x: CanIter[CanNext[CanIter[CanNext[R]]]]) -> dict[R, R]
+```
+
 ## Returned functions
 
 A returned function is lazy too, so it is explored with placeholders of its own, and

--- a/optype/infer/_explore.py
+++ b/optype/infer/_explore.py
@@ -37,7 +37,9 @@ from ._spy import (
     _own_spy,
     _SpyObject,
     _SpyStr,
+    _starved,
     _TraceItem,
+    _yields as _yield_budget,
 )
 from ._values import _Fn, _Gen, _Rec, _RecRef, _RecVar, _walk, fn_spies
 
@@ -61,6 +63,8 @@ _YIELD_LIMIT = 64
 # large indices stay within reach
 _VARIADIC_COUNTS = (2, 3, 4, 5, 6, 7, 8, 16, 32, 64, 128, 256, 512, 1024)
 _KWARGS_LIMIT = 8  # max injected `**kwargs` keys
+# the iterator yield budgets to try for a splat into a fixed-arity call, e.g. divmod
+_YIELD_COUNTS = 2, 3, 4, 5, 6, 7, 8, 16, 32, 64
 
 type _Traces = dict[int, list[_TraceItem]]
 
@@ -380,15 +384,27 @@ def _explore_spies(
     omit: Collection[str] = (),
     fix: Collection[str] = (),
 ) -> _Recon:
-    # rerun with fresh spies whenever the variadic placeholders come up short
     kinds = {p.kind for p in params.values()}
+
     counts = iter(_VARIADIC_COUNTS)
     count = next(counts)
+
+    # rerun with new spies when the variadic placeholders/iterator yield budget runs out
+    budgets = iter(_YIELD_COUNTS)
+    budget = 1
+
     keys: list[str] = []
+
     # registering `func` itself keeps a returned self-reference from recursing
     token = _exploring.set(_exploring.get() | {_explore_key(func)})
+
+    yield_token = _yield_budget.set(budget)
+    starve_token = _starved.set(False)
     try:
         while True:
+            _yield_budget.set(budget)
+            _starved.set(False)
+
             # a fresh `self` instance per attempt, so a mutated one cannot leak
             fixed = _fixed_self(func, params) | {n: params[n].default for n in fix}
             spies, args, kwds = _placeholders(params, count, keys, omit, fixed)
@@ -408,15 +424,20 @@ def _explore_spies(
                     raise InferError(msg) from exc
                 keys.append(key)
             except (IndexError, TypeError, ValueError) as exc:
-                if Parameter.VAR_POSITIONAL not in kinds:
+                if Parameter.VAR_POSITIONAL in kinds:
+                    if (count := next(counts, 0)) == 0:
+                        msg = f"ran out of `*args` placeholders ({exc})"
+                        raise InferError(msg) from exc
+                # a call like `divmod(*x)` may have failed only because the iterator
+                # handed it too few values; if so, try again with more, else give up
+                elif not _starved.get() or (budget := next(budgets, 0)) == 0:
                     raise
-                if (count := next(counts, 0)) == 0:
-                    msg = f"ran out of `*args` placeholders ({exc})"
-                    raise InferError(msg) from exc
             else:
                 traces = _snapshot((*spies.values(), *fn_spies(results)))
                 return spies, traces, results, count, fixed
     finally:
+        _starved.reset(starve_token)
+        _yield_budget.reset(yield_token)
         _exploring.reset(token)
 
 

--- a/optype/infer/_explore.py
+++ b/optype/infer/_explore.py
@@ -39,7 +39,7 @@ from ._spy import (
     _SpyStr,
     _starved,
     _TraceItem,
-    _yields as _yield_budget,
+    _yield_budget,
 )
 from ._values import _Fn, _Gen, _Rec, _RecRef, _RecVar, _walk, fn_spies
 
@@ -63,8 +63,9 @@ _YIELD_LIMIT = 64
 # large indices stay within reach
 _VARIADIC_COUNTS = (2, 3, 4, 5, 6, 7, 8, 16, 32, 64, 128, 256, 512, 1024)
 _KWARGS_LIMIT = 8  # max injected `**kwargs` keys
-# the iterator yield budgets to try for a splat into a fixed-arity call, e.g. divmod
-_YIELD_COUNTS = 2, 3, 4, 5, 6, 7, 8, 16, 32, 64
+# yield budgets to try for a splat into a fixed-arity call (e.g. `divmod`): an exact
+# arity is needed, so these stay contiguous; a sparse range would skip valid arities
+_YIELD_COUNTS = tuple(range(2, 17))
 
 type _Traces = dict[int, list[_TraceItem]]
 
@@ -303,6 +304,8 @@ def _explore[T](
             (spy, len(spy.__optype_trace__))
             for spy in _reachable((*args, *kwds.values(), *_closed_over(func)))
         ]
+        # `_starved` is a per-run splat signal, so a prior run cannot leak into this one
+        _starved.set(False)
         token = _fork.set(iter(plan))
         try:
             result = func(*args, **kwds)
@@ -403,7 +406,6 @@ def _explore_spies(
     try:
         while True:
             _yield_budget.set(budget)
-            _starved.set(False)
 
             # a fresh `self` instance per attempt, so a mutated one cannot leak
             fixed = _fixed_self(func, params) | {n: params[n].default for n in fix}
@@ -424,13 +426,19 @@ def _explore_spies(
                     raise InferError(msg) from exc
                 keys.append(key)
             except (IndexError, TypeError, ValueError) as exc:
-                if Parameter.VAR_POSITIONAL in kinds:
+                # a too-short splat raises `TypeError`; gate on it so the target's own
+                # error (e.g. a `ValueError`) can't churn the budget and bury itself
+                if (
+                    isinstance(exc, TypeError)
+                    and _starved.get()
+                    and (budget := next(budgets, 0)) != 0
+                ):
+                    pass
+                elif Parameter.VAR_POSITIONAL in kinds:
                     if (count := next(counts, 0)) == 0:
                         msg = f"ran out of `*args` placeholders ({exc})"
                         raise InferError(msg) from exc
-                # a call like `divmod(*x)` may have failed only because the iterator
-                # handed it too few values; if so, try again with more, else give up
-                elif not _starved.get() or (budget := next(budgets, 0)) == 0:
+                else:
                     raise
             else:
                 traces = _snapshot((*spies.values(), *fn_spies(results)))

--- a/optype/infer/_spy.py
+++ b/optype/infer/_spy.py
@@ -1,5 +1,7 @@
 """Recording proxy objects that trace the operations performed on them."""
 
+import dis
+import sys
 from collections.abc import Callable, Generator, Iterator
 from contextvars import ContextVar
 from enum import StrEnum
@@ -35,6 +37,50 @@ class _Marker(StrEnum):
 
 
 _fork: ContextVar[Iterator[bool] | None] = ContextVar("_fork", default=None)
+
+# the yield count for a splatted-call iterator whose arity no bytecode pins: the
+# fallback that `_explore_spies` grows until the fixed-arity call succeeds
+_yields: ContextVar[int] = ContextVar("_yields", default=1)
+# set when a growable splatted-call iterator hits the budget, so `_explore_spies` only
+# grows the budget when a fixed-arity splat actually came up short
+_starved: ContextVar[bool] = ContextVar("_starved", default=False)
+
+
+def _instruction_arg(code: bytes, i: int) -> int:
+    arg = code[i + 1]
+    shift = 8
+    j = i - 2
+    while j >= 0 and dis.opname[code[j]] == "EXTENDED_ARG":
+        arg |= code[j + 1] << shift
+        shift += 8
+        j -= 2
+    return arg
+
+
+def _iter_context() -> "tuple[int | None, bool]":
+    """The fixed arity the caller's unpack demands, and whether it splats into a call.
+
+    `UNPACK_SEQUENCE`/`UNPACK_EX` pin an exact arity; `CALL_FUNCTION_EX` (`f(*x)`) has
+    no local arity signal, so its iterator grows via the `_yields` budget instead.
+    """
+    try:
+        frame = sys._getframe(2)  # _iter_context -> __iter__ -> the consuming frame  # noqa: SLF001
+    except ValueError:
+        return None, False
+    if (i := frame.f_lasti) < 0:
+        return None, False
+    code = frame.f_code.co_code
+    match dis.opname[code[i]]:
+        case "UNPACK_SEQUENCE":
+            return _instruction_arg(code, i), False
+        case "UNPACK_EX":
+            # low byte: items before the star, high byte: after; +1 feeds the star
+            arg = _instruction_arg(code, i)
+            return (arg & 0xFF) + (arg >> 8) + 1, False
+        case "CALL_FUNCTION_EX":
+            return None, True
+        case _:
+            return None, False
 
 
 def _decide() -> bool:
@@ -136,6 +182,8 @@ class _SpyType(type):
 class _SpyObject(_Spy, metaclass=_SpyType):
     __optype_element__: "_SpyObject | None" = None
     __optype_iterator__: bool = False
+    __optype_arity__: "int | None" = None
+    __optype_growable__: bool = False
     # spies are descriptors (`__get__`), so only ever read through the class `__dict__`
     __optype_instance__: "ClassVar[_SpyObject | None]" = None
 
@@ -264,9 +312,19 @@ class _SpyObject(_Spy, metaclass=_SpyType):
     # no need for `__missing__`
 
     def __iter__(self, /) -> "_SpyObject":
+        arity, growable = _iter_context()
+
         if self.__optype_iterator__:
+            if arity is not None:
+                self.__optype_arity__ = arity
+            if growable:
+                self.__optype_growable__ = True
             return self  # an iterator is its own iterable (idempotent `iter()`)
-        return self.__optype_trace_add__("__iter__", (), {}, _iterator_of(self))
+
+        out = _iterator_of(self)
+        out.__optype_arity__ = arity
+        out.__optype_growable__ = growable
+        return self.__optype_trace_add__("__iter__", (), {}, out)
 
     def __reversed__(self, /) -> "_SpyObject":
         return self.__optype_trace_add__("__reversed__", (), {}, _iterator_of(self))
@@ -276,7 +334,13 @@ class _SpyObject(_Spy, metaclass=_SpyType):
 
     # return `Any` instead of `_SpyObject` to avoid an LSP error for `__dir__`
     def __next__(self, /) -> Any:
-        if any(item.attr == "__next__" for item in self.__optype_trace__):
+        # count from the trace, not a field, so a forked run's rollback is reflected
+        served = sum(1 for item in self.__optype_trace__ if item.attr == "__next__")
+        arity, growable = self.__optype_arity__, self.__optype_growable__
+        limit = arity if arity is not None else _yields.get() if growable else 1
+        if served >= limit:
+            if growable and arity is None:
+                _starved.set(True)
             raise StopIteration
         return self.__optype_trace_add__("__next__", (), {}, _element_of(self))
 

--- a/optype/infer/_spy.py
+++ b/optype/infer/_spy.py
@@ -5,6 +5,8 @@ import sys
 from collections.abc import Callable, Generator, Iterator
 from contextvars import ContextVar
 from enum import StrEnum
+from functools import lru_cache
+from types import CodeType
 from typing import Any, ClassVar, NamedTuple, Self, cast, final, override
 
 type _AnyFunc = Callable[..., object]
@@ -40,10 +42,19 @@ _fork: ContextVar[Iterator[bool] | None] = ContextVar("_fork", default=None)
 
 # the yield count for a splatted-call iterator whose arity no bytecode pins: the
 # fallback that `_explore_spies` grows until the fixed-arity call succeeds
-_yields: ContextVar[int] = ContextVar("_yields", default=1)
+_yield_budget: ContextVar[int] = ContextVar("_yield_budget", default=1)
 # set when a growable splatted-call iterator hits the budget, so `_explore_spies` only
 # grows the budget when a fixed-arity splat actually came up short
 _starved: ContextVar[bool] = ContextVar("_starved", default=False)
+
+# the caller's bytecode is a CPython detail; elsewhere fall back to one element
+_CPYTHON = sys.implementation.name == "cpython"
+
+
+@lru_cache(maxsize=256)
+def _co_code(code: CodeType) -> bytes:
+    # `co_code` rebuilds a deoptimized copy on each access, so cache it per code object
+    return code.co_code
 
 
 def _instruction_arg(code: bytes, i: int) -> int:
@@ -57,19 +68,23 @@ def _instruction_arg(code: bytes, i: int) -> int:
     return arg
 
 
-def _iter_context() -> "tuple[int | None, bool]":
+def _iter_context() -> tuple[int | None, bool]:
     """The fixed arity the caller's unpack demands, and whether it splats into a call.
 
     `UNPACK_SEQUENCE`/`UNPACK_EX` pin an exact arity; `CALL_FUNCTION_EX` (`f(*x)`) has
-    no local arity signal, so its iterator grows via the `_yields` budget instead.
+    no local arity signal, so its iterator grows via the `_yield_budget` instead.
     """
+    if not _CPYTHON:
+        return None, False
+
     try:
         frame = sys._getframe(2)  # _iter_context -> __iter__ -> the consuming frame  # noqa: SLF001
     except ValueError:
+        frame = None
+    if frame is None or (i := frame.f_lasti) < 0:
         return None, False
-    if (i := frame.f_lasti) < 0:
-        return None, False
-    code = frame.f_code.co_code
+
+    code = _co_code(frame.f_code)
     match dis.opname[code[i]]:
         case "UNPACK_SEQUENCE":
             return _instruction_arg(code, i), False
@@ -337,7 +352,7 @@ class _SpyObject(_Spy, metaclass=_SpyType):
         # count from the trace, not a field, so a forked run's rollback is reflected
         served = sum(1 for item in self.__optype_trace__ if item.attr == "__next__")
         arity, growable = self.__optype_arity__, self.__optype_growable__
-        limit = arity if arity is not None else _yields.get() if growable else 1
+        limit = arity if arity is not None else _yield_budget.get() if growable else 1
         if served >= limit:
             if growable and arity is None:
                 _starved.set(True)

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -442,6 +442,22 @@ def _takes3(a: Any, _b: Any, _c: Any, /) -> Any:
     return a
 
 
+def _takes9(
+    a: Any,
+    _b: Any,
+    _c: Any,
+    _d: Any,
+    _e: Any,
+    _f: Any,
+    _g: Any,
+    _h: Any,
+    _i: Any,
+    /,
+) -> Any:
+    # exactly 9 positional parameters; its arity falls in a former yield-budget gap
+    return a
+
+
 def _spread(*args: Any) -> Any:
     return _takes3(*args)
 
@@ -1298,6 +1314,33 @@ def test_unpack_splat_no_budget_leak() -> None:
     # `0 + a + b`, surfacing a `CanAdd` (#683)
     sig = infer(lambda x, y, z: (divmod(*divmod(x, y)), sum(z)))  # type: ignore[misc]
     assert "CanAdd" not in sig
+    assert "CanRAdd" in sig  # `z`'s constraint is still inferred, just not doubled
+
+
+def test_unpack_splat_gap_arity() -> None:
+    # a splat into a 9-ary call lands on a budget the old sparse range skipped (#683)
+    assert infer(lambda x: _takes9(*x)) == "[R](x: CanIter[CanNext[R]]) -> R"
+
+
+def test_unpack_args_and_splat() -> None:
+    # `*args` and a growable splat coexist: each grows its own budget instead of the
+    # `*args` retry starving the splat of yields (#683)
+    def f(*args: Any) -> Any:
+        return divmod(*divmod(args[0], args[1]))  # type: ignore[misc]
+
+    sig = infer(f)
+    assert "CanDivmod" in sig
+    assert "CanRDivmod" in sig
+
+
+def test_unpack_splat_error_not_masked() -> None:
+    # a non-arity error from a splat target must surface as-is, not be buried under a
+    # bogus "got N args" after needlessly climbing the whole yield budget (#683)
+    def picky(_a: Any) -> Any:
+        raise ValueError("domain error")
+
+    with pytest.raises(InferError, match="domain error"):
+        infer(lambda x: picky(*x))
 
 
 def test_variadic_mixed() -> None:

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -783,7 +783,7 @@ ITERATOR_CASES: list[tuple[Callable[..., Any], str]] = [
         lambda x: ((i for i in x), 1),
         "[R](x: CanIter[CanNext[R]]) -> tuple[Generator[R], Literal[1]]",
     ),
-    # a fixed-arity unpack reads its arity from the caller's bytecode frame (#683)
+    # fixed-size unpacking (#683)
     (_unpack_pair, "[R](x: CanIter[CanNext[R]]) -> tuple[R, R]"),
     (_unpack_triple, "[R](x: CanIter[CanNext[R]]) -> tuple[R, R, R]"),
     (_unpack_star, "[R](x: CanIter[CanNext[R]]) -> tuple[R, list[R]]"),
@@ -799,7 +799,7 @@ ITERATOR_CASES: list[tuple[Callable[..., Any], str]] = [
         lambda x: {k: v for k, v in x},  # noqa: C416
         "[R: CanHash](x: CanIter[CanNext[CanIter[CanNext[R]]]]) -> dict[R, R]",
     ),
-    # a splat into a fixed-arity call grows the yield budget until the call fits (#683)
+    # a splat into a fixed-arity call (#683)
     (
         lambda x, y: divmod(*divmod(x, y)),  # type: ignore[misc]
         (
@@ -814,19 +814,6 @@ ITERATOR_CASES: list[tuple[Callable[..., Any], str]] = [
         (
             "[T, R](x: CanDivmod[T, CanIter[CanNext[R]]], y: T) -> tuple[R, R]\n"
             "[T, R](x: T, y: CanRDivmod[T, CanIter[CanNext[R]]]) -> tuple[R, R]"
-        ),
-    ),
-    # the splat's grown budget must not leak to a co-occurring `sum`: `z` stays a plain
-    # single-element iterable, exactly as `lambda z: sum(z)` infers it (#683)
-    (
-        lambda x, y, z: (divmod(*divmod(x, y)), sum(z)),  # type: ignore[misc]
-        (
-            "[T, U: CanDivmod[U, R], R, R2]"
-            "(x: CanDivmod[T, CanIter[CanNext[U]]], y: T, "
-            "z: CanIter[CanNext[CanRAdd[Literal[0], R2]]]) -> tuple[R, R2]\n"
-            "[T, U: CanRDivmod[U, R], R, R2]"
-            "(x: T, y: CanRDivmod[T, CanIter[CanNext[U]]], "
-            "z: CanIter[CanNext[CanRAdd[Literal[0], R2]]]) -> tuple[R, R2]"
         ),
     ),
 ]
@@ -1298,12 +1285,19 @@ def test_variadic_exhausted() -> None:
 
 
 def test_unpack_mixed_splat() -> None:
-    # one global yield budget cannot satisfy two splats of different fixed arities
+    # two splats of different fixed arities can't share one budget
     def f(a: Any, b: Any) -> Any:
         return divmod(*a), _takes3(*b)  # type: ignore[misc]
 
     with pytest.raises(InferError):
         infer(f)
+
+
+def test_unpack_splat_no_budget_leak() -> None:
+    # the splat's budget must not leak to `sum(z)`: a 2nd element would chain
+    # `0 + a + b`, surfacing a `CanAdd` (#683)
+    sig = infer(lambda x, y, z: (divmod(*divmod(x, y)), sum(z)))  # type: ignore[misc]
+    assert "CanAdd" not in sig
 
 
 def test_variadic_mixed() -> None:

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -718,6 +718,38 @@ FUNCTION_CASES: list[tuple[Callable[..., Any], str]] = [
     (lambda: functools.partial(print, "a"), "() -> partial"),
 ]
 
+
+def _unpack_pair(x: Any) -> Any:
+    a, b = x
+    return a, b
+
+
+def _unpack_triple(x: Any) -> Any:
+    a, b, c = x
+    return a, b, c
+
+
+def _unpack_star(x: Any) -> Any:
+    a, *b = x
+    return a, b
+
+
+def _unpack_iter(x: Any) -> Any:
+    a, b = iter(x)
+    return a, b
+
+
+def _divmod_unpack(x: Any, y: Any) -> Any:
+    div, mod = divmod(x, y)
+    return div, mod
+
+
+def _unpack_two_seqs(x: Any, y: Any) -> Any:
+    a, b = x
+    c, d, e = y
+    return a, b, c, d, e
+
+
 ITERATOR_CASES: list[tuple[Callable[..., Any], str]] = [
     # lazy builtin iterators are iterated like generators
     (lambda x: map(str, x), "(x: CanIter[CanNext[CanStr]]) -> map[str]"),
@@ -750,6 +782,52 @@ ITERATOR_CASES: list[tuple[Callable[..., Any], str]] = [
     (
         lambda x: ((i for i in x), 1),
         "[R](x: CanIter[CanNext[R]]) -> tuple[Generator[R], Literal[1]]",
+    ),
+    # a fixed-arity unpack reads its arity from the caller's bytecode frame (#683)
+    (_unpack_pair, "[R](x: CanIter[CanNext[R]]) -> tuple[R, R]"),
+    (_unpack_triple, "[R](x: CanIter[CanNext[R]]) -> tuple[R, R, R]"),
+    (_unpack_star, "[R](x: CanIter[CanNext[R]]) -> tuple[R, list[R]]"),
+    (_unpack_iter, "[R](x: CanIter[CanNext[R]]) -> tuple[R, R]"),
+    (
+        _unpack_two_seqs,
+        (
+            "[R, R2](x: CanIter[CanNext[R]], y: CanIter[CanNext[R2]]) "
+            "-> tuple[R, R, R2, R2, R2]"
+        ),
+    ),
+    (
+        lambda x: {k: v for k, v in x},  # noqa: C416
+        "[R: CanHash](x: CanIter[CanNext[CanIter[CanNext[R]]]]) -> dict[R, R]",
+    ),
+    # a splat into a fixed-arity call grows the yield budget until the call fits (#683)
+    (
+        lambda x, y: divmod(*divmod(x, y)),  # type: ignore[misc]
+        (
+            "[T, U: CanDivmod[U, R], R]"
+            "(x: CanDivmod[T, CanIter[CanNext[U]]], y: T) -> R\n"
+            "[T, U: CanRDivmod[U, R], R]"
+            "(x: T, y: CanRDivmod[T, CanIter[CanNext[U]]]) -> R"
+        ),
+    ),
+    (
+        _divmod_unpack,
+        (
+            "[T, R](x: CanDivmod[T, CanIter[CanNext[R]]], y: T) -> tuple[R, R]\n"
+            "[T, R](x: T, y: CanRDivmod[T, CanIter[CanNext[R]]]) -> tuple[R, R]"
+        ),
+    ),
+    # the splat's grown budget must not leak to a co-occurring `sum`: `z` stays a plain
+    # single-element iterable, exactly as `lambda z: sum(z)` infers it (#683)
+    (
+        lambda x, y, z: (divmod(*divmod(x, y)), sum(z)),  # type: ignore[misc]
+        (
+            "[T, U: CanDivmod[U, R], R, R2]"
+            "(x: CanDivmod[T, CanIter[CanNext[U]]], y: T, "
+            "z: CanIter[CanNext[CanRAdd[Literal[0], R2]]]) -> tuple[R, R2]\n"
+            "[T, U: CanRDivmod[U, R], R, R2]"
+            "(x: T, y: CanRDivmod[T, CanIter[CanNext[U]]], "
+            "z: CanIter[CanNext[CanRAdd[Literal[0], R2]]]) -> tuple[R, R2]"
+        ),
     ),
 ]
 
@@ -1217,6 +1295,15 @@ def test_variadic_exhausted() -> None:
     # placeholder growth is bounded; running out reports cleanly
     with pytest.raises(InferError, match="placeholder"):
         infer(lambda *args: args[10_000])
+
+
+def test_unpack_mixed_splat() -> None:
+    # one global yield budget cannot satisfy two splats of different fixed arities
+    def f(a: Any, b: Any) -> Any:
+        return divmod(*a), _takes3(*b)  # type: ignore[misc]
+
+    with pytest.raises(InferError):
+        infer(f)
 
 
 def test_variadic_mixed() -> None:


### PR DESCRIPTION
before

```console
$ optype infer "lambda x, y: divmod(*divmod(x, y))"
InferError: divmod expected 2 arguments, got 1
```

after

```console
$ optype infer "lambda x, y: divmod(*divmod(x, y))"
[T, U: CanDivmod[U, R], R](x: CanDivmod[T, CanIter[CanNext[U]]], y: T) -> R
[T, U: CanRDivmod[U, R], R](x: T, y: CanRDivmod[T, CanIter[CanNext[U]]]) -> R
```

You might've expected the `x.__divmod__`  to return a tuple here, but that's not the most general solution; unpacking only requires for the RHS to be iterable; not a nominal (ew) tuple.

closes #683