### PR TITLE
`infer`: variadic callable parameter unpacking

### DIFF
--- a/docs/reference/experimental/infer.md
+++ b/docs/reference/experimental/infer.md
@@ -309,6 +309,18 @@ $ optype infer "lambda **kwargs: kwargs"
 [T](**kwargs: T) -> dict[str, T]
 ```
 
+A variadic spread into a callable collapses into a single `*tuple[T, ...]`, so its
+arity tracks the variadic rather than the placeholder count. This also covers element
+spreads like `map` (whose signature and `strict` flag require Python 3.14):
+
+```console
+$ optype infer "lambda f, *args: f(*args)"
+[T, R](f: (*tuple[T, ...]) -> R, *args: T) -> R
+
+$ optype infer "map"
+[T, U, R]((T, *tuple[U, ...]) -> R, CanIter[CanNext[T]], *iterables: CanIter[CanNext[U]], strict: CanBool = False) -> map[R]
+```
+
 ## Parameter defaults
 
 [PEP 696](https://peps.python.org/pep-0696/) type parameter defaults are used when

--- a/optype/infer/_ir.py
+++ b/optype/infer/_ir.py
@@ -4,7 +4,7 @@ from collections.abc import Generator, Iterable
 from dataclasses import dataclass
 from typing import override
 
-type Node = Lit | Type | Name | App | Fn | Union | Inter | Not | Polarity
+type Node = Lit | Type | Name | App | Fn | Union | Inter | Not | Polarity | Unpack
 
 _NOT = "~"  # the type complement prefix
 
@@ -100,6 +100,13 @@ class Polarity:
 
 
 @dataclass(frozen=True, slots=True)
+class Unpack:
+    """A PEP 646 unpacking, e.g. a `*tuple[T, ...]` variadic callable parameter."""
+
+    part: Node
+
+
+@dataclass(frozen=True, slots=True)
 class Union:
     """A `|`-union of two or more types."""
 
@@ -151,6 +158,8 @@ def subtype(sub: Node | Arg, sup: Node | Arg) -> bool:
                     for param, wide in zip(params, wider_params, strict=True)
                 )
             )
+        case Unpack(part), Unpack(wider):
+            result = subtype(part, wider)
         case _:
             result = False
     return result
@@ -288,7 +297,7 @@ def names(node: Node | Arg) -> Generator[str]:
         case Fn(params, ret):
             for part in (*params, ret):
                 yield from names(part)
-        case Not(part) | Polarity(part=part):
+        case Not(part) | Polarity(part=part) | Unpack(part):
             yield from names(part)
         case Lit() | Type():
             return
@@ -324,6 +333,8 @@ def render(node: Node) -> str:
             out = _prefix(_NOT, part)
         case Polarity(sign, part):
             out = _prefix(sign, part)
+        case Unpack(part):
+            out = _prefix("*", part)
         case Union(parts) | Inter(parts):
             sep, dual = (" | ", Inter) if isinstance(node, Union) else (" & ", Union)
             out = sep.join(

--- a/optype/infer/_render.py
+++ b/optype/infer/_render.py
@@ -40,6 +40,7 @@ _TYPEVARS = "TUVWXYZ"
 _TYPEVAR_TUPLE = "*Ts"
 _NEVER = "Never"
 _OBJECT = "object"
+_ELLIPSIS = "..."
 _TUPLE_LIMIT = 16
 
 # the attribute polarity sigils of the fictional inline `Has['name', T]` form
@@ -370,6 +371,7 @@ class _Renderer:
     _fixed: Mapping[str, object]
     _results: list[object]
     _traces: _Traces
+    _count: int  # the `*args` placeholder count used during exploration
 
     _prefix: dict[str, str]
     _nameless: set[str]
@@ -399,6 +401,7 @@ class _Renderer:
         self._spies = spies
         self._results = results
         self._traces = traces
+        self._count = count
 
         self._prefix = {n: _PARAM_PREFIX.get(p.kind, "") for n, p in params.items()}
         self._nameless = {
@@ -576,6 +579,34 @@ class _Renderer:
             out = _ir.Name(_OBJECT)
         return out
 
+    def _collapse_varargs(
+        self,
+        members: Sequence[_Op],
+        pos: list[_ir.Node],
+    ) -> list[_ir.Node]:
+        # the variadic spreads `count` copies of one spy: the placeholder (`f(*args)`)
+        # or its iterated element (`map`); collapse the trailing run to `*tuple[T, ...]`
+        varpos = self._varpos
+        call_args = members[0].args
+        if varpos is None or not call_args:
+            return pos
+
+        tail = call_args[-1]
+        if not isinstance(tail, _SpyObject) or (
+            tail is not varpos and tail is not varpos.__optype_element__
+        ):
+            return pos
+
+        # require every call to splat the same trailing run, else order would decide
+        count = self._count
+        if not all(
+            m.args[-1] is tail and _spy_runs(m.args, tail)[-1] == count for m in members
+        ):
+            return pos
+
+        inner = _ir.App("tuple", (self.return_type(tail), _ir.Name(_ELLIPSIS)))
+        return [*pos[: len(pos) - count], _ir.Unpack(inner)]
+
     def group(self, proto: _Proto, members: Sequence[_Op]) -> _ir.Node:
         if isinstance(proto, tuple):  # coercion protocols, which record no args
             return _ir.Union(tuple(map(_ir.Name, proto)))
@@ -601,7 +632,8 @@ class _Renderer:
         ret = self.returns(members)
 
         if proto == "CanCall":
-            return _ir.Fn(args, _or_object(ret))
+            call_pos = self._collapse_varargs(members, pos)
+            return _ir.Fn((*call_pos, *args[len(pos) :]), _or_object(ret))
 
         if (attr := members[0].attr) is not None:
             # a read is covariant (a property suffices) and a write contravariant
@@ -762,10 +794,10 @@ class _Renderer:
                 return _ir.App("tuple", tuple(parts))
 
             if all(item is spy for item in items):
-                return _ir.App("tuple", (self.return_type(spy), _ir.Name("...")))
+                return _ir.App("tuple", (self.return_type(spy), _ir.Name(_ELLIPSIS)))
 
         if len(items) > _TUPLE_LIMIT:  # e.g. `random.getstate`
-            return _ir.App("tuple", (self._union_type(items), _ir.Name("...")))
+            return _ir.App("tuple", (self._union_type(items), _ir.Name(_ELLIPSIS)))
 
         elems = (self.union((item,)) or _ir.Name(_NEVER) for item in items)
         return _ir.App("tuple", tuple(elems))

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -497,6 +497,10 @@ def _spread(*args: Any) -> Any:
     return _takes3(*args)
 
 
+def _call_spread(f: Any, *args: Any) -> Any:
+    return f(*args)
+
+
 def _kwargs_key(**kwargs: Any) -> Any:
     return kwargs["key"]
 
@@ -547,6 +551,8 @@ VARIADIC_CASES: list[tuple[Callable[..., Any], str]] = [
     (lambda *args: (args[0], len(args)), "[T](*args: T) -> tuple[T, Literal[2]]"),
     (_var_kwargs, "[T](**kwargs: T) -> dict[str, T]"),
     (_sum_kwargs, "[R](**kwargs: CanRAdd[Literal[0], R]) -> R"),
+    # a variadic spread into a callable collapses to `*tuple[T, ...]` (gh-687)
+    (_call_spread, "[T, R](f: (*tuple[T, ...]) -> R, *args: T) -> R"),
 ]
 
 
@@ -807,6 +813,11 @@ ITERATOR_CASES: list[tuple[Callable[..., Any], str]] = [
     (
         lambda f, x: map(f, x),
         "[T, R](f: (T) -> R, x: CanIter[CanNext[T]]) -> map[R]",
+    ),
+    # the variadic iterables collapse into a `*tuple[T, ...]` mapper (gh-687)
+    (
+        lambda f, *iterables: map(f, *iterables),
+        "[T, R](f: (*tuple[T, ...]) -> R, *iterables: CanIter[CanNext[T]]) -> map[R]",
     ),
     (
         lambda x: map(lambda v: lambda: v, x),


### PR DESCRIPTION
before:

```console
$ optype infer "map"
[T, U, R]((T, U, U) -> R, CanIter[CanNext[T]], *iterables: CanIter[CanNext[U]], strict: CanBool = False) -> map[R]
```

after:

```console
$ optype infer "map"
[T, U, R]((T, *tuple[U, ...]) -> R, CanIter[CanNext[T]], *iterables: CanIter[CanNext[U]], strict: CanBool = False) -> map[R]
```

Closes #687