### PR TITLE
`infer`: yield 2 items by default

### DIFF
--- a/docs/reference/experimental/infer.md
+++ b/docs/reference/experimental/infer.md
@@ -438,6 +438,17 @@ $ optype infer "lambda f, x: map(f, x)"
 [T, R](f: (T) -> R, x: CanIter[CanNext[T]]) -> map[R]
 ```
 
+Iteration yields two elements, so a callable that compares them, like `sorted` or `max`,
+traces the comparison too:
+
+```console
+$ optype infer "lambda xs: sorted(xs)"
+[R: CanLt[R, CanBool]](xs: CanIter[CanNext[R]]) -> list[R]
+
+$ optype infer "lambda xs: max(xs)"
+[R: CanGt[R, CanBool]](xs: CanIter[CanNext[R]]) -> R
+```
+
 ## Unpacking
 
 An unpacking iterates the parameter, and every target shares one element type, like

--- a/optype/infer/_ir.py
+++ b/optype/infer/_ir.py
@@ -1,6 +1,6 @@
 """A minimal algebraic representation of inferred type expressions."""
 
-from collections.abc import Iterable
+from collections.abc import Generator, Iterable
 from dataclasses import dataclass
 from typing import override
 
@@ -273,6 +273,25 @@ def _prefix(op: str, part: Node) -> str:
     """Format a prefix-operated type, parenthesized where precedence requires."""
     inner = render(part)
     return f"{op}({inner})" if isinstance(part, Union | Inter | Fn) else op + inner
+
+
+def names(node: Node | Arg) -> Generator[str]:
+    # every type-name leaf, in order, so typevar uses can be counted
+    match node:
+        case Name(name):
+            yield name
+        case Arg(value=value):
+            yield from names(value)
+        case App(args=parts) | Union(parts) | Inter(parts):
+            for part in parts:
+                yield from names(part)
+        case Fn(params, ret):
+            for part in (*params, ret):
+                yield from names(part)
+        case Not(part) | Polarity(part=part):
+            yield from names(part)
+        case Lit() | Type():
+            return
 
 
 def render(node: Node) -> str:

--- a/optype/infer/_render.py
+++ b/optype/infer/_render.py
@@ -2,7 +2,7 @@
 
 import builtins
 import sys
-from collections import defaultdict
+from collections import Counter, defaultdict
 from collections.abc import Collection, Generator, Iterable, Mapping, Sequence
 from inspect import Parameter, _ParameterKind
 from itertools import groupby
@@ -386,6 +386,7 @@ class _Renderer:
     _rec_body: dict[_RecVar, object]
 
     _pool: list[_SpyObject]
+    _param_spies: list[_SpyObject]
     _group_traces: _Traces
 
     def __init__(
@@ -468,7 +469,55 @@ class _Renderer:
                 pool.append(spy)
             self._vars[id(spy)] = var
         self._pool = pool
+        self._param_spies = param_spies
         self._group_traces = _group_traces(self._vars, reps, traces)
+        self._inline_single_use()
+
+    def _inline_single_use(self) -> None:
+        # a bounded typevar referenced once and absent from the return carries no more
+        # than its bound, so it inlines back into the one spot that uses it
+
+        vars_, reps = self._vars, self._reps
+
+        bounds = {
+            rep: self.traces(self._group_traces.get(rep, ())) for rep in self._named
+        }
+        rendered = [
+            *(self._slot(spy) for spy in self._param_spies),
+            *(node for node in bounds.values() if node is not None),
+            self._union_type(self._results),
+        ]
+        counts = Counter(name for node in rendered for name in _ir.names(node))
+
+        pool_vars = {
+            var: reps.get(sid, sid)
+            for spy in self._pool
+            if (var := vars_[sid := id(spy)]) != _TYPEVAR_TUPLE
+        }
+        inline = {
+            var
+            for var, rep in pool_vars.items()
+            if counts[var] == 1 and bounds[rep] is not None
+        }
+        if not inline:
+            return
+
+        # renumber the survivors back to a gapless `T, U, V, ...`
+        remap = {
+            old: _TYPEVARS[n] if n < len(_TYPEVARS) else f"T{n}"
+            for n, old in enumerate(var for var in pool_vars if var not in inline)
+        }
+
+        self._vars = {
+            sid: remap.get(var, var) for sid, var in vars_.items() if var not in inline
+        }
+        self._pool = [spy for spy in self._pool if id(spy) in self._vars]
+        self._named = {
+            rep: remap.get(var, var)
+            for rep, var in self._named.items()
+            if var not in inline
+        }
+        self._group_traces = _group_traces(self._vars, reps, self._traces)
 
     def _name_results(self, param_ids: set[int], reps: dict[int, int]) -> None:
         for result in self._results:

--- a/optype/infer/_spy.py
+++ b/optype/infer/_spy.py
@@ -45,14 +45,18 @@ class _Marker(StrEnum):
 
 _fork: ContextVar[Iterator[bool] | None] = ContextVar("_fork", default=None)
 
-# the yield count for a splatted-call iterator whose arity no bytecode pins: the
-# fallback that `_explore_spies` grows until the fixed-arity call succeeds
+# the yield count for a splatted-call iterator whose arity no bytecode pins: the exact
+# arity the splat demands, which `_explore_spies` grows into until the call succeeds
 _yield_budget: ContextVar[int] = ContextVar("_yield_budget", default=1)
 # set when a growable splatted-call iterator hits the budget, so `_explore_spies` only
 # grows the budget when a fixed-arity splat actually came up short
 _starved: ContextVar[bool] = ContextVar("_starved", default=False)
 
-# the caller's bytecode is a CPython detail; elsewhere fall back to one element
+# one element exercises no pairwise op, so `sorted`/`min` never reach their elements'
+# `__lt__` (#686); a pair suffices, and `_render` inlines the extra typevar away
+_DEFAULT_YIELD = 2
+
+# the caller's bytecode is a CPython detail; elsewhere fall back to two elements
 _CPYTHON = sys.implementation.name == "cpython"
 
 
@@ -384,7 +388,13 @@ class _SpyObject(_Spy, metaclass=_SpyType):
         # count from the trace, not a field, so a forked run's rollback is reflected
         served = sum(1 for item in self.__optype_trace__ if item.attr == "__next__")
         arity, growable = self.__optype_arity__, self.__optype_growable__
-        limit = arity if arity is not None else _yield_budget.get() if growable else 1
+        limit = (
+            arity
+            if arity is not None
+            else _yield_budget.get()
+            if growable
+            else _DEFAULT_YIELD
+        )
         if served >= limit:
             if growable and arity is None:
                 _starved.set(True)

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -206,10 +206,19 @@ UNARY_CASES: list[tuple[Callable[[Any], Any], str]] = [
         lambda x: {i: str(i) for i in x},
         "[R: CanStr & CanHash](x: CanIter[CanNext[R]]) -> dict[R, str]",
     ),
+    # `0 + a + b` reflects two ways: the total keeps adding (`T` recurs in its bound)
+    # or is absorbed right (`T` is used once, so it inlines)
     (
         lambda x: sum(x),
-        "[R](x: CanIter[CanNext[CanRAdd[Literal[0], R]]]) -> R",
+        (
+            "[T: CanRAdd[Literal[0], CanAdd[T, R]], R](x: CanIter[CanNext[T]]) -> R\n"
+            "[R](x: CanIter[CanNext[CanRAdd[Literal[0] | R, R]]]) -> R"
+        ),
     ),
+    # comparing reducers reach `__lt__`/`__gt__` only once the iterator yields a pair
+    (lambda x: sorted(x), "[R: CanLt[R, CanBool]](x: CanIter[CanNext[R]]) -> list[R]"),
+    (lambda x: min(x), "[R: CanLt[R, CanBool]](x: CanIter[CanNext[R]]) -> R"),
+    (lambda x: max(x), "[R: CanGt[R, CanBool]](x: CanIter[CanNext[R]]) -> R"),
     (lambda x: (x + 1, x + 1), "[R](x: CanAdd[Literal[1], R]) -> tuple[R, R]"),
     (lambda x: (x + 1, x + 2), "[R](x: CanAdd[Literal[1, 2], R]) -> tuple[R, R]"),
     (
@@ -353,11 +362,10 @@ BINARY_CASES: list[tuple[Callable[[Any, Any], Any], str]] = [
     ),
     (lambda x, y: x[y], "[T, R](x: CanGetitem[T, R], y: T) -> R"),
     (lambda x, y: y[str(x)], "[R](x: CanStr, y: CanGetitem[str, R]) -> R"),
-    # `sorted` discards the `key` results, so they are unconstrained; the explicit
-    # `object` keeps the last argument out of the return slot
+    # `sorted` compares the `key` results, so they must be mutually `<`-comparable
     (
         lambda xs, key: sorted(xs, key=key),
-        "[R](xs: CanIter[CanNext[R]], key: (R) -> object) -> list[R]",
+        "[T, R](xs: CanIter[CanNext[R]], key: (R) -> T & CanLt[T, CanBool]) -> list[R]",
     ),
     (lambda x, y: x, "[T](x: T, y: object) -> T"),  # noqa: ARG005
     (lambda x, y: (type(x), type(y)), "[T, U](x: T, y: U) -> tuple[type[T], type[U]]"),
@@ -1152,6 +1160,15 @@ def test_infer_generator() -> None:
     )
 
 
+def test_inline_renumbers_survivors() -> None:
+    # `str`'s element is single-use and inlines away; the surviving `map(g, y)`
+    # typevar, first named `U`, must renumber to `T` to keep the parameters gapless
+    assert infer(lambda x, g, y: (map(str, x), map(g, y))) == (
+        "[T, R](x: CanIter[CanNext[CanStr]], g: (T) -> R, y: CanIter[CanNext[T]])"
+        " -> tuple[map[str], map[R]]"
+    )
+
+
 def test_infer_generator_yields() -> None:
     # heterogeneous yields are sampled and unioned; an empty generator yields Never
     def hetero() -> Any:
@@ -1337,11 +1354,15 @@ def test_unpack_mixed_splat() -> None:
 
 
 def test_unpack_splat_no_budget_leak() -> None:
-    # the splat's budget must not leak to `sum(z)`: a 2nd element would chain
-    # `0 + a + b`, surfacing a `CanAdd` (#683)
-    sig = infer(lambda x, y, z: (divmod(*divmod(x, y)), sum(z)))  # type: ignore[misc]
-    assert "CanAdd" not in sig
-    assert "CanRAdd" in sig  # `z`'s constraint is still inferred, just not doubled
+    # the splat's grown budget (here 3) must not leak to `sum(z)`; isolated, `z` keeps
+    # the default yield of 2, so its `CanAdd` chain stays one level deep (#683, #686)
+    assert infer(lambda x, z: (_takes3(*x), sum(z))) == (
+        "[T: CanRAdd[Literal[0], CanAdd[T, R2]], R, R2]"
+        "(x: CanIter[CanNext[R]], z: CanIter[CanNext[T]]) -> tuple[R, R2]\n"
+        "[R, R2]"
+        "(x: CanIter[CanNext[R]], z: CanIter[CanNext[CanRAdd[Literal[0] | R2, R2]]])"
+        " -> tuple[R, R2]"
+    )
 
 
 def test_unpack_splat_gap_arity() -> None:


### PR DESCRIPTION
before:

```console
$ optype infer "lambda xs: sorted(xs)"
[R](xs: CanIter[CanNext[R]]) -> list[R]
```

after: 

```console
$ optype infer "lambda xs: sorted(xs)"
[R: CanLt[R, CanBool]](xs: CanIter[CanNext[R]]) -> list[R]
```

closes #686