### PR TITLE
`infer`: non-greedy overloaded signature exploration

### DIFF
--- a/docs/reference/experimental/infer.md
+++ b/docs/reference/experimental/infer.md
@@ -66,6 +66,25 @@ $ optype infer "lambda x: -x + x"
 [T, R](x: CanNeg[T] & CanRAdd[T, R]) -> R
 ```
 
+A builtin without an `inspect.signature` recovers its parameters from the docstring,
+reporting each documented call form as an overload:
+
+```console
+$ optype infer "iter"
+[R](iterable: CanIter[R]) -> R
+[R](callable: () -> R, sentinel: object) -> Iterator[R]
+```
+
+Unsatisfiable forms are dropped and same-arity forms collapse into one. The docstring is
+also lossy: it marks neither `*args` nor the keyword-only `*`, so both become plain
+positionals. Read these forms as the shape of the call, not a faithful signature:
+
+```console
+$ optype infer "max"
+[T, U: CanGt[T, CanBool], V: CanGt[U | T, CanBool]](iterable: T, default: U, key: V) -> V | U | T
+[T, U: CanGt[T, CanBool], V: CanGt[U | T, CanBool], W: CanGt[V | U | T, CanBool]](arg1: T, arg2: U, args: V, key: W) -> W | V | U | T
+```
+
 ## Intersections
 
 Python has no intersection types, so the `&` is not valid Python: both requirements

--- a/optype/infer/_api.py
+++ b/optype/infer/_api.py
@@ -13,12 +13,16 @@ from ._explore import (
     _declared_defaults,
     _explore_lenient,
     _explore_spies,
-    _parameters,
+    _parameter_forms,
     _Recon,
 )
 from ._render import _Defaults, _Names, signatures
 from ._spy import _AnyFunc, _TraceItem
 from ._values import _Fn, _Gen, _Rec
+
+
+class _SelectError(ValueError):
+    """A selected parameter or position is absent from a particular call form."""
 
 
 def _select(params: Iterable[str | int], names: _Names) -> _Names:
@@ -27,13 +31,13 @@ def _select(params: Iterable[str | int], names: _Names) -> _Names:
         if isinstance(p, int):
             if not -len(names) <= p < len(names):
                 msg = f"no parameter at position {p}"
-                raise ValueError(msg)
+                raise _SelectError(msg)
             selected.append(names[p])
         elif p in names:
             selected.append(p)
         else:
             msg = f"unknown parameter {p!r}"
-            raise ValueError(msg)
+            raise _SelectError(msg)
     return selected or names
 
 
@@ -146,12 +150,11 @@ def _defaults(
     return {}, False, overloads
 
 
-def _infer(func: _AnyFunc, params: tuple[str | int, ...]) -> str:
-    if nin := _numpy.ufunc_nin(func):
-        names = _numpy.ufunc_params(nin)
-        return _numpy.infer_ufunc(func, names, _select(params, names))
-
-    parameters = _parameters(func)
+def _infer_form(
+    func: _AnyFunc,
+    parameters: Mapping[str, Parameter],
+    params: tuple[str | int, ...],
+) -> list[str]:
     selected = _select(params, list(parameters))
     try:
         recon, fallback = _explore_lenient(func, parameters)
@@ -160,10 +163,42 @@ def _infer(func: _AnyFunc, params: tuple[str | int, ...]) -> str:
     if fallback:
         # the rejected parameters render from their defaults; skip the probing
         lines = signatures(recon, parameters, selected, fallback)
-        return "\n".join(dict.fromkeys(lines))
+        return list(dict.fromkeys(lines))
     defaults, negate, overloads = _defaults(func, parameters, selected, recon)
     lines = signatures(recon, parameters, selected, defaults, negate=negate)
-    return "\n".join(dict.fromkeys((*overloads, *lines)))
+    return list(dict.fromkeys((*overloads, *lines)))
+
+
+def _infer(func: _AnyFunc, params: tuple[str | int, ...]) -> str:
+    if nin := _numpy.ufunc_nin(func):
+        names = _numpy.ufunc_params(nin)
+        return _numpy.infer_ufunc(func, names, _select(params, names))
+
+    forms = _parameter_forms(func)
+    if len(forms) == 1:
+        # a lone form's error is the result's; the loop below only tolerates a failed
+        # form because another may still match
+        return "\n".join(_infer_form(func, forms[0], params))
+
+    # one overload per documented form: an unsatisfiable form is dropped and a
+    # `_SelectError` filters one out, but an unexpected error still propagates
+    lines: list[str] = []
+    reasons: list[str] = []
+    misses: list[str] = []
+    for parameters in forms:
+        try:
+            lines += _infer_form(func, parameters, params)
+        except _SelectError as exc:
+            misses.append(str(exc))
+        except InferError as exc:
+            reasons.append(str(exc))
+    if lines:
+        return "\n".join(dict.fromkeys(lines))
+    if reasons:
+        raise InferError("; ".join(dict.fromkeys(reasons)))
+    if misses:
+        raise _SelectError("; ".join(dict.fromkeys(misses)))
+    raise InferError("no inferable call form")
 
 
 def infer(func: _AnyFunc, /, *params: str | int) -> str:

--- a/optype/infer/_explore.py
+++ b/optype/infer/_explore.py
@@ -1,5 +1,6 @@
 """Run a function against spy placeholders and record what happens."""
 
+import gc
 import keyword
 import re
 import warnings
@@ -40,6 +41,7 @@ from ._spy import (
     _starved,
     _TraceItem,
     _yield_budget,
+    as_spy,
 )
 from ._values import _Fn, _Gen, _Rec, _RecRef, _RecVar, _walk, fn_spies
 
@@ -47,14 +49,16 @@ __all__ = (
     "_Recon",
     "_Traces",
     "_declared_defaults",
-    "_doc_params",
+    "_doc_signatures",
     "_explore_lenient",
     "_explore_spies",
+    "_parameter_forms",
     "_parameters",
 )
 
 _RE_DOC_SIGNATURE = re.compile(r"\b(\w+)\(([^)]*)\)")
 _RE_DOC_PARAM = re.compile(r"(?:^|,)\s*\**([a-zA-Z_]\w*)")
+_RE_DOC_ARROW = re.compile(r"\s*->")
 
 _FORK_LIMIT = 64
 _RUN_LIMIT = 256
@@ -109,30 +113,60 @@ def _snapshot(params: Iterable[_SpyObject]) -> _Traces:
     return traces
 
 
-def _doc_params(func: _AnyFunc) -> list[str] | None:
-    name = getattr(func, "__name__", "")
-    if not name:
-        return None
-    for match in _RE_DOC_SIGNATURE.finditer(func.__doc__ or ""):
-        if match[1] != name:
-            continue
-        params = match[2].replace("[", "").replace("]", "")
-        names = _RE_DOC_PARAM.findall(params)
-        # a usage example like `reduce(lambda x, y: ...)` yields keywords, not params
-        if names and not any(map(keyword.iskeyword, names)):
-            return names
+def _doc_param_names(group: str) -> list[str] | None:
+    params = group.replace("[", "").replace("]", "")
+    names = _RE_DOC_PARAM.findall(params)
+    # a usage example like `reduce(lambda x, y: ...)` yields keywords, not params
+    if names and not any(map(keyword.iskeyword, names)):
+        return names
     return None
 
 
-def _parameters(func: _AnyFunc) -> Mapping[str, Parameter]:
+def _doc_signatures(func: _AnyFunc) -> list[list[str]]:
+    """Every documented call form's parameter names, by arity (one per arity).
+
+    Arrow-annotated forms (`name(...) -> ret`) are the real overloads; a docstring's
+    usage examples lack the arrow. When none are annotated (e.g. `next`, `slice`),
+    fall back to the first form. Same-arity forms infer the same structure, so only
+    the first of each arity is kept (its parameter names win).
+    """
+    name = getattr(func, "__name__", "")
+    if not name:
+        return []
+    doc = func.__doc__ or ""
+    arrow_forms: list[list[str]] = []
+    first: list[str] | None = None
+    for match in _RE_DOC_SIGNATURE.finditer(doc):
+        if match[1] != name or (names := _doc_param_names(match[2])) is None:
+            continue
+        if first is None:
+            first = names
+        if _RE_DOC_ARROW.match(doc, match.end()):
+            arrow_forms.append(names)
+    forms = arrow_forms or ([first] if first is not None else [])
+    by_arity: dict[int, list[str]] = {}
+    for f in forms:
+        by_arity.setdefault(len(f), f)
+    return list(by_arity.values())
+
+
+def _parameter_forms(func: _AnyFunc) -> list[Mapping[str, Parameter]]:
+    # the parameters of every call form: the real signature's, else the docstring's
     try:
-        return signature(func).parameters
+        return [signature(func).parameters]
     except TypeError as exc:  # not callable
         raise InferError(str(exc)) from exc
     except ValueError as exc:  # no signature
-        if (names := _doc_params(func)) is None:
+        if not (forms := _doc_signatures(func)):
             raise InferError(str(exc)) from exc
-        return {n: Parameter(n, Parameter.POSITIONAL_OR_KEYWORD) for n in names}
+        return [
+            {n: Parameter(n, Parameter.POSITIONAL_OR_KEYWORD) for n in names}
+            for names in forms
+        ]
+
+
+def _parameters(func: _AnyFunc) -> Mapping[str, Parameter]:
+    return _parameter_forms(func)[0]  # the first call form
 
 
 def _declared_defaults(params: Mapping[str, Parameter]) -> dict[str, object]:
@@ -179,6 +213,20 @@ def _sync[T](agen: AsyncGenerator[T, Any]) -> Generator[T]:
 
 # lazy builtin iterators with a single type argument
 _ITERATOR_TYPES = frozenset({enumerate, filter, map, zip})
+
+# the lazy iterator returned by the 2-argument `iter(callable, sentinel)`
+_CALLABLE_ITERATOR = type(iter(int, None))
+
+
+def _ref0_is_callable() -> bool:
+    # `iter(callable, sentinel)` keeps the callable as its first gc referent on CPython
+    def probe() -> None: ...
+
+    refs = gc.get_referents(iter(probe, object()))
+    return len(refs) == 2 and refs[0] is probe
+
+
+_CALLABLE_FIRST = _ref0_is_callable()
 
 _FUNCTION_TYPES = (
     FunctionType,
@@ -265,21 +313,41 @@ def _next(result: object, path: dict[int, _RecVar | None] | None = None) -> obje
             # `enumerate[R]` is parameterized by the element type, not the yields
             values = [item for _, item in cast("list[tuple[int, object]]", values)]
         out = _Gen([_next(v, path) for v in values], cls.__name__)
+    elif (
+        cls is _CALLABLE_ITERATOR
+        and _CALLABLE_FIRST
+        and len(refs := gc.get_referents(result)) == 2
+        and (fn := as_spy(refs[0])) is not None
+    ):
+        # `iter(callable, sentinel)`: call the callable for the element type; iterating
+        # would stop at the sentinel and pollute it. Referent 0 is the callable (per
+        # `_CALLABLE_FIRST`; not a spy-search, since the sentinel may be a spy too).
+        # Calling `fn()` is deliberate: the recorded `__call__` is what renders the
+        # parameter as `() -> R`, as `_explore_spies` snapshots after this runs.
+        out = _Gen([_next(fn(), path)], "Iterator")
     elif isinstance(_unwrap(result), _FUNCTION_TYPES):
         out = _explore_func(cast("_AnyFunc", result))
     else:
-        # pyright fails miserably here when narrowing types
-        match result:
-            case tuple():
-                out = tuple(_next(item, path) for item in result)  # pyright:ignore[reportUnknownArgumentType,reportUnknownVariableType]
-            case list():
-                out = [_next(item, path) for item in result]  # pyright:ignore[reportUnknownArgumentType,reportUnknownVariableType]
-            case Mapping():
-                # the keys must stay hashable, so only the values recurse
-                out = cls({key: _next(value, path) for key, value in result.items()})  # type:ignore[call-arg] # pyright:ignore[reportCallIssue,reportUnknownVariableType]
-            case _:
-                out = result
+        out = _next_container(cls, result, path)
     return _Rec(var, out) if (var := path.pop(rid)) is not None else out
+
+
+def _next_container(
+    cls: type[object],
+    result: object,
+    path: dict[int, _RecVar | None],
+) -> object:
+    # pyright fails miserably here when narrowing types
+    match result:
+        case tuple():
+            return tuple(_next(item, path) for item in result)  # pyright:ignore[reportUnknownArgumentType,reportUnknownVariableType]
+        case list():
+            return [_next(item, path) for item in result]  # pyright:ignore[reportUnknownArgumentType,reportUnknownVariableType]
+        case Mapping():
+            # the keys must stay hashable, so only the values recurse
+            return cls({key: _next(value, path) for key, value in result.items()})  # type:ignore[call-arg] # pyright:ignore[reportCallIssue,reportUnknownVariableType]
+        case _:
+            return result
 
 
 def _rollback(marks: Iterable[tuple[_SpyObject, int]]) -> None:

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -11,14 +11,16 @@ import random
 import secrets
 import subprocess  # noqa: S404
 import sys
+import warnings
 import weakref
 from collections.abc import Callable
+from inspect import Parameter
 from typing import Any
 
 import pytest
 
-from optype.infer import InferError, InferWarning, infer
-from optype.infer._explore import _doc_params
+from optype.infer import InferError, InferWarning, _api, infer
+from optype.infer._explore import _doc_signatures, _parameter_forms
 from optype.infer._ir import App, Arg, Fn, Lit, Name, Node, Type, render, subtype, union
 
 
@@ -1537,23 +1539,158 @@ def test_not_callable() -> None:
         infer(not_callable)
 
 
-def test_doc_params() -> None:
+def test_doc_signatures() -> None:
     def f() -> None: ...
 
-    f.__doc__ = "f(a, b=1, [c]) -> z"
-    assert _doc_params(f) == ["a", "b", "c"]
+    f.__doc__ = "f(a) -> z\nf(a, b) -> z"
+    assert _doc_signatures(f) == [["a"], ["a", "b"]]
 
-    f.__doc__ = "no signature line here"
-    assert _doc_params(f) is None
+    # defaults and optional-bracket groups reduce to bare parameter names
+    f.__doc__ = "f(a, b=1, [c]) -> z"
+    assert _doc_signatures(f) == [["a", "b", "c"]]
+
+    # same-arity forms render identically, so only the first is kept
+    f.__doc__ = "f(a) -> z\nf(b) -> z\nf(c, d) -> z"
+    assert _doc_signatures(f) == [["a"], ["c", "d"]]
+
+    # no arrow: fall back to the first form (e.g. `next`, `slice`)
+    f.__doc__ = "f(a, b)\nFor example, f(x, y)."
+    assert _doc_signatures(f) == [["a", "b"]]
 
     # a usage example, not a signature: its keyword arg is no parameter name
     f.__doc__ = "Apply f. For example, f(lambda x, y: x + y, [1, 2, 3])."
-    assert _doc_params(f) is None
+    assert _doc_signatures(f) == []
+
+    f.__doc__ = "no signature line here"
+    assert _doc_signatures(f) == []
 
 
 def test_doc_signature() -> None:
-    # builtins like `int` have no signature; fall back to the docstring
-    assert infer(int) == "(x: CanInt | CanIndex) -> int"
+    # builtins like `int` have no signature; fall back to the docstring. The
+    # unsatisfiable `int(x, base)` form is dropped silently, without a warning.
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", InferWarning)
+        assert infer(int) == "(x: CanInt | CanIndex) -> int"
+
+
+def _needs_doc(func: Callable[..., object]) -> pytest.MarkDecorator:
+    # some Python builds strip the call-form lines from a builtin's docstring, leaving
+    # no parameters to recover; only assert the output where the build provides them
+    return pytest.mark.skipif(
+        not _doc_signatures(func),
+        reason=f"{getattr(func, '__name__', func)!r} docstring carries no call forms",
+    )
+
+
+def test_iter() -> None:
+    # the callable_iterator enrichment, independent of `iter`'s own docstring
+    assert infer(lambda f, s: iter(f, s)) == "[R](f: () -> R, s: object) -> Iterator[R]"
+    # the callable is the first argument, not the sentinel: a non-spy callable can't
+    # be probed, so the element type is left opaque rather than blamed on the sentinel
+    assert infer(lambda s: iter(int, s)) == "(s: object) -> callable_iterator"
+
+
+@_needs_doc(iter)
+def test_iter_overloads() -> None:
+    assert infer(iter) == (
+        "[R](iterable: CanIter[R]) -> R\n"
+        "[R](callable: () -> R, sentinel: object) -> Iterator[R]"
+    )
+
+
+@_needs_doc(max)
+@_needs_doc(min)
+def test_max_min() -> None:
+    assert infer(max) == (
+        "[T, U: CanGt[T, CanBool], V: CanGt[U | T, CanBool]]"
+        "(iterable: T, default: U, key: V) -> V | U | T\n"
+        "[T, U: CanGt[T, CanBool], V: CanGt[U | T, CanBool], "
+        "W: CanGt[V | U | T, CanBool]]"
+        "(arg1: T, arg2: U, args: V, key: W) -> W | V | U | T"
+    )
+    assert infer(min) == (
+        "[T, U: CanLt[T, CanBool], V: CanLt[U | T, CanBool]]"
+        "(iterable: T, default: U, key: V) -> V | U | T\n"
+        "[T, U: CanLt[T, CanBool], V: CanLt[U | T, CanBool], "
+        "W: CanLt[V | U | T, CanBool]]"
+        "(arg1: T, arg2: U, args: V, key: W) -> W | V | U | T"
+    )
+
+
+@_needs_doc(max)
+def test_select_filters_forms() -> None:
+    # `iterable` belongs to the first form only; the second is filtered out silently,
+    # not reported as a form with "no satisfying placeholder"
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", InferWarning)
+        assert infer(max, "iterable") == (
+            "[T, U: CanGt[T, CanBool], V: CanGt[U | T, CanBool]]"
+            "(iterable: T) -> V | U | T"
+        )
+    # a name in no form is still a clean selection error
+    with pytest.raises(ValueError, match="unknown parameter"):
+        infer(max, "zzz")
+
+
+@pytest.mark.parametrize(
+    ("func", "expected"),
+    [
+        # forms differing only in parameter name collapse to one (mapping/iterable/...)
+        pytest.param(
+            dict,
+            (
+                "[R: CanHash, R2](mapping: Has['keys', () -> +CanIter[CanNext[R]]]"
+                " & CanGetitem[R, R2]) -> dict[R, R2]"
+            ),
+            marks=_needs_doc(dict),
+        ),
+        pytest.param(str, "(object: CanStr) -> str", marks=_needs_doc(str)),
+        pytest.param(range, "(stop: CanIndex) -> range", marks=_needs_doc(range)),
+        pytest.param(
+            bytes,
+            "(iterable_of_ints: CanBytes) -> bytes",
+            marks=_needs_doc(bytes),
+        ),
+        # the second form raises during exploration and drops out
+        pytest.param(type, "[T](object: T) -> type[T]", marks=_needs_doc(type)),
+        # no arrow forms in the docstring: the single fallback form
+        pytest.param(
+            next,
+            "[R](iterator: CanNext[R], default: object) -> R",
+            marks=_needs_doc(next),
+        ),
+        pytest.param(slice, "(stop: object) -> slice", marks=_needs_doc(slice)),
+    ],
+)
+def test_single_form_builtins(func: Callable[..., Any], expected: str) -> None:
+    # the unsatisfiable forms are omitted silently; that silence is asserted below
+    assert infer(func) == expected
+
+
+@pytest.mark.skipif(
+    len(_parameter_forms(str)) < 2,
+    reason="this build's str docstring exposes a single call form",
+)
+def test_omitted_form_silent() -> None:
+    # dropping a form no placeholder can satisfy is routine, not warning-worthy
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", InferWarning)
+        assert infer(str) == "(object: CanStr) -> str"
+
+
+def test_all_forms_unsatisfiable(monkeypatch: pytest.MonkeyPatch) -> None:
+    # every form fails exploration and yields no line: the reasons surface as one error
+    def boom(*_args: object) -> object:
+        raise TypeError("boom")
+
+    pos = Parameter.POSITIONAL_OR_KEYWORD
+    forms = [
+        {"a": Parameter("a", pos)},
+        {"a": Parameter("a", pos), "b": Parameter("b", pos)},
+    ]
+    monkeypatch.setattr(_api, "_parameter_forms", lambda _func: forms)
+    with pytest.raises(InferError, match="boom"):
+        infer(boom)
 
 
 def test_type() -> None:


### PR DESCRIPTION
before:

```console
$ optype infer "iter"
[R](iterable: CanIter[R]) -> R

$ optype infer "max"
[T, U: CanGt[T, CanBool], V: CanGt[U | T, CanBool]](iterable: T, default: U, key: V) -> V | U | T
```

after:

```console
$ optype infer "iter"
[R](iterable: CanIter[R]) -> R
[R](callable: () -> R, sentinel: object) -> Iterator[R]

$ optype infer "max"
[T, U: CanGt[T, CanBool], V: CanGt[U | T, CanBool]](iterable: T, default: U, key: V) -> V | U | T
[T, U: CanGt[T, CanBool], V: CanGt[U | T, CanBool], W: CanGt[V | U | T, CanBool]](arg1: T, arg2: U, args: V, key: W) -> W | V | U | T
```

Closes #685