### PR TITLE
`infer`: support all `types` types

### DIFF
--- a/docs/reference/experimental/infer.md
+++ b/docs/reference/experimental/infer.md
@@ -200,6 +200,14 @@ $ optype infer "def f(x): del x.spam"
 (x: Has['spam']) -> None
 ```
 
+A builtin object renders by its importable `types` name, so a module is `ModuleType`, a
+code object `CodeType`, etc.
+
+```console
+$ optype infer "def f(): return f.__code__"
+() -> CodeType
+```
+
 ## Classes
 
 `type` reads the class directly instead of dispatching through a dunder, but every

--- a/optype/infer/_ir.py
+++ b/optype/infer/_ir.py
@@ -322,9 +322,20 @@ def names(node: Node | Arg) -> Generator[str]:
             return
 
 
+# the two `types` members that alias another's type, so each type maps to one name
+_TYPE_ALIASES = "LambdaType", "BuiltinMethodType"
+
+# cpython-internal `__name__`s (`ModuleType.__name__ == "module"`) to importable names
+_TYPES_NAMES: dict[type, str] = {
+    tp: name
+    for name, tp in vars(types).items()
+    if isinstance(tp, type) and tp.__name__ != name and name not in _TYPE_ALIASES
+}
+
+
 def _render_type(cls: type) -> str:
-    if cls is types.EllipsisType:
-        return "EllipsisType"
+    if alias := _TYPES_NAMES.get(cls):
+        return alias
     prefix = "np." if cls.__module__.partition(".")[0] == "numpy" else ""
     return prefix + cls.__name__
 

--- a/optype/infer/_render.py
+++ b/optype/infer/_render.py
@@ -626,13 +626,13 @@ class _Renderer:
                 val = self._value_union(mapping.values(), tuples=True) or _ir.Name(
                     _NEVER,
                 )
-                return _ir.App(cls.__name__, (key, val))
+                return _ir.App(_ir.render(_ir.Type(cls)), (key, val))
             case list() | set() | frozenset():
                 inner = self._value_union(
                     cast("Collection[object]", result),
                     tuples=True,
                 )
-                return _ir.App(cls.__name__, (inner or _ir.Name(_NEVER),))
+                return _ir.App(_ir.render(_ir.Type(cls)), (inner or _ir.Name(_NEVER),))
             case tuple() if cls is tuple:
                 return (
                     self._tuple(cast("tuple[object, ...]", result))

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -14,7 +14,8 @@ import sys
 import warnings
 import weakref
 from collections.abc import Callable
-from inspect import Parameter
+from inspect import Parameter, currentframe
+from types import MappingProxyType
 from typing import Any
 
 import pytest
@@ -760,7 +761,7 @@ FUNCTION_CASES: list[tuple[Callable[..., Any], str]] = [
     ),
     (lambda x: [lambda: x], "[T](x: T) -> list[() -> T]"),
     (lambda x: {"get": lambda: x}, "[T](x: T) -> dict[Literal['get'], () -> T]"),
-    (lambda x: {lambda: x}, "(x: object) -> set[function]"),
+    (lambda x: {lambda: x}, "(x: object) -> set[FunctionType]"),
     # ...and so is a function within the yields of a generator
     (_yield_fn, "[T](x: T) -> Generator[() -> T]"),
     (
@@ -782,9 +783,9 @@ FUNCTION_CASES: list[tuple[Callable[..., Any], str]] = [
     (lambda *args: lambda: args, "[*Ts](*args: *Ts) -> () -> tuple[*Ts]"),
     # a recursive function (factory) has an inexpressible type, so it stays opaque,
     # as do variadic parameters and a `partial` of a non-function
-    (_self_return, "(x: object) -> function"),
-    (_fn_factory, "(n: object) -> () -> function"),
-    (lambda x: lambda *args: x, "(x: object) -> function"),  # noqa: ARG005
+    (_self_return, "(x: object) -> FunctionType"),
+    (_fn_factory, "(n: object) -> () -> FunctionType"),
+    (lambda x: lambda *args: x, "(x: object) -> FunctionType"),  # noqa: ARG005
     (lambda f: functools.partial(f, 1), "(f: object) -> partial"),
     (lambda: functools.partial(print, "a"), "() -> partial"),
 ]
@@ -1274,7 +1275,7 @@ def test_returned_function_mutual_recursion() -> None:
     def pong(x: Any) -> Any:  # noqa: ARG001
         return ping
 
-    assert infer(ping) == "(x: object) -> (x: object) -> function"
+    assert infer(ping) == "(x: object) -> (x: object) -> FunctionType"
 
 
 def test_infer_empty_container() -> None:
@@ -1295,6 +1296,17 @@ def test_infer_ellipsis() -> None:
     assert infer(lambda: ...) == "() -> EllipsisType"
     assert infer(lambda x: (x, ...)) == "[T](x: T) -> tuple[T, EllipsisType]"
     assert infer(lambda: [..., ...]) == "() -> list[EllipsisType]"
+
+
+def test_infer_types_aliases() -> None:
+    # render by the importable `types` name, not the cpython-internal `__name__`
+    assert infer(lambda: math) == "() -> ModuleType"
+    assert infer(lambda: (lambda: 0).__code__) == "() -> CodeType"
+    assert infer(lambda: currentframe()) == "() -> FrameType"
+    assert infer(lambda: type.__dict__["__dict__"]) == "() -> GetSetDescriptorType"
+    assert infer(lambda: MappingProxyType({"k": 1})) == (
+        "() -> MappingProxyType[Literal['k'], Literal[1]]"
+    )
 
 
 class _MyGeneric[T]: ...  # module-level, so its name resolves


### PR DESCRIPTION
before

```console
$ optype infer "def f(): return f.__code__"
() -> code

$ optype infer "def f():
    import math
    return math
"
() -> module
```

after:

```console
$ optype infer "def f(): return f.__code__"
() -> CodeType

$ optype infer "def f():
    import math
    return math
"
() -> ModuleType
```

closes #704
closes #705