### PR TITLE
`infer`: presence-dispatch overloads

### DIFF
--- a/docs/infer.md
+++ b/docs/infer.md
@@ -692,9 +692,29 @@ placeholder arguments (no real side effects, no reliance on concrete values). Th
 extends to anything it returns: a returned function is called with placeholders of its
 own, and a returned lazy iterator is iterated. A returned function that raises during
 this exploration is not treated as an error: its type stays an opaque `function`.
-An attribute probe with a fallback, such as `hasattr` or `getattr` with a default,
-reports the attribute as a requirement anyway: a placeholder has every attribute, so
-the fallback branch is never taken.
+
+A single-parameter function that dispatches on an attribute's presence (`hasattr`,
+`getattr` with a default, or `try`/`except AttributeError`) is explored again with the
+attribute forced absent, to reach the branch a placeholder otherwise hides. Because the
+attribute is tolerated rather than required, the parameter widens past `Has[...]`. When
+the return ignores the attribute's value, a single overload covers it, its return the
+union of both branches (so a `hasattr` predicate accepts any object and returns `bool`);
+when the present branch returns the value, that overload stays over an `object` fallback
+(the only sound supertype of an arbitrary present return):
+
+```pycon
+>>> print(infer(lambda x: hasattr(x, "spam")))
+(x: object) -> bool
+>>> print(infer(lambda x: 0 if hasattr(x, "spam") else 1))
+(x: object) -> int
+>>> print(infer(lambda x: getattr(x, "spam", None)))
+[R](x: Has['spam', +R]) -> R
+(x: object) -> object
+```
+
+Anything else keeps the strict baseline that requires the attribute: more than one
+parameter, several presence-tests at once, a present branch that needs more than the
+attribute itself, or an absent branch that can't run on placeholders (as with `dict`).
 
 When `infer` can't handle the input, it raises `InferError` (a `NotImplementedError`
 subclass). That's the case for operations without a matching protocol, such as an
@@ -709,19 +729,15 @@ out-of-range index, a failed unpacking, or a missing `**kwargs` key, and reporte
 reports their count, and `args` and `kwargs` are never empty.
 
 The number of explored branches is capped, so a function with many of them gets a
-signature that only covers the explored ones, along with an `InferWarning` that
-categorizes each coverage gap (the branch or run budget) and names the affected call
-form. The `optype infer` command prints these to standard error, leaving the signature
-alone on standard output. Pass `strict=True` to raise an `InferError` instead of
-returning a provisional signature.
+signature that only covers the explored ones, along with an `InferWarning` that names the
+gap and the affected call form. The CLI prints it to standard error; `strict=True` raises
+an `InferError` instead.
 
 It can only observe operations that go through a dunder method. Anything that inspects a
 parameter at the C level is invisible, so a parameter passed to `id()`, `isinstance()`,
-or an identity check (`is`) is reported as `object` rather than its real requirement.
-A branch taken on the concrete magnitude of a derived integer is invisible for the same
-reason: a spy reports `len`, `int`, or `index` as a small placeholder value, so a path
-gated on it (`len(x) > 5`, or work done only on a loop's fifth element) is not explored,
-and the requirements behind it are missed.
+or an identity check (`is`) is reported as `object` rather than its real requirement. The
+same blind spot hides a branch on a derived integer: `len`, `int`, and `index` return a
+small placeholder, so `len(x) > 5` is never explored.
 
 !!! warning "Generic bounds"
 

--- a/optype/infer/_analyze.py
+++ b/optype/infer/_analyze.py
@@ -6,7 +6,7 @@ from itertools import groupby
 from typing import cast
 
 from ._protocols import _DUNDER_ATTR, _DUNDER_CAN_R, _DUNDER_CLASS_ATTR
-from ._spy import _own_spy, _SpyObject, _TraceItem, _Traces, as_spy
+from ._spy import _Marker, _own_spy, _Spy, _SpyObject, _TraceItem, _Traces, as_spy
 from ._values import _children, _Fn, _Gen, _Rec, _RecRef, _walk
 
 type _Producer = Mapping[int, tuple[_SpyObject, _TraceItem]]
@@ -17,6 +17,75 @@ def return_spies(value: object) -> Generator[_SpyObject]:
     for node in _walk(value):
         if (spy := as_spy(node)) is not None:
             yield spy
+
+
+def dispatch_candidates(
+    spies: Mapping[str, _SpyObject],
+    traces: _Traces,
+) -> list[tuple[str, str]]:
+    """The `(parameter, attribute)` reads on `spies`, to probe for presence-dispatch."""
+    return list(
+        dict.fromkeys(
+            (param, name)
+            for param, spy in spies.items()
+            for item in traces.get(id(spy), ())
+            if item.attr == "__getattr__" and item.args
+            if isinstance(name := item.args[0], str) and not isinstance(name, _Spy)
+        ),
+    )
+
+
+def _param_traces(
+    spies: Mapping[str, _SpyObject],
+    traces: _Traces,
+    param: str,
+) -> Sequence[_TraceItem]:
+    """The recorded ops on `param`'s spy, empty if it has none."""
+    spy = spies.get(param)
+    return () if spy is None else traces.get(id(spy), ())
+
+
+def absent_verdict(
+    spies: Mapping[str, _SpyObject],
+    traces: _Traces,
+    param: str,
+    name: str,
+) -> bool | None:
+    """How forcing `name` absent resolves `param`, from one scan of its trace.
+
+    `None`: absence not tolerated, no dispatch. `True`: only the absence remains, widen
+    to `object`. `False`: a present-branch read survives, keep an `object` fallback.
+    """
+    items = _param_traces(spies, traces, param)
+    marker = "__getattr__", name
+    if not any(item.attr == _Marker.ABSENT and item.args == marker for item in items):
+        return None
+    return all(item.attr == _Marker.ABSENT for item in items)
+
+
+def requires_only_presence(
+    spies: Mapping[str, _SpyObject],
+    traces: _Traces,
+    param: str,
+    name: str,
+) -> bool:
+    """Whether `param`'s sole requirement is the bare presence of `name`.
+
+    Every op must read `name` and never constrain its value, so widening the parameter
+    past `Has[name]` drops nothing a caller would have to satisfy.
+    """
+    items = _param_traces(spies, traces, param)
+    return bool(items) and all(
+        item.attr == "__getattr__"
+        and item.args == (name,)
+        and not traces.get(id(item.return_))
+        for item in items
+    )
+
+
+def returns_ground(results: Iterable[object]) -> bool:
+    """Whether no result carries a spy, so the return is a concrete type."""
+    return all(next(return_spies(r), None) is None for r in results)
 
 
 def _trace_order(params: Sequence[_SpyObject], traces: _Traces) -> list[_SpyObject]:

--- a/optype/infer/_api.py
+++ b/optype/infer/_api.py
@@ -2,22 +2,46 @@
 
 import warnings
 from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
 from inspect import Parameter
 
 # `from . import` would import the package itself, which imports this module
 import optype.infer._numpy as _numpy
+from ._analyze import (
+    absent_verdict,
+    dispatch_candidates,
+    requires_only_presence,
+    returns_ground,
+)
 from ._errors import InferError, InferWarning
 from ._explore import (
     _declared_defaults,
     _Exploration,
     _explore_lenient,
     _explore_spies,
-    _Gap,
+    _GapKind,
     _parameter_forms,
 )
-from ._render import _Defaults, _Names, signatures
+from ._render import (
+    _Defaults,
+    _Names,
+    signatures,
+    union_signature,
+    widened_signature,
+)
 from ._spy import _AnyFunc, _TraceItem
 from ._values import map_values
+
+
+@dataclass(frozen=True, slots=True)
+class _Gap:
+    """A coverage gap at a call form."""
+
+    kind: _GapKind
+    where: str  # the call form, e.g. "(x, y)"
+
+    def message(self) -> str:
+        return f"{self.kind} in {self.where}"
 
 
 class _SelectError(ValueError):
@@ -127,6 +151,47 @@ def _defaults(
     return {}, False, overloads
 
 
+def _dispatch_overloads(
+    func: _AnyFunc,
+    params: Mapping[str, Parameter],
+    selected: _Names,
+    exploration: _Exploration,
+    baseline: list[str],
+) -> list[str]:
+    """The overloads for a presence-test on a single parameter's attribute.
+
+    Forcing the attribute absent surfaces the branch a placeholder hides. If the return
+    ignores the attribute's value, one overload covers it: the parameter widens to
+    `object`, the return unions both branches. If the present branch returns the value,
+    that overload stays over an `object` fallback. Otherwise the `baseline` holds.
+    """
+    candidates = (
+        dispatch_candidates(exploration.spies, exploration.traces)
+        if len(params) == 1
+        else ()
+    )
+    if len(candidates) != 1:
+        return baseline
+    ((param, name),) = candidates
+    if not requires_only_presence(exploration.spies, exploration.traces, param, name):
+        return baseline
+    try:
+        variant = _explore_spies(func, params, absent={param: (name,)})
+    except Exception:  # noqa: BLE001
+        return baseline
+    widens = absent_verdict(variant.spies, variant.traces, param, name)
+    if widens is None:
+        return baseline
+    if (
+        widens
+        and returns_ground(exploration.results)
+        and returns_ground(variant.results)
+    ):
+        return union_signature(exploration, variant, params, selected)
+    tail = widened_signature(variant, params, selected)
+    return baseline + tail if tail else baseline
+
+
 def _infer_form(
     func: _AnyFunc,
     parameters: Mapping[str, Parameter],
@@ -134,19 +199,21 @@ def _infer_form(
     gaps: set[_Gap],
 ) -> list[str]:
     selected = _select(params, list(parameters))
+    where = f"({', '.join(parameters)})"
     try:
         exploration, fallback = _explore_lenient(func, parameters)
     except (IndexError, TypeError, ValueError) as exc:
         raise InferError(str(exc)) from exc
-    if exploration.gaps:
-        where = f"({', '.join(parameters)})"
-        gaps.update(_Gap(g.kind, g.where or where) for g in exploration.gaps)
+    gaps.update(_Gap(kind, where) for kind in exploration.gaps)
     if fallback:
         # the rejected parameters render from their defaults; skip the probing
         lines = signatures(exploration, parameters, selected, fallback)
         return list(dict.fromkeys(lines))
     defaults, negate, overloads = _defaults(func, parameters, selected, exploration)
     lines = signatures(exploration, parameters, selected, defaults, negate=negate)
+    if not defaults and not overloads:
+        # dispatch only when defaults didn't already split the form
+        lines = _dispatch_overloads(func, parameters, selected, exploration, lines)
     return list(dict.fromkeys((*overloads, *lines)))
 
 
@@ -190,10 +257,8 @@ def infer(func: _AnyFunc, /, *params: str | int, strict: bool = False) -> str:
     >>> print(infer(lambda x: x + 1))
     [R](x: CanAdd[Literal[1], R]) -> R
 
-    Because `infer` runs the function against placeholders, it can only observe
-    the paths those placeholders drive. When exploration is incomplete it emits an
-    `InferWarning` naming the affected call form; pass `strict=True` to raise an
-    `InferError` instead of returning a provisional signature.
+    When exploration is incomplete it emits an `InferWarning` naming the affected
+    call form; pass `strict=True` to raise an `InferError` instead.
 
     Raises:
         InferError: If `func` is not supported, such as a non-callable, an
@@ -208,9 +273,8 @@ def infer(func: _AnyFunc, /, *params: str | int, strict: bool = False) -> str:
         raise InferError("the result is nested too deeply") from exc
     if gaps:
         detail = "; ".join(sorted(g.message() for g in gaps))
+        msg = f"incomplete exploration: {detail}"
         if strict:
-            msg = f"not exhaustively explored: {detail}"
             raise InferError(msg)
-        msg = f"not every branch was explored: {detail}"
         warnings.warn(msg, InferWarning, stacklevel=2)
     return result

--- a/optype/infer/_explore.py
+++ b/optype/infer/_explore.py
@@ -16,7 +16,6 @@ from collections.abc import (
 )
 from contextlib import suppress
 from contextvars import ContextVar
-from dataclasses import dataclass
 from enum import StrEnum
 from functools import partial
 from inspect import Parameter, isasyncgen, iscoroutine, isgenerator, signature
@@ -71,17 +70,6 @@ class _GapKind(StrEnum):
     RUN_BUDGET = "run budget exhausted"
 
 
-@dataclass(frozen=True, slots=True)
-class _Gap:
-    """A coverage gap: a path the exploration left unexplored."""
-
-    kind: _GapKind
-    where: str = ""  # the affected call form, e.g. "(x, y)"
-
-    def message(self) -> str:
-        return f"{self.kind}{f' in {self.where}' if self.where else ''}"
-
-
 class _Exploration(NamedTuple):
     """What one exploration of a function against spy placeholders produced."""
 
@@ -91,7 +79,7 @@ class _Exploration(NamedTuple):
     var_count: int  # the `*args` placeholder count
     fixed: Mapping[str, object]  # parameters passed as-is, not spies
     deprecated: str | None = None  # a `DeprecationWarning` message raised when called
-    gaps: frozenset[_Gap] = frozenset()  # the paths left unexplored
+    gaps: frozenset[_GapKind] = frozenset()  # kinds of unexplored path
 
 
 def _reachable(params: Iterable[object]) -> Generator[_SpyObject]:
@@ -404,7 +392,7 @@ def _explore[T](
     func: Callable[..., T] | Callable[..., Coroutine[Any, None, T]],
     args: Sequence[object],
     kwds: Mapping[str, object],
-) -> tuple[list[T], str | None, frozenset[_Gap]]:
+) -> tuple[list[T], str | None, frozenset[_GapKind]]:
     results: list[T] = []
     deprecated: str | None = None
     stack: list[list[bool]] = [[]]
@@ -446,7 +434,7 @@ def _explore[T](
     if not results:
         raise InferError("the function never ran to completion") from last_exc
     hits = (dropped, _GapKind.BRANCH_BUDGET), (bool(stack), _GapKind.RUN_BUDGET)
-    gaps = frozenset(_Gap(kind) for hit, kind in hits if hit)
+    gaps = frozenset(kind for hit, kind in hits if hit)
     return results, deprecated, gaps
 
 
@@ -499,13 +487,24 @@ def _placeholders(
     return spies, args, kwds
 
 
+def _force_absent(
+    spies: Mapping[str, _SpyObject],
+    absent: Mapping[str, Collection[str]],
+) -> None:
+    for name, attrs in absent.items():
+        if (spy := spies.get(name)) is not None:
+            spy.__optype_absent__ = frozenset(attrs)
+
+
 def _explore_spies(
     func: _AnyFunc,
     params: Mapping[str, Parameter],
     omit: Collection[str] = (),
     fix: Collection[str] = (),
+    absent: Mapping[str, Collection[str]] | None = None,
 ) -> _Exploration:
     kinds = {p.kind for p in params.values()}
+    forced_absent = absent or {}
 
     counts = iter(_VARIADIC_COUNTS)
     count = next(counts)
@@ -530,6 +529,7 @@ def _explore_spies(
                 n: _typed_default(params[n].default) for n in fix
             }
             spies, args, kwds = _placeholders(params, count, keys, omit, fixed)
+            _force_absent(spies, forced_absent)
             try:
                 results, deprecated, gaps = _explore(func, args, kwds)
                 results = [_next(r) for r in results]

--- a/optype/infer/_render.py
+++ b/optype/infer/_render.py
@@ -460,14 +460,22 @@ class _Renderer:
 
     def traces(self, items: Iterable[_TraceItem]) -> _ir.Node | None:
         items = list(items)
-        # a surviving absence marker proves the dunder was only probed optionally
-        optional = {item.args[0] for item in items if item.attr == _Marker.ABSENT}
+        # an absence marker means the op was optional; an attribute probe keys on its
+        # name, so it spares the other reads
+        optional = {item.args for item in items if item.attr == _Marker.ABSENT}
         groups: dict[
             tuple[_Proto, str | None, bool, int, tuple[str, ...]],
             list[_Op],
         ] = {}
         for item in items:
-            if item.attr == _Marker.ABSENT or item.attr in optional:
+            if item.attr == _Marker.ABSENT:
+                continue
+            probed = (
+                ("__getattr__", item.args[0])
+                if item.attr == "__getattr__" and item.args
+                else (item.attr,)
+            )
+            if probed in optional:
                 continue
             op = resolve(item)
             key = op.proto, op.attr, op.classvar, len(op.args), tuple(sorted(op.kwargs))
@@ -677,6 +685,7 @@ class _Renderer:
         defaults: _Defaults | None = None,
         *,
         negate: bool = False,
+        ret: _ir.Node | None = None,
     ) -> str:
         defaults = defaults or {}
         defaulted = {
@@ -701,14 +710,18 @@ class _Renderer:
         ]
 
         generics = f"[{', '.join(typevars)}]" if typevars else ""
-        params = ", ".join(
-            decl
-            for name in selected
-            if (decl := self._param(name, defaults, negate=negate)) is not None
-        )
-        return f"{generics}({params}) -> {self.return_types()}"
+        decls = (self._param(name, defaults, negate=negate) for name in selected)
+        params = ", ".join(decl for decl in decls if decl is not None)
+        returns = self.return_types() if ret is None else _ir.render(ret)
+        return f"{generics}({params}) -> {returns}"
 
-    def _param(self, name: str, defaults: _Defaults, *, negate: bool) -> str | None:
+    def _param(
+        self,
+        name: str,
+        defaults: _Defaults,
+        *,
+        negate: bool,
+    ) -> str | None:
         # a positional-only parameter cannot be passed by keyword, so no name shows
         label = "" if name in self._nameless else f"{self._prefix[name]}{name}: "
         if name in self._fixed and name not in self._optional:
@@ -730,6 +743,15 @@ class _Renderer:
         return f"{label}{_ir.render(node)}{_suffix(defaults, name)}"
 
 
+def _renderers(
+    exploration: _Exploration,
+    params: Mapping[str, Parameter],
+) -> list[_Renderer]:
+    traces, results = exploration.traces, exploration.results
+    reflected = reflect([*exploration.spies.values(), *fn_spies(results)], traces)
+    return [_Renderer(exploration, params, t) for t in (traces, reflected)]
+
+
 def signatures(
     exploration: _Exploration,
     params: Mapping[str, Parameter],
@@ -738,14 +760,47 @@ def signatures(
     *,
     negate: bool = False,
 ) -> list[str]:
-    traces, results = exploration.traces, exploration.results
-    roots = [*exploration.spies.values(), *fn_spies(results)]
-    reflected = reflect(roots, traces)
     lines = [
-        _Renderer(exploration, params, t).render(selected, defaults, negate=negate)
-        for t in (traces, reflected)
+        r.render(selected, defaults, negate=negate)
+        for r in _renderers(exploration, params)
     ]
     if exploration.deprecated is not None:
         head = f"@deprecated({exploration.deprecated!r})"
         lines = [f"{head}\n{line}" for line in lines]
     return lines
+
+
+def widened_signature(
+    exploration: _Exploration,
+    params: Mapping[str, Parameter],
+    selected: _Names,
+) -> list[str]:
+    """The fallback overload for a value dispatch, deduplicated: the parameter as the
+    absent branch leaves it, the return widened to `object` (the only sound supertype of
+    an arbitrary present return).
+
+    Empty if a signature still declares a type parameter: a pinned return cannot bind
+    one, so a parameter-only typevar would dangle. The lines carry no `@deprecated`
+    prefix, so a leading `[` is an unambiguous generic.
+    """
+    lines = [
+        r.render(selected, ret=_ir.Name(_OBJECT))
+        for r in _renderers(exploration, params)
+    ]
+    if any(line.startswith("[") for line in lines):
+        return []
+    return list(dict.fromkeys(lines))
+
+
+def union_signature(
+    exploration: _Exploration,
+    variant: _Exploration,
+    params: Mapping[str, Parameter],
+    selected: _Names,
+) -> list[str]:
+    """The single overload for a presence dispatch whose return ignores the attribute's
+    value: the parameter (forced absent in `variant`) widens to `object`, and the return
+    unions the present and absent branches (so a `hasattr` predicate renders `bool`).
+    """
+    combined = variant._replace(results=[*exploration.results, *variant.results])
+    return signatures(combined, params, selected)

--- a/optype/infer/_spy.py
+++ b/optype/infer/_spy.py
@@ -240,6 +240,7 @@ class _SpyObject(_Spy, metaclass=_SpyType):
     __optype_iterator__: bool = False
     __optype_arity__: "int | None" = None
     __optype_growable__: bool = False
+    __optype_absent__: "frozenset[str]" = frozenset()
     # spies are descriptors (`__get__`), so only ever read through the class `__dict__`
     __optype_instance__: "ClassVar[_SpyObject | None]" = None
 
@@ -263,6 +264,10 @@ class _SpyObject(_Spy, metaclass=_SpyType):
         if _internal(attr):
             return None
 
+        if attr in self.__optype_absent__:
+            # the marker survives only if a completing run tolerates the absence
+            self.__optype_trace_add__(_Marker.ABSENT, ("__getattr__", attr), {}, None)
+            raise AttributeError(attr)
         return self.__optype_trace_add__("__getattr__", (attr,), {}, _SpyObject())
 
     @override

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -21,7 +21,8 @@ from typing import Any
 import pytest
 
 from optype.infer import InferError, InferWarning, _api, infer
-from optype.infer._explore import _doc_signatures, _Gap, _GapKind, _parameter_forms
+from optype.infer._api import _Gap
+from optype.infer._explore import _doc_signatures, _GapKind, _parameter_forms
 from optype.infer._ir import (
     App,
     Arg,
@@ -1609,22 +1610,13 @@ def test_infer_choice_does_not_hang(choose: Callable[..., Any]) -> None:
         infer(choose)
 
 
-def test_fork_truncation_warning() -> None:
-    # when the budget runs out before every branch was explored, it warns. Distinct
-    # `x[i]` spies each fork on `bool`; a single spy's truthiness is stable per run.
-    def f(x: Any) -> Any:
-        return [bool(x[i]) for i in range(10)]
-
-    with pytest.warns(InferWarning, match="branch"):
-        infer(f)
-
-
 def _budget_exhausting(x: Any) -> Any:
     return [bool(x[i]) for i in range(10)]
 
 
-def test_gap_names_form() -> None:
-    # the warning categorizes the gap and names the affected call form
+def test_fork_truncation_warning() -> None:
+    # when the budget runs out before every branch was explored, the warning categorizes
+    # the gap and names the affected form. Distinct `x[i]` spies each fork on `bool`.
     with pytest.warns(InferWarning, match=r"run budget exhausted in \(x\)"):
         infer(_budget_exhausting)
 
@@ -1633,7 +1625,7 @@ def test_strict_raises_on_gap() -> None:
     # the same incompleteness that warns by default fails closed under `strict`
     with pytest.warns(InferWarning):
         assert isinstance(infer(_budget_exhausting), str)
-    with pytest.raises(InferError, match="not exhaustively explored"):
+    with pytest.raises(InferError, match="incomplete exploration"):
         infer(_budget_exhausting, strict=True)
 
 
@@ -1646,10 +1638,157 @@ def test_strict_silent_when_complete() -> None:
 
 
 def test_gap_message_and_dedup() -> None:
-    assert _Gap(_GapKind.RUN_BUDGET, "(x)").message() == "run budget exhausted in (x)"
-    assert _Gap(_GapKind.BRANCH_BUDGET).message() == "branch budget exhausted"
+    gap = _Gap(_GapKind.RUN_BUDGET, "(x)")
+    assert gap.message() == "run budget exhausted in (x)"
     # frozen and slotted, so equal gaps collapse in a set
-    assert len({_Gap(_GapKind.RUN_BUDGET), _Gap(_GapKind.RUN_BUDGET)}) == 1
+    assert len({gap, _Gap(_GapKind.RUN_BUDGET, "(x)")}) == 1
+
+
+def test_dispatch_hasattr_collapses_to_object() -> None:
+    # `hasattr` tolerates absence, so the attribute is not a requirement
+    assert infer(lambda x: hasattr(x, "a")) == "(x: object) -> bool"
+
+
+def test_dispatch_try_except_bool_collapses_to_object() -> None:
+    # a `try`/`except AttributeError` that returns a bool is also a presence predicate
+    def f(x: Any) -> Any:
+        try:
+            x.value  # noqa: B018
+        except AttributeError:
+            return False
+        return True
+
+    assert infer(f) == "(x: object) -> bool"
+
+
+def test_dispatch_negated_predicate_collapses_to_object() -> None:
+    # the inverted polarity (`False` present, `True` absent) is still a bool predicate
+    assert infer(lambda x: not hasattr(x, "a")) == "(x: object) -> bool"
+
+
+def test_dispatch_presence_independent_return_collapses() -> None:
+    # the return ignores the attribute's value, so one overload with the unioned return
+    # of both branches covers it, rather than an `object` fallback
+    assert infer(lambda x: 1 if hasattr(x, "a") else 2) == "(x: object) -> int"
+
+
+def test_dispatch_getattr_default_widens_fallback() -> None:
+    # a value dispatch keeps two overloads, but the fallback's return widens to a sound
+    # supertype of the present `R` (`object`), so the overloads no longer overlap
+    def f(x: Any) -> Any:
+        return getattr(x, "value", None)
+
+    assert infer(f) == "[R](x: Has['value', +R]) -> R\n(x: object) -> object"
+
+
+def test_dispatch_try_except_value_widens_fallback() -> None:
+    def f(x: Any) -> Any:
+        try:
+            return x.value
+        except AttributeError:
+            return 0
+
+    assert infer(f) == "[R](x: Has['value', +R]) -> R\n(x: object) -> object"
+
+
+def test_dispatch_required_attribute_unchanged() -> None:
+    # a directly-used attribute has no fallback, so its absent variant raises and is
+    # dropped; the attribute stays a hard requirement
+    assert infer(lambda x: x.a) == "[R](x: Has['a', +R]) -> R"
+
+
+def test_dispatch_conditional_use_no_overload() -> None:
+    # `y.foo` is used in one branch of an unrelated fork, not dispatched on; forcing it
+    # absent completes via the other branch but leaves no tolerated-absence marker
+    def f(x: Any, y: Any) -> Any:
+        return x if 0 in x else y.foo()
+
+    assert infer(f) == (
+        "[T: CanContains[Literal[0]], R](x: T, y: Has['foo', () -> +R]) -> T | R"
+    )
+
+
+def test_dispatch_independent_dispatches_keep_baseline() -> None:
+    # two presence-tests on one parameter don't compose soundly, so the strict baseline
+    # (requiring both) is kept rather than overloads that resolve wrongly for mixed x
+    def f(x: Any) -> Any:
+        return hasattr(x, "a"), hasattr(x, "b")
+
+    assert infer(f) == (
+        "(x: Has['a'] & Has['b']) -> tuple[Literal[True], Literal[True]]"
+    )
+
+
+def test_dispatch_multi_parameter_keeps_baseline() -> None:
+    # a dispatch on a multi-parameter function isn't collapsed or widened (the fallback
+    # can't be rendered soundly without losing the other parameters), so the baseline
+    # stays; `y`'s own `a` is unaffected by forcing `x`'s `a` absent
+    def f(x: Any, y: Any) -> Any:
+        return hasattr(x, "a"), y.a
+
+    assert infer(f) == ("[R](x: Has['a'], y: Has['a', +R]) -> tuple[Literal[True], R]")
+
+
+def test_dispatch_value_from_parameter_keeps_baseline() -> None:
+    # the absent branch derives its value from the parameter (`x.b`), so a widened
+    # fallback would orphan that typevar; the strict baseline is kept instead
+    def f(x: Any) -> Any:
+        return hasattr(x, "a") or x.b
+
+    assert infer(f) == "(x: Has['a']) -> bool"
+
+
+def test_dispatch_fallback_keeps_unconditional_requirement() -> None:
+    # the `value` absence marker must not suppress the absent branch's `fallback` read
+    def f(x: Any) -> Any:
+        try:
+            return x.value
+        except AttributeError:
+            x.fallback  # noqa: B018
+            return 0
+
+    assert infer(f) == "[R](x: Has['value', +R]) -> R\n(x: Has['fallback']) -> object"
+
+
+def test_dispatch_value_capability_keeps_baseline() -> None:
+    # the present branch constrains the value (`+ 1`), so an `object` fallback would
+    # admit a `value` that cannot add; the sound baseline is kept
+    def f(x: Any) -> Any:
+        return getattr(x, "value", 0) + 1
+
+    assert infer(f) == "[R](x: Has['value', +CanAdd[Literal[1], R]]) -> R"
+
+
+def test_dispatch_present_extra_requirement_keeps_baseline() -> None:
+    # the present branch also requires `b`, so widening to `object` would be unsound
+    def f(x: Any) -> Any:
+        if hasattr(x, "a"):
+            _ = x.b
+            return True
+        return False
+
+    assert infer(f) == "(x: Has['a'] & Has['b']) -> bool"
+
+
+def test_dispatch_no_budget_warning_for_plain_reads() -> None:
+    # reading many attributes is not a dispatch, so it must not trip the dispatch budget
+    def f(x: Any) -> Any:
+        return x.a, x.b, x.c, x.d, x.e, x.f, x.g, x.h, x.i
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        assert isinstance(infer(f), str)
+    assert isinstance(infer(f, strict=True), str)
+
+
+def test_dispatch_multi_parameter_no_budget_warning() -> None:
+    # a multi-parameter function never dispatches, so attribute reads cannot truncate
+    def f(x: Any, y: Any) -> Any:
+        return x.a, x.b, x.c, x.d, x.e, x.f, x.g, x.h, x.i, y
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        assert isinstance(infer(f), str)
 
 
 def test_target_exception_skipped() -> None:
@@ -2070,4 +2209,4 @@ def test_cli_warns_on_stderr() -> None:
     assert out.returncode == 0
     assert out.stdout.startswith("(x: CanGetitem")
     assert "warning:" in out.stderr
-    assert "branch" in out.stderr
+    assert "incomplete exploration" in out.stderr


### PR DESCRIPTION
before:

```console
$ optype infer "lambda x: hasattr(x, 'a')"
(x: Has['a']) -> bool
```

after:

```console
$ optype infer "lambda x: hasattr(x, 'a')"
(x: object) -> bool
```