### PR TITLE
`infer`: reraise exceptions

### DIFF
--- a/docs/reference/experimental/infer.md
+++ b/docs/reference/experimental/infer.md
@@ -663,8 +663,9 @@ the fallback branch is never taken.
 When `infer` can't handle the input, it raises `InferError` (a `NotImplementedError`
 subclass). That's the case for operations without a matching protocol, such as an
 attribute access whose name is not statically known (a computed `getattr`), and for
-arguments that aren't callable to begin with. Exceptions raised from within the
-function itself aren't caught.
+arguments that aren't callable to begin with. A function that never runs to completion,
+such as `lambda: 0 / 0`, raises `InferError` chained from the triggering exception
+(`__cause__`).
 
 Variadic parameters are explored with a few placeholders, retried with more after an
 out-of-range index, a failed unpacking, or a missing `**kwargs` key, and reported as an

--- a/optype/infer/_cli.py
+++ b/optype/infer/_cli.py
@@ -28,4 +28,6 @@ def run(*args: str) -> None:
     try:
         print(infer(eval(code, namespace), *params))
     except (InferError, ValueError) as exc:
-        sys.exit(f"{type(exc).__name__}: {exc}")
+        cause = exc.__cause__
+        detail = f" ({type(cause).__name__}: {cause})" if cause is not None else ""
+        sys.exit(f"{type(exc).__name__}: {exc}{detail}")

--- a/optype/infer/_explore.py
+++ b/optype/infer/_explore.py
@@ -355,6 +355,7 @@ def _explore[T](
     results: list[T] = []
     stack: list[list[bool]] = [[]]
     dropped = False
+    last_exc: Exception | None = None
     for _ in range(_RUN_LIMIT):  # caps the exponential blowup of independent forks
         if not stack:
             break
@@ -380,13 +381,14 @@ def _explore[T](
             _rollback(marks)
         except (InferError, IndexError, KeyError, TypeError, ValueError):
             raise  # signals the driver acts on, not a rejected run
-        except Exception:  # noqa: BLE001
+        except Exception as exc:  # noqa: BLE001
             # the target rejected these spy values (assert, zero-division, ...); skip
+            last_exc = exc
             _rollback(marks)
         finally:
             _fork.reset(token)
     if not results:
-        raise InferError("the function never ran to completion")
+        raise InferError("the function never ran to completion") from last_exc
     if dropped or stack:
         warnings.warn("not every branch was explored", InferWarning, stacklevel=3)
     return results

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -1566,8 +1566,16 @@ def test_target_exception_skipped() -> None:
     def f(x: Any) -> None:  # noqa: ARG001
         raise AssertionError
 
-    with pytest.raises(InferError, match="completion"):
+    with pytest.raises(InferError, match="completion") as excinfo:
         infer(f)
+    assert isinstance(excinfo.value.__cause__, AssertionError)
+
+
+def test_target_exception_cause() -> None:
+    # when no run completes, the target's last exception is chained as the cause
+    with pytest.raises(InferError, match="completion") as excinfo:
+        infer(lambda: 0 / 0)
+    assert isinstance(excinfo.value.__cause__, ZeroDivisionError)
 
 
 def test_target_exception_partial() -> None:


### PR DESCRIPTION
before:

```console
$ optype infer "lambda: 0/0"
InferError: the function never ran to completion
```

after:

```console
$ optype infer "lambda: 0/0"
InferError: the function never ran to completion (ZeroDivisionError: division by zero)
```