### PR TITLE
`infer`: stable `__bool__` and related branching truthiness dunders

### DIFF
--- a/docs/reference/experimental/infer.md
+++ b/docs/reference/experimental/infer.md
@@ -272,6 +272,17 @@ $ optype infer "lambda x: 0 < x < 10"
 [R, R2: CanBool](x: CanGt[Literal[0], R2 & CanBool] & CanLt[Literal[10], R]) -> R | R2
 ```
 
+A predicate is assumed stable within a single call, so repeating it on the same operand
+agrees rather than branching again. A self-contradicting guard is therefore never
+satisfiable, and its body is left untraced:
+
+```console
+$ optype infer "lambda x: x.foo() if (x and not x) else x"
+[T: CanBool](x: T) -> T
+```
+
+Distinct operands stay independent, so `a in x` and `b in x` still branch separately.
+
 ## Variadic parameters
 
 A `*args` parameter that is only passed around as a whole is inferred as a

--- a/optype/infer/_spy.py
+++ b/optype/infer/_spy.py
@@ -12,7 +12,12 @@ from typing import Any, ClassVar, NamedTuple, Self, cast, final, override
 type _AnyFunc = Callable[..., object]
 type _Args = tuple[object, ...]
 type _Kwargs = dict[str, object]
-type _Memo = tuple[object, int | None] | None  # (fork plan, value); None value = absent
+type _Memo = tuple[object, int | None]  # (fork plan, value); None value = absent
+type _KeyedMemo = tuple[object, dict[int, tuple[object, int]]]
+
+
+def _slot(attr: str) -> str:
+    return f"__optype_{attr.strip('_')}__"
 
 
 def _internal(attr: str) -> bool:
@@ -110,10 +115,10 @@ def _decide_stable(spy: "_SpyObject", attr: str, /, *, optional: bool = False) -
     # memoized per run (keyed by the fork plan) so repeats agree; else two disagreeing
     # `len(seq)` send e.g. `random.choice` into a non-terminating `_randbelow(0)`
 
-    slot = f"__optype_{attr.strip('_')}__"
+    slot = _slot(attr)
     plan = _fork.get()
 
-    memo: _Memo = getattr(spy, slot)
+    memo: _Memo | None = getattr(spy, slot)
     if memo is not None and memo[0] is plan:
         if memo[1] is None:
             raise _AbsentError
@@ -127,6 +132,35 @@ def _decide_stable(spy: "_SpyObject", attr: str, /, *, optional: bool = False) -
     value = spy.__optype_trace_add__(attr, (), {}, int(_decide()))
     setattr(spy, slot, (plan, value))
     return value
+
+
+def _decide_keyed(
+    spy: "_SpyObject",
+    attr: str,
+    item: object,
+    /,
+    *,
+    keep_arg: bool,
+) -> bool:
+    # per-operand variant of `_decide_stable`: `y in x` forks once per distinct `y`, so
+    # `y in x and y not in x` agrees within a run while `a in x` and `b in x` stay free.
+    # the cache retains `item` so its `id` can't be reused by a later distinct operand
+    slot = _slot(attr)
+    plan = _fork.get()
+
+    cache: dict[int, tuple[object, int]]
+    memo: _KeyedMemo | None = getattr(spy, slot)
+    if memo is not None and memo[0] is plan:
+        cache = memo[1]
+    else:
+        cache = {}
+        setattr(spy, slot, (plan, cache))
+
+    key = id(item)
+    if key not in cache:
+        args = (item,) if keep_arg else ()
+        cache[key] = item, spy.__optype_trace_add__(attr, args, {}, int(_decide()))
+    return bool(cache[key][1])
 
 
 class _TraceItem(NamedTuple):
@@ -274,7 +308,7 @@ class _SpyObject(_Spy, metaclass=_SpyType):
         return self.__optype_trace_add__("__hash__", (), {}, super().__hash__())
 
     def __bool__(self, /) -> bool:
-        return self.__optype_trace_add__("__bool__", (), {}, _decide())
+        return bool(_decide_stable(self, "__bool__"))
 
     ###
 
@@ -294,13 +328,11 @@ class _SpyObject(_Spy, metaclass=_SpyType):
 
     ###
 
-    # TODO: __mro_entries__
+    def __instancecheck__(self, instance: object, /) -> bool:
+        return _decide_keyed(self, "__instancecheck__", instance, keep_arg=False)
 
-    def __instancecheck__(self, _instance: object, /) -> bool:
-        return self.__optype_trace_add__("__instancecheck__", (), {}, _decide())
-
-    def __subclasscheck__(self, _subclass: object, /) -> bool:
-        return self.__optype_trace_add__("__subclasscheck__", (), {}, _decide())
+    def __subclasscheck__(self, subclass: object, /) -> bool:
+        return _decide_keyed(self, "__subclasscheck__", subclass, keep_arg=False)
 
     ###
 
@@ -345,7 +377,7 @@ class _SpyObject(_Spy, metaclass=_SpyType):
         return self.__optype_trace_add__("__reversed__", (), {}, _iterator_of(self))
 
     def __contains__(self, item: object, /) -> bool:
-        return self.__optype_trace_add__("__contains__", (item,), {}, _decide())
+        return _decide_keyed(self, "__contains__", item, keep_arg=True)
 
     # return `Any` instead of `_SpyObject` to avoid an LSP error for `__dir__`
     def __next__(self, /) -> Any:

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -144,6 +144,10 @@ UNARY_CASES: list[tuple[Callable[[Any], Any], str]] = [
         "[T: CanGt[Literal[0], CanBool] & CanNeg[R], R](x: T) -> T | R",
     ),
     (lambda x: -x if x else x, "[T: CanBool & CanNeg[R], R](x: T) -> R | T"),
+    # `and` returns an operand: falsy `x` yields `x`, truthy `x` yields `not x`
+    (lambda x: x and not x, "[T: CanBool](x: T) -> bool | T"),  # noqa: SIM220
+    # `bool` is stable per run, so the `and` is always falsy and `foo` is unreachable
+    (lambda x: x.foo() if (x and not x) else x, "[T: CanBool](x: T) -> T"),  # noqa: SIM220
     (
         lambda x: (x + 1) if x else (x - 1),
         (
@@ -364,6 +368,27 @@ BINARY_CASES: list[tuple[Callable[[Any, Any], Any], str]] = [
     (lambda x, y: x or y, "[T: CanBool, U](x: T, y: U) -> T | U"),
     (lambda x, y: x if x in y else y, "[T, U: CanContains[T]](x: T, y: U) -> T | U"),
     (lambda x, y: x and y, "[T: CanBool, U](x: T, y: U) -> U | T"),
+    # a predicate is stable per run, so a self-contradicting guard never traces `foo`
+    (
+        lambda x, y: y.foo() if (y in x and y not in x) else x,
+        "[T: CanContains[U], U](x: T, y: U) -> T",
+    ),
+    (
+        lambda x, y: y.foo() if (isinstance(y, x) and not isinstance(y, x)) else x,
+        "[T: CanInstancecheck](x: T, y: object) -> T",
+    ),
+    (
+        lambda x, y: y.foo() if (issubclass(y, x) and not issubclass(y, x)) else x,
+        "[T: CanSubclasscheck](x: T, y: object) -> T",
+    ),
+    # distinct operands stay independent, so this guard is satisfiable and traces `foo`
+    (
+        lambda x, y: y.foo() if (y in x and 0 not in x) else x,
+        (
+            "[T: CanContains[Literal[0] | U], U: Has['foo', () -> +R], R]"
+            "(x: T, y: U) -> T | R"
+        ),
+    ),
     (
         lambda x, y: -x if x else -y if y else x,
         "[T: CanBool & CanNeg[R], R, R2](x: T, y: CanBool & CanNeg[R2]) -> R | R2 | T",
@@ -1357,10 +1382,11 @@ def test_variadic_mixed() -> None:
 
 def test_fork_explosion() -> None:
     # exploration is budgeted: a function that forks on every run raises (timely)
-    # instead of exhaustively walking all 2**100 decision paths
+    # instead of exhaustively walking all 2**100 decision paths. Distinct `x[i]` spies
+    # each fork independently, since one spy's `bool` is stable per run.
     def f(x: Any) -> Any:
-        for _ in range(100):
-            bool(x)
+        for i in range(100):
+            bool(x[i])
         return x
 
     with pytest.raises(InferError, match="completion"):
@@ -1379,9 +1405,10 @@ def test_infer_choice_does_not_hang(choose: Callable[..., Any]) -> None:
 
 
 def test_fork_truncation_warning() -> None:
-    # when the budget runs out before every branch was explored, it warns
+    # when the budget runs out before every branch was explored, it warns. Distinct
+    # `x[i]` spies each fork on `bool`; a single spy's truthiness is stable per run.
     def f(x: Any) -> Any:
-        return [bool(x) for _ in range(10)]
+        return [bool(x[i]) for i in range(10)]
 
     with pytest.warns(InferWarning, match="branch"):
         infer(f)


### PR DESCRIPTION
before:

```console
$ optype infer "lambda x: x.foo() if (x and not x) else x"
[T: CanBool & Has['foo', () -> +R], R](x: T) -> T | R
```

after:

```console
$ optype infer "lambda x: x.foo() if (x and not x) else x"
[T: CanBool](x: T) -> T
```