### PR TITLE
`infer`: fix overly-narrow `format` string literals

### DIFF
--- a/optype/infer/_explore.py
+++ b/optype/infer/_explore.py
@@ -36,6 +36,7 @@ from ._spy import (
     _fork,
     _Marker,
     _own_spy,
+    _SpyBytes,
     _SpyObject,
     _SpyStr,
     _starved,
@@ -160,6 +161,15 @@ def _parameters(func: _AnyFunc) -> Mapping[str, Parameter]:
 def _declared_defaults(params: Mapping[str, Parameter]) -> dict[str, object]:
     """The declared parameter defaults, by name."""
     return {n: p.default for n, p in params.items() if p.default is not Parameter.empty}
+
+
+def _typed_default(value: object) -> object:
+    """A rejected default's type is known, but its value is not, so widen it."""
+    if isinstance(value, str):
+        return _SpyStr(value)
+    if isinstance(value, bytes):
+        return _SpyBytes(value)
+    return value
 
 
 def _await[R](coro: Coroutine[Any, Any, R]) -> R:
@@ -495,7 +505,9 @@ def _explore_spies(
             _yield_budget.set(budget)
 
             # a fresh `self` instance per attempt, so a mutated one cannot leak
-            fixed = _fixed_self(func, params) | {n: params[n].default for n in fix}
+            fixed = _fixed_self(func, params) | {
+                n: _typed_default(params[n].default) for n in fix
+            }
             spies, args, kwds = _placeholders(params, count, keys, omit, fixed)
             try:
                 results, deprecated = _explore(func, args, kwds)
@@ -562,4 +574,7 @@ def _explore_lenient(
         with suppress(Exception):
             exploration = _explore_spies(func, params, fix=fix - {name})
             fix.discard(name)
-    return exploration, defaults
+    # a still-fixed default widens to its type; a promoted one keeps its literal
+    return exploration, {
+        name: exploration.fixed.get(name, value) for name, value in defaults.items()
+    }

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -1071,9 +1071,7 @@ def test_method_descriptor() -> None:
     assert infer(object.__str__) == "(object) -> str"
     assert infer(dict[Any, Any].get) == "[T = None](dict, CanHash, T = None) -> T"
     # `memoryview()` is constructed from a spy through its `__buffer__`
-    assert infer(memoryview.tobytes) == (
-        "(memoryview, order: Literal['C'] = 'C') -> bytes"
-    )
+    assert infer(memoryview.tobytes) == "(memoryview, order: str = 'C') -> bytes"
 
 
 def test_method_descriptor_fixed_defaults() -> None:
@@ -1083,9 +1081,11 @@ def test_method_descriptor_fixed_defaults() -> None:
         "(str, sep: None = None, maxsplit: CanIndex = -1) -> list[Never]"
     )
     assert infer(bytes.decode) == (
-        "(bytes, encoding: Literal['utf-8'] = 'utf-8', "
-        "errors: Literal['strict'] = 'strict') -> str"
+        "(bytes, encoding: str = 'utf-8', errors: str = 'strict') -> str"
     )
+    # a rejected default widens to its type, both for the parameter and where the
+    # value flows on (the `format_spec` reaches `value.__format__`)
+    assert infer(format) == "(CanFormat[str], str = '') -> str"
 
 
 def test_method_descriptor_unsupported() -> None:


### PR DESCRIPTION
before:

```console
$ optype infer "format"
(CanFormat[Literal['']], Literal[''] = '') -> str
```

after:

```console
$ optype infer "format"
(CanFormat[str], str = '') -> str
```


closes #689