### PR TITLE
`infer`: `EllipsisType`

### DIFF
--- a/optype/infer/_ir.py
+++ b/optype/infer/_ir.py
@@ -1,5 +1,6 @@
 """A minimal algebraic representation of inferred type expressions."""
 
+import types
 from collections.abc import Generator, Iterable
 from dataclasses import dataclass
 from typing import assert_never, override
@@ -322,6 +323,8 @@ def names(node: Node | Arg) -> Generator[str]:
 
 
 def _render_type(cls: type) -> str:
+    if cls is types.EllipsisType:
+        return "EllipsisType"
     prefix = "np." if cls.__module__.partition(".")[0] == "numpy" else ""
     return prefix + cls.__name__
 

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -1290,6 +1290,13 @@ def test_infer_empty_container() -> None:
     assert infer(returns([[]])) == "() -> list[list[Never]]"
 
 
+def test_infer_ellipsis() -> None:
+    # the `...` value is `EllipsisType`, never its unusable `ellipsis` `__name__`
+    assert infer(lambda: ...) == "() -> EllipsisType"
+    assert infer(lambda x: (x, ...)) == "[T](x: T) -> tuple[T, EllipsisType]"
+    assert infer(lambda: [..., ...]) == "() -> list[EllipsisType]"
+
+
 @pytest.mark.skipif(sys.version_info < (3, 15), reason="requires Python 3.15+")
 def test_infer_frozendict() -> None:
     frozendict: Any = getattr(builtins, "frozendict", None)


### PR DESCRIPTION
before:

```console
$ optype infer "lambda: ..."
() -> ellipsis
```

after:

```console
$ optype infer "lambda: ..."
() -> EllipsisType
```

closes #700