### PR TITLE
`infer`: strict mode

### DIFF
--- a/docs/infer.md
+++ b/docs/infer.md
@@ -709,11 +709,19 @@ out-of-range index, a failed unpacking, or a missing `**kwargs` key, and reporte
 reports their count, and `args` and `kwargs` are never empty.
 
 The number of explored branches is capped, so a function with many of them gets a
-signature that only covers the explored ones, along with an `InferWarning`.
+signature that only covers the explored ones, along with an `InferWarning` that
+categorizes each coverage gap (the branch or run budget) and names the affected call
+form. The `optype infer` command prints these to standard error, leaving the signature
+alone on standard output. Pass `strict=True` to raise an `InferError` instead of
+returning a provisional signature.
 
 It can only observe operations that go through a dunder method. Anything that inspects a
 parameter at the C level is invisible, so a parameter passed to `id()`, `isinstance()`,
 or an identity check (`is`) is reported as `object` rather than its real requirement.
+A branch taken on the concrete magnitude of a derived integer is invisible for the same
+reason: a spy reports `len`, `int`, or `index` as a small placeholder value, so a path
+gated on it (`len(x) > 5`, or work done only on a loop's fifth element) is not explored,
+and the requirements behind it are missed.
 
 !!! warning "Generic bounds"
 

--- a/docs/reference/experimental/infer.md
+++ b/docs/reference/experimental/infer.md
@@ -23,7 +23,7 @@ more.
 ## `infer`
 
 ```python
-def infer(func, /, *params: str | int) -> str: ...
+def infer(func, /, *params: str | int, strict: bool = False) -> str: ...
 ```
 
 Infer the `optype` protocol(s) required of `func`'s parameters, returned as the inferred
@@ -42,7 +42,9 @@ Pass parameter names or positions to report only those parameters:
 '[T, R](x: CanGetitem[T, R]) -> R'
 ```
 
-Raises [`InferError`](#infererror) when `func` is not supported.
+Raises [`InferError`](#infererror) when `func` is not supported. When exploration is
+incomplete it emits an [`InferWarning`](#inferwarning) and still returns a provisional
+signature; pass `strict=True` to raise an `InferError` instead.
 
 ## `InferError`
 
@@ -53,5 +55,8 @@ parameter that requires a value no placeholder can provide.
 ## `InferWarning`
 
 A subclass of `RuntimeWarning`, emitted when `infer` could not explore the function
-exhaustively, such as when the branch budget runs out. The returned signature then only
-covers the explored forms.
+exhaustively, such as when the branch or run budget runs out. The message categorizes
+each coverage gap and names the affected call form, and the returned signature then only
+covers the explored paths. The `optype infer` command prints the warning to standard
+error, leaving the signature alone on standard output. Pass `strict=True` to `infer` to
+raise an [`InferError`](#infererror) instead.

--- a/optype/infer/.ruff.toml
+++ b/optype/infer/.ruff.toml
@@ -4,6 +4,7 @@ cache-dir = "../../.ruff_cache"
 [lint.per-file-ignores]
 "_api.py" = ["PLR0402"]
 "_cli.py" = ["S102", "S307", "T201"]
+"_explore.py" = ["PLR0914"]
 "_numpy.py" = ["PLR0402"]
 "_protocols.py" = ["PLR0402"]
 "_render.py" = ["PLR0402"]

--- a/optype/infer/_api.py
+++ b/optype/infer/_api.py
@@ -1,16 +1,18 @@
 """The `infer` entry point: explore, probe the defaults, render."""
 
+import warnings
 from collections.abc import Iterable, Mapping
 from inspect import Parameter
 
 # `from . import` would import the package itself, which imports this module
 import optype.infer._numpy as _numpy
-from ._errors import InferError
+from ._errors import InferError, InferWarning
 from ._explore import (
     _declared_defaults,
     _Exploration,
     _explore_lenient,
     _explore_spies,
+    _Gap,
     _parameter_forms,
 )
 from ._render import _Defaults, _Names, signatures
@@ -70,6 +72,7 @@ def _bind_exploration(exp: _Exploration, defaults: _Defaults) -> _Exploration:
         exp.var_count,
         exp.fixed,
         exp.deprecated,
+        exp.gaps,
     )
 
 
@@ -128,12 +131,16 @@ def _infer_form(
     func: _AnyFunc,
     parameters: Mapping[str, Parameter],
     params: tuple[str | int, ...],
+    gaps: set[_Gap],
 ) -> list[str]:
     selected = _select(params, list(parameters))
     try:
         exploration, fallback = _explore_lenient(func, parameters)
     except (IndexError, TypeError, ValueError) as exc:
         raise InferError(str(exc)) from exc
+    if exploration.gaps:
+        where = f"({', '.join(parameters)})"
+        gaps.update(_Gap(g.kind, g.where or where) for g in exploration.gaps)
     if fallback:
         # the rejected parameters render from their defaults; skip the probing
         lines = signatures(exploration, parameters, selected, fallback)
@@ -143,7 +150,7 @@ def _infer_form(
     return list(dict.fromkeys((*overloads, *lines)))
 
 
-def _infer(func: _AnyFunc, params: tuple[str | int, ...]) -> str:
+def _infer(func: _AnyFunc, params: tuple[str | int, ...], gaps: set[_Gap]) -> str:
     if nin := _numpy.ufunc_nin(func):
         names = _numpy.ufunc_params(nin)
         return _numpy.infer_ufunc(func, names, _select(params, names))
@@ -152,7 +159,7 @@ def _infer(func: _AnyFunc, params: tuple[str | int, ...]) -> str:
     if len(forms) == 1:
         # a lone form's error is the result's; the loop below only tolerates a failed
         # form because another may still match
-        return "\n".join(_infer_form(func, forms[0], params))
+        return "\n".join(_infer_form(func, forms[0], params, gaps))
 
     # one overload per documented form: an unsatisfiable form is dropped and a
     # `_SelectError` filters one out, but an unexpected error still propagates
@@ -161,7 +168,7 @@ def _infer(func: _AnyFunc, params: tuple[str | int, ...]) -> str:
     misses: list[str] = []
     for parameters in forms:
         try:
-            lines += _infer_form(func, parameters, params)
+            lines += _infer_form(func, parameters, params, gaps)
         except _SelectError as exc:
             misses.append(str(exc))
         except InferError as exc:
@@ -175,7 +182,7 @@ def _infer(func: _AnyFunc, params: tuple[str | int, ...]) -> str:
     raise InferError("no inferable call form")
 
 
-def infer(func: _AnyFunc, /, *params: str | int) -> str:
+def infer(func: _AnyFunc, /, *params: str | int, strict: bool = False) -> str:
     """Infer the `optype` protocol(s) required of `func`'s parameters.
 
     Pass parameter names or positions to report only those parameters.
@@ -183,12 +190,27 @@ def infer(func: _AnyFunc, /, *params: str | int) -> str:
     >>> print(infer(lambda x: x + 1))
     [R](x: CanAdd[Literal[1], R]) -> R
 
+    Because `infer` runs the function against placeholders, it can only observe
+    the paths those placeholders drive. When exploration is incomplete it emits an
+    `InferWarning` naming the affected call form; pass `strict=True` to raise an
+    `InferError` instead of returning a provisional signature.
+
     Raises:
         InferError: If `func` is not supported, such as a non-callable, an
             operation without a matching protocol, or a parameter that requires
-            a value that no placeholder can provide.
+            a value that no placeholder can provide; or, with `strict=True`, if
+            the function could not be explored exhaustively.
     """
+    gaps: set[_Gap] = set()
     try:
-        return _infer(func, params)
+        result = _infer(func, params, gaps)
     except RecursionError as exc:
         raise InferError("the result is nested too deeply") from exc
+    if gaps:
+        detail = "; ".join(sorted(g.message() for g in gaps))
+        if strict:
+            msg = f"not exhaustively explored: {detail}"
+            raise InferError(msg)
+        msg = f"not every branch was explored: {detail}"
+        warnings.warn(msg, InferWarning, stacklevel=2)
+    return result

--- a/optype/infer/_cli.py
+++ b/optype/infer/_cli.py
@@ -2,8 +2,9 @@
 
 import ast
 import sys
+import warnings
 
-from optype.infer import InferError, infer
+from optype.infer import InferError, InferWarning, infer
 
 
 def run(*args: str) -> None:
@@ -26,8 +27,15 @@ def run(*args: str) -> None:
     exec(compile(ast.Module(body[:-1], []), "<expr>", "exec"), namespace)
     code = compile(ast.Expression(last.value), "<expr>", "eval")
     try:
-        print(infer(eval(code, namespace), *params))
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always", InferWarning)
+            signature = infer(eval(code, namespace), *params)
     except (InferError, ValueError) as exc:
         cause = exc.__cause__
         detail = f" ({type(cause).__name__}: {cause})" if cause is not None else ""
         sys.exit(f"{type(exc).__name__}: {exc}{detail}")
+
+    print(signature)
+    for entry in caught:
+        if issubclass(entry.category, InferWarning):
+            print(f"warning: {entry.message}", file=sys.stderr)

--- a/optype/infer/_explore.py
+++ b/optype/infer/_explore.py
@@ -16,6 +16,8 @@ from collections.abc import (
 )
 from contextlib import suppress
 from contextvars import ContextVar
+from dataclasses import dataclass
+from enum import StrEnum
 from functools import partial
 from inspect import Parameter, isasyncgen, iscoroutine, isgenerator, signature
 from itertools import islice
@@ -28,7 +30,7 @@ from types import (
 )
 from typing import Any, NamedTuple, cast
 
-from ._errors import InferError, InferWarning
+from ._errors import InferError
 from ._spy import (
     _AbsentError,
     _AnyFunc,
@@ -62,6 +64,24 @@ _KWARGS_LIMIT = 8  # max injected `**kwargs` keys
 _YIELD_COUNTS = tuple(range(2, 17))
 
 
+class _GapKind(StrEnum):
+    """A reason the exploration could not cover every path."""
+
+    BRANCH_BUDGET = "branch budget exhausted"
+    RUN_BUDGET = "run budget exhausted"
+
+
+@dataclass(frozen=True, slots=True)
+class _Gap:
+    """A coverage gap: a path the exploration left unexplored."""
+
+    kind: _GapKind
+    where: str = ""  # the affected call form, e.g. "(x, y)"
+
+    def message(self) -> str:
+        return f"{self.kind}{f' in {self.where}' if self.where else ''}"
+
+
 class _Exploration(NamedTuple):
     """What one exploration of a function against spy placeholders produced."""
 
@@ -71,6 +91,7 @@ class _Exploration(NamedTuple):
     var_count: int  # the `*args` placeholder count
     fixed: Mapping[str, object]  # parameters passed as-is, not spies
     deprecated: str | None = None  # a `DeprecationWarning` message raised when called
+    gaps: frozenset[_Gap] = frozenset()  # the paths left unexplored
 
 
 def _reachable(params: Iterable[object]) -> Generator[_SpyObject]:
@@ -383,7 +404,7 @@ def _explore[T](
     func: Callable[..., T] | Callable[..., Coroutine[Any, None, T]],
     args: Sequence[object],
     kwds: Mapping[str, object],
-) -> tuple[list[T], str | None]:
+) -> tuple[list[T], str | None, frozenset[_Gap]]:
     results: list[T] = []
     deprecated: str | None = None
     stack: list[list[bool]] = [[]]
@@ -424,9 +445,9 @@ def _explore[T](
             _fork.reset(token)
     if not results:
         raise InferError("the function never ran to completion") from last_exc
-    if dropped or stack:
-        warnings.warn("not every branch was explored", InferWarning, stacklevel=3)
-    return results, deprecated
+    hits = (dropped, _GapKind.BRANCH_BUDGET), (bool(stack), _GapKind.RUN_BUDGET)
+    gaps = frozenset(_Gap(kind) for hit, kind in hits if hit)
+    return results, deprecated, gaps
 
 
 def _fixed_self(func: _AnyFunc, params: Mapping[str, Parameter]) -> dict[str, object]:
@@ -510,7 +531,7 @@ def _explore_spies(
             }
             spies, args, kwds = _placeholders(params, count, keys, omit, fixed)
             try:
-                results, deprecated = _explore(func, args, kwds)
+                results, deprecated, gaps = _explore(func, args, kwds)
                 results = [_next(r) for r in results]
             except KeyError as exc:
                 key = exc.args[0] if exc.args else None
@@ -548,6 +569,7 @@ def _explore_spies(
                     count,
                     fixed,
                     deprecated,
+                    gaps,
                 )
     finally:
         _starved.reset(starve_token)

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -21,7 +21,7 @@ from typing import Any
 import pytest
 
 from optype.infer import InferError, InferWarning, _api, infer
-from optype.infer._explore import _doc_signatures, _parameter_forms
+from optype.infer._explore import _doc_signatures, _Gap, _GapKind, _parameter_forms
 from optype.infer._ir import (
     App,
     Arg,
@@ -1619,6 +1619,39 @@ def test_fork_truncation_warning() -> None:
         infer(f)
 
 
+def _budget_exhausting(x: Any) -> Any:
+    return [bool(x[i]) for i in range(10)]
+
+
+def test_gap_names_form() -> None:
+    # the warning categorizes the gap and names the affected call form
+    with pytest.warns(InferWarning, match=r"run budget exhausted in \(x\)"):
+        infer(_budget_exhausting)
+
+
+def test_strict_raises_on_gap() -> None:
+    # the same incompleteness that warns by default fails closed under `strict`
+    with pytest.warns(InferWarning):
+        assert isinstance(infer(_budget_exhausting), str)
+    with pytest.raises(InferError, match="not exhaustively explored"):
+        infer(_budget_exhausting, strict=True)
+
+
+def test_strict_silent_when_complete() -> None:
+    # an exhaustively explored function neither warns nor raises under `strict`
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", InferWarning)
+        result = infer(lambda x: x + 1, strict=True)
+    assert result == "[R](x: CanAdd[Literal[1], R]) -> R"
+
+
+def test_gap_message_and_dedup() -> None:
+    assert _Gap(_GapKind.RUN_BUDGET, "(x)").message() == "run budget exhausted in (x)"
+    assert _Gap(_GapKind.BRANCH_BUDGET).message() == "branch budget exhausted"
+    # frozen and slotted, so equal gaps collapse in a set
+    assert len({_Gap(_GapKind.RUN_BUDGET), _Gap(_GapKind.RUN_BUDGET)}) == 1
+
+
 def test_target_exception_skipped() -> None:
     # a non-protocol error from the target marks a failed run; it never escapes
     def f(x: Any) -> None:  # noqa: ARG001
@@ -2029,3 +2062,12 @@ def test_cli_infer_error() -> None:
     out = _run_cli("-m", "optype", "infer", "lambda x, y: getattr(x, str(y))")
     assert out.returncode == 1
     assert out.stderr.startswith("InferError: no protocol")
+
+
+def test_cli_warns_on_stderr() -> None:
+    # an incomplete exploration keeps the signature on stdout and the warning on stderr
+    out = _run_cli("-m", "optype", "infer", "lambda x: [bool(x[i]) for i in range(10)]")
+    assert out.returncode == 0
+    assert out.stdout.startswith("(x: CanGetitem")
+    assert "warning:" in out.stderr
+    assert "branch" in out.stderr


### PR DESCRIPTION
before:

```console
$ optype infer "lambda x: [bool(x[i]) for i in range(10)]"
(x: CanGetitem[Literal[0, 1, 2, 3, 4, 5, 6, 7, 8, 9], CanBool]) -> list[Literal[True]] | list[Literal[True, False]]
```

after:

```console
$ optype infer "lambda x: [bool(x[i]) for i in range(10)]"
(x: CanGetitem[Literal[0, 1, 2, 3, 4, 5, 6, 7, 8, 9], CanBool]) -> list[Literal[True]] | list[Literal[True, False]]
warning: incomplete exploration: run budget exhausted in (x)
```

`infer(..., strict=True)` raises `InferError` instead of returning a provisional signature.