### PR TITLE
`infer`: unwrap `GenericAlias` and `TypeForm` support

### DIFF
--- a/docs/reference/experimental/infer.md
+++ b/docs/reference/experimental/infer.md
@@ -245,6 +245,30 @@ $ optype infer "lambda x: int if x else bool"
 (x: CanBool) -> type[int]
 ```
 
+A subscripted generic keeps its arguments, builtin or user-defined:
+
+```console
+$ optype infer "lambda: list[int]"
+() -> type[list[int]]
+
+$ optype infer "lambda: dict[str, int]"
+() -> type[dict[str, int]]
+```
+
+A union or `Callable` has no `type[...]` form, so it renders as a `TypeForm`
+([PEP 747](https://peps.python.org/pep-0747/)):
+
+```console
+$ optype infer "lambda: int | str"
+() -> TypeForm[int | str]
+
+$ optype infer "from collections.abc import Callable
+lambda: Callable[[int], str]"
+() -> TypeForm[(int) -> str]
+```
+
+An origin or argument that doesn't resolve by name keeps the bare `GenericAlias`.
+
 ## Branches
 
 Both sides of a conditional are explored, so the parameter has to satisfy every branch

--- a/optype/infer/_render.py
+++ b/optype/infer/_render.py
@@ -2,8 +2,9 @@
 
 import builtins
 import sys
+import types
 from collections import Counter
-from collections.abc import Collection, Iterable, Mapping, Sequence
+from collections.abc import Callable, Collection, Iterable, Mapping, Sequence
 from inspect import Parameter, _ParameterKind
 from typing import Any, cast, final
 
@@ -34,6 +35,7 @@ from ._spy import (
     as_spy,
 )
 from ._values import _Fn, _Gen, _Rec, _RecRef, _RecVar, _walk, fn_spies
+from optype.inspect import is_generic_alias, is_union_type
 
 _PARAM_PREFIX: dict[_ParameterKind, str] = {
     Parameter.VAR_POSITIONAL: "*",
@@ -45,6 +47,9 @@ _TYPEVAR_TUPLE_NAME = "Ts"  # the PEP 646 typevar-tuple binder, used as `*Ts`
 _NEVER = "Never"
 _OBJECT = "object"
 _TUPLE_LIMIT = 16
+
+# `object`-typed so the `is` check isn't flagged (`Callable` is a special form)
+_CALLABLE_ORIGIN: object = Callable
 
 # the attribute polarity sigils of the fictional inline `Has['name', T]` form
 _READ = _ir.COVARIANT  # a read-only property suffices
@@ -565,11 +570,56 @@ class _Renderer:
             return _ir.Type(cls)
         return None  # a local class has no nameable type, so it stays a bare `type`
 
+    def _type_expr(self, value: object) -> _ir.Node | None:
+        """The type a value *is*, not the type *of* it: `list[int]` -> `list[int]`."""
+        if isinstance(value, type):
+            return self._class_of(value)
+        if is_union_type(value):  # `int | str` and `typing.Union[int, str]` alike
+            parts = self._type_args(value.__args__)
+            return None if parts is None else _ir.union(parts)
+        if is_generic_alias(value):  # builtin `list[int]` and user `Foo[int]` alike
+            if value.__origin__ is _CALLABLE_ORIGIN:
+                # `Callable`'s `__args__` is a flat `(*params, ret)`, not a type row
+                return self._callable_type(value.__args__)
+            origin = self._type_expr(value.__origin__)
+            args = self._type_args(value.__args__)
+            if isinstance(origin, _ir.Type) and args is not None:
+                return _ir.App(_ir.render(origin), tuple(args))
+        return None
+
+    def _callable_type(self, args: tuple[object, ...]) -> _ir.Node | None:
+        """A `Callable[...]` value as the `(params) -> ret` form rendered elsewhere."""
+        *params, ret = args  # `_type_args` renders a `Callable[..., R]`'s `...` too
+        ret_node = self._type_expr(ret)
+        param_nodes = self._type_args(params)
+        if ret_node is None or param_nodes is None:
+            return None
+        return _ir.Fn(tuple(param_nodes), ret_node)
+
+    def _type_args(self, values: Sequence[object]) -> list[_ir.Node] | None:
+        """Every type argument as an annotation node, or `None` if any is unnameable."""
+        args: list[_ir.Node] = []
+        for value in values:
+            node = _ir.Dots() if value is ... else self._type_expr(value)
+            if node is None:
+                return None
+            args.append(node)
+        return args
+
     def _container(self, result: object) -> _ir.Node:
+        if (inner := self._type_expr(result)) is not None:
+            # `type[...]` for a class, `TypeForm[...]` for a union or `Callable`
+            class_form = isinstance(result, type) or (
+                is_generic_alias(result) and result.__origin__ is not _CALLABLE_ORIGIN
+            )
+            return _ir.App("type" if class_form else "TypeForm", (inner,))
+
+        if is_generic_alias(result):
+            # an unnameable origin or argument keeps the honest, if unhelpful, alias
+            return _ir.Type(types.GenericAlias)
+
         cls = type(result)
         match result:
-            case type() if (inner := self._class_of(result)) is not None:
-                return _ir.App("type", (inner,))
             case Mapping():
                 mapping = cast("Mapping[object, object]", result)
                 key = self._value_union(mapping, tuples=True) or _ir.Name(_NEVER)

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -1297,6 +1297,59 @@ def test_infer_ellipsis() -> None:
     assert infer(lambda: [..., ...]) == "() -> list[EllipsisType]"
 
 
+class _MyGeneric[T]: ...  # module-level, so its name resolves
+
+
+def test_infer_generic_alias() -> None:
+    # a subscripted generic denotes the type it spells, not its `GenericAlias` runtime
+    assert infer(lambda: list[int]) == "() -> type[list[int]]"
+    assert infer(lambda: dict[str, int]) == "() -> type[dict[str, int]]"
+    assert infer(lambda: tuple[int, ...]) == "() -> type[tuple[int, ...]]"
+    assert infer(lambda: list[int | None]) == "() -> type[list[int | None]]"
+    assert infer(lambda: list[dict[str, int]]) == "() -> type[list[dict[str, int]]]"
+    assert infer(lambda x: (x, list[int])) == "[T](x: T) -> tuple[T, type[list[int]]]"
+    # a user-defined generic (`typing._GenericAlias`) unwraps like a builtin one
+    assert infer(lambda: _MyGeneric[int]) == "() -> type[_MyGeneric[int]]"
+    assert infer(lambda: list[_MyGeneric[int]]) == "() -> type[list[_MyGeneric[int]]]"
+
+
+def test_infer_generic_alias_union() -> None:
+    # a union has no `type[...]` form; `type[int | str]` means `type[int] | type[str]`
+    assert infer(lambda: int | str) == "() -> TypeForm[int | str]"
+    assert infer(lambda: int | None) == "() -> TypeForm[int | None]"
+
+
+def test_infer_generic_alias_callable() -> None:
+    # a `Callable` has no `type[...]` form either; `TypeForm` over the arrow form
+    assert infer(lambda: Callable[[int], str]) == "() -> TypeForm[(int) -> str]"
+    assert infer(lambda: Callable[..., str]) == "() -> TypeForm[(...) -> str]"
+    assert infer(lambda: list[Callable[[int], str]]) == (
+        "() -> type[list[(int) -> str]]"
+    )
+
+
+def test_infer_generic_alias_unnameable() -> None:
+    # an unnameable origin or argument keeps the unhelpful but honest `GenericAlias`
+    def make_builtin() -> Callable[[], Any]:
+        class Local: ...
+
+        return lambda: list[Local]
+
+    def make_callable() -> Callable[[], Any]:
+        class Local: ...
+
+        return lambda: Callable[[int], Local]
+
+    def make_user() -> Callable[[], Any]:
+        class Local: ...
+
+        return lambda: _MyGeneric[Local]
+
+    assert infer(make_builtin()) == "() -> GenericAlias"
+    assert infer(make_callable()) == "() -> GenericAlias"
+    assert infer(make_user()) == "() -> GenericAlias"
+
+
 @pytest.mark.skipif(sys.version_info < (3, 15), reason="requires Python 3.15+")
 def test_infer_frozendict() -> None:
     frozendict: Any = getattr(builtins, "frozendict", None)


### PR DESCRIPTION
before:

```console
$ optype infer "lambda: list[int]"
() -> GenericAlias

$ optype infer "lambda: int | str"
() -> Union
```

after:

```console
$ optype infer "lambda: list[int]"
() -> type[list[int]]

$ optype infer "lambda: int | str"
() -> TypeForm[int | str]
```

closes #701