### PR TITLE
`infer`: code cleanup

### DIFF
--- a/docs/infer.md
+++ b/docs/infer.md
@@ -69,25 +69,6 @@ $ optype infer "lambda x: -x + x"
 [T, R](x: CanNeg[T] & CanRAdd[T, R]) -> R
 ```
 
-A builtin without an `inspect.signature` recovers its parameters from the docstring,
-reporting each documented call form as an overload:
-
-```console
-$ optype infer "iter"
-[R](iterable: CanIter[R]) -> R
-[R](callable: () -> R, sentinel: object) -> Iterator[R]
-```
-
-Unsatisfiable forms are dropped and same-arity forms collapse into one. The docstring is
-also lossy: it marks neither `*args` nor the keyword-only `*`, so both become plain
-positionals. Read these forms as the shape of the call, not a faithful signature:
-
-```console
-$ optype infer "max"
-[T, U: CanGt[T, CanBool], V: CanGt[U | T, CanBool]](iterable: T, default: U, key: V) -> V | U | T
-[T, U: CanGt[T, CanBool], V: CanGt[U | T, CanBool], W: CanGt[V | U | T, CanBool]](arg1: T, arg2: U, args: V, key: W) -> W | V | U | T
-```
-
 ## Intersections
 
 Python has no intersection types, so the `&` is not valid Python: both requirements
@@ -166,7 +147,7 @@ $ optype infer "lambda x: x.__name__"
 
 An attribute without a shipped protocol renders as the fictional inline form
 `Has['name', T]`. Like `&` and `~`, it is not valid Python, but it is expressible as
-a protocol with a single member. The type argument carries a polarity sigil: a read
+a protocol with a single member. The type argument carries a variance sign: a read
 requires only the covariant `+T`, so a `@property` getter suffices:
 
 ```python
@@ -182,7 +163,13 @@ $ optype infer "lambda x: x.spam"
 [R](x: Has['spam', +R]) -> R
 ```
 
-When the attribute is called, the sigil sinks into the callable's return type, where
+!!! tip "Reading the `+`/`-` signs"
+
+    The sign is the direction the value flows: a covariant `+T` is **produced** (read
+    out, like a getter's return type), and a contravariant `-T` is **consumed** (passed
+    in, like a setter's argument). So a read is `+`, a write is `-`.
+
+When the attribute is called, the sign sinks into the callable's return type, where
 the covariance applies: `Has['spam', () -> +R]` is the method `def spam(self) -> R`:
 
 ```console
@@ -217,8 +204,8 @@ $ optype infer "def f(): return f.__code__"
 recording proxy has a unique class, so the result is still tied to its parameter:
 
 ```console
-$ optype infer "type"
-[T](object: T) -> type[T]
+$ optype infer "lambda x: type(x)"
+[T](x: T) -> type[T]
 
 $ optype infer "lambda x: type(next(x))"
 [R](x: CanNext[R]) -> type[R]
@@ -557,6 +544,10 @@ $ optype infer "lambda x: {k: v for k, v in x}"
 [R: CanHash](x: CanIter[CanNext[CanIter[CanNext[R]]]]) -> dict[R, R]
 ```
 
+A placeholder iterator yields two elements, so a two-target unpack (and a starred one) is
+covered, but a fixed unpack of three or more targets cannot be satisfied and raises an
+`InferError`.
+
 ## Returned functions
 
 A returned function is lazy too, so it is explored with placeholders of its own, and
@@ -718,10 +709,11 @@ attribute itself, or an absent branch that can't run on placeholders (as with `d
 
 When `infer` can't handle the input, it raises `InferError` (a `NotImplementedError`
 subclass). That's the case for operations without a matching protocol, such as an
-attribute access whose name is not statically known (a computed `getattr`), and for
-arguments that aren't callable to begin with. A function that never runs to completion,
-such as `lambda: 0 / 0`, raises `InferError` chained from the triggering exception
-(`__cause__`).
+attribute access whose name is not statically known (a computed `getattr`); for arguments
+that aren't callable to begin with; and for a builtin whose parameters `inspect.signature`
+cannot recover (such as `iter`, `max`, or `type` itself, though `type(x)` within a
+function is fine). A function that never runs to completion, such as `lambda: 0 / 0`,
+raises `InferError` chained from the triggering exception (`__cause__`).
 
 Variadic parameters are explored with a few placeholders, retried with more after an
 out-of-range index, a failed unpacking, or a missing `**kwargs` key, and reported as an

--- a/optype/infer/_analyze.py
+++ b/optype/infer/_analyze.py
@@ -83,7 +83,7 @@ def requires_only_presence(
     )
 
 
-def returns_ground(results: Iterable[object]) -> bool:
+def returns_concrete(results: Iterable[object]) -> bool:
     """Whether no result carries a spy, so the return is a concrete type."""
     return all(next(return_spies(r), None) is None for r in results)
 

--- a/optype/infer/_api.py
+++ b/optype/infer/_api.py
@@ -11,7 +11,7 @@ from ._analyze import (
     absent_verdict,
     dispatch_candidates,
     requires_only_presence,
-    returns_ground,
+    returns_concrete,
 )
 from ._errors import InferError, InferWarning
 from ._explore import (
@@ -20,7 +20,7 @@ from ._explore import (
     _explore_lenient,
     _explore_spies,
     _GapKind,
-    _parameter_forms,
+    _parameters,
 )
 from ._render import (
     _Defaults,
@@ -45,7 +45,7 @@ class _Gap:
 
 
 class _SelectError(ValueError):
-    """A selected parameter or position is absent from a particular call form."""
+    """A selected parameter or position is absent from the signature."""
 
 
 def _select(params: Iterable[str | int], names: _Names) -> _Names:
@@ -184,8 +184,8 @@ def _dispatch_overloads(
         return baseline
     if (
         widens
-        and returns_ground(exploration.results)
-        and returns_ground(variant.results)
+        and returns_concrete(exploration.results)
+        and returns_concrete(variant.results)
     ):
         return union_signature(exploration, variant, params, selected)
     tail = widened_signature(variant, params, selected)
@@ -222,31 +222,8 @@ def _infer(func: _AnyFunc, params: tuple[str | int, ...], gaps: set[_Gap]) -> st
         names = _numpy.ufunc_params(nin)
         return _numpy.infer_ufunc(func, names, _select(params, names))
 
-    forms = _parameter_forms(func)
-    if len(forms) == 1:
-        # a lone form's error is the result's; the loop below only tolerates a failed
-        # form because another may still match
-        return "\n".join(_infer_form(func, forms[0], params, gaps))
-
-    # one overload per documented form: an unsatisfiable form is dropped and a
-    # `_SelectError` filters one out, but an unexpected error still propagates
-    lines: list[str] = []
-    reasons: list[str] = []
-    misses: list[str] = []
-    for parameters in forms:
-        try:
-            lines += _infer_form(func, parameters, params, gaps)
-        except _SelectError as exc:
-            misses.append(str(exc))
-        except InferError as exc:
-            reasons.append(str(exc))
-    if lines:
-        return "\n".join(dict.fromkeys(lines))
-    if reasons:
-        raise InferError("; ".join(dict.fromkeys(reasons)))
-    if misses:
-        raise _SelectError("; ".join(dict.fromkeys(misses)))
-    raise InferError("no inferable call form")
+    parameters = _parameters(func)
+    return "\n".join(_infer_form(func, parameters, params, gaps))
 
 
 def infer(func: _AnyFunc, /, *params: str | int, strict: bool = False) -> str:

--- a/optype/infer/_explore.py
+++ b/optype/infer/_explore.py
@@ -1,8 +1,6 @@
 """Run a function against spy placeholders and record what happens."""
 
 import gc
-import keyword
-import re
 import warnings
 from collections.abc import (
     AsyncGenerator,
@@ -47,10 +45,6 @@ from ._spy import (
 )
 from ._values import _Fn, _Gen, _Rec, _RecRef, _RecVar, _walk, fn_spies
 
-_RE_DOC_SIGNATURE = re.compile(r"\b(\w+)\(([^)]*)\)")
-_RE_DOC_PARAM = re.compile(r"(?:^|,)\s*\**([a-zA-Z_]\w*)")
-_RE_DOC_ARROW = re.compile(r"\s*->")
-
 _FORK_LIMIT = 64
 _RUN_LIMIT = 256
 _YIELD_LIMIT = 64
@@ -58,8 +52,8 @@ _YIELD_LIMIT = 64
 # large indices stay within reach
 _VARIADIC_COUNTS = (2, 3, 4, 5, 6, 7, 8, 16, 32, 64, 128, 256, 512, 1024)
 _KWARGS_LIMIT = 8  # max injected `**kwargs` keys
-# yield budgets to try for a splat into a fixed-arity call (e.g. `divmod`): an exact
-# arity is needed, so these stay contiguous; a sparse range would skip valid arities
+# yield budgets to try for a star-unpack into a fixed-arity call (e.g. `divmod`): an
+# exact arity is needed, so these stay contiguous; a sparse range would skip valid ones
 _YIELD_COUNTS = tuple(range(2, 17))
 
 
@@ -111,60 +105,11 @@ def _snapshot(params: Iterable[_SpyObject]) -> _Traces:
     return traces
 
 
-def _doc_param_names(group: str) -> list[str] | None:
-    params = group.replace("[", "").replace("]", "")
-    names = _RE_DOC_PARAM.findall(params)
-    # a usage example like `reduce(lambda x, y: ...)` yields keywords, not params
-    if names and not any(map(keyword.iskeyword, names)):
-        return names
-    return None
-
-
-def _doc_signatures(func: _AnyFunc) -> list[list[str]]:
-    """Every documented call form's parameter names, by arity (one per arity).
-
-    Arrow-annotated forms (`name(...) -> ret`) are the real overloads; a docstring's
-    usage examples lack the arrow. When none are annotated (e.g. `next`, `slice`),
-    fall back to the first form. Same-arity forms infer the same structure, so only
-    the first of each arity is kept (its parameter names win).
-    """
-    name = getattr(func, "__name__", "")
-    if not name:
-        return []
-    doc = func.__doc__ or ""
-    arrow_forms: list[list[str]] = []
-    first: list[str] | None = None
-    for match in _RE_DOC_SIGNATURE.finditer(doc):
-        if match[1] != name or (names := _doc_param_names(match[2])) is None:
-            continue
-        if first is None:
-            first = names
-        if _RE_DOC_ARROW.match(doc, match.end()):
-            arrow_forms.append(names)
-    forms = arrow_forms or ([first] if first is not None else [])
-    by_arity: dict[int, list[str]] = {}
-    for f in forms:
-        by_arity.setdefault(len(f), f)
-    return list(by_arity.values())
-
-
-def _parameter_forms(func: _AnyFunc) -> list[Mapping[str, Parameter]]:
-    # the parameters of every call form: the real signature's, else the docstring's
-    try:
-        return [signature(func).parameters]
-    except TypeError as exc:  # not callable
-        raise InferError(str(exc)) from exc
-    except ValueError as exc:  # no signature
-        if not (forms := _doc_signatures(func)):
-            raise InferError(str(exc)) from exc
-        return [
-            {n: Parameter(n, Parameter.POSITIONAL_OR_KEYWORD) for n in names}
-            for names in forms
-        ]
-
-
 def _parameters(func: _AnyFunc) -> Mapping[str, Parameter]:
-    return _parameter_forms(func)[0]  # the first call form
+    try:
+        return signature(func).parameters
+    except (TypeError, ValueError) as exc:  # not callable, or no signature
+        raise InferError(str(exc)) from exc
 
 
 def _declared_defaults(params: Mapping[str, Parameter]) -> dict[str, object]:
@@ -407,7 +352,7 @@ def _explore[T](
             (spy, len(spy.__optype_trace__))
             for spy in _reachable((*args, *kwds.values(), *_closed_over(func)))
         ]
-        # `_starved` is a per-run splat signal, so a prior run cannot leak into this one
+        # `_starved` is a per-run star-unpack flag, so no prior run leaks into this one
         _starved.set(False)
         token = _fork.set(iter(plan))
 
@@ -547,8 +492,8 @@ def _explore_spies(
                     raise InferError(msg) from exc
                 keys.append(key)
             except (IndexError, TypeError, ValueError) as exc:
-                # a too-short splat raises `TypeError`; gate on it so the target's own
-                # error (e.g. a `ValueError`) can't churn the budget and bury itself
+                # a too-short star-unpack raises `TypeError`; gate on it so the target's
+                # own error (e.g. a `ValueError`) can't churn the budget and bury itself
                 if (
                     isinstance(exc, TypeError)
                     and _starved.get()

--- a/optype/infer/_ir.py
+++ b/optype/infer/_ir.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from typing import assert_never, override
 
 type Node = (
-    Lit | Type | Name | App | Fn | Union | Inter | Not | Polarity | Unpack | Dots
+    Lit | Type | Name | App | Fn | Union | Inter | Not | Variance | Unpack | Dots
 )
 
 _NOT = "~"  # the type complement prefix
@@ -14,7 +14,7 @@ _OR = "|"  # the union separator
 _AND = "&"  # the intersection separator
 _DOTS = "..."  # the `...` ellipsis
 
-# the shared polarity sigils: covariant (read-only) and contravariant (write-only)
+# the shared variance signs: covariant (read-only) and contravariant (write-only)
 COVARIANT = "+"
 CONTRAVARIANT = "-"
 
@@ -102,8 +102,8 @@ class Not:
 
 
 @dataclass(frozen=True, slots=True)
-class Polarity:
-    """A polarity-marked type: covariant (read-only) or contravariant (write-only)."""
+class Variance:
+    """A variance-marked type: covariant (read-only) or contravariant (write-only)."""
 
     sign: str
     part: Node
@@ -316,7 +316,7 @@ def names(node: Node | Arg) -> Generator[str]:
         case Fn(params, ret):
             for part in (*params, ret):
                 yield from names(part)
-        case Not(part) | Polarity(part=part) | Unpack(part):
+        case Not(part) | Variance(part=part) | Unpack(part):
             yield from names(part)
         case Lit() | Type() | Dots():
             return
@@ -360,9 +360,9 @@ def _render_fn(params: tuple[Node | Arg, ...], ret: Node) -> str:
     return f"({decls}) -> {render(ret)}"
 
 
-def _render_prefix(node: Not | Polarity | Unpack) -> str:
+def _render_prefix(node: Not | Variance | Unpack) -> str:
     match node:
-        case Polarity(sign, part):
+        case Variance(sign, part):
             return _prefix(sign, part)
         case Not(part):
             return _prefix(_NOT, part)
@@ -394,7 +394,7 @@ def render(node: Node) -> str:
             out = _render_app(base, args)
         case Fn(params, ret):
             out = _render_fn(params, ret)
-        case Not() | Polarity() | Unpack():
+        case Not() | Variance() | Unpack():
             out = _render_prefix(node)
         case Union(parts):
             out = _render_union(parts, _OR, Inter)

--- a/optype/infer/_protocols.py
+++ b/optype/infer/_protocols.py
@@ -9,9 +9,8 @@ from ._spy import _Args, _Kwargs, _Marker, _Spy, _TraceItem
 from optype._core import _can, _has
 from optype.inspect import get_protocol_members
 
-_DUNDER_ATTR_READ = frozenset({"__getattr__", "__getattribute__"})
 _DUNDER_ATTR_WRITE = frozenset({"__delattr__", "__setattr__"})
-_DUNDER_ATTR = _DUNDER_ATTR_READ | _DUNDER_ATTR_WRITE
+_DUNDER_ATTR = frozenset({"__getattr__", "__getattribute__"}) | _DUNDER_ATTR_WRITE
 _DUNDER_CLASS_ATTR = frozenset({
     _Marker.CLASS_DELATTR,
     _Marker.CLASS_GETATTR,

--- a/optype/infer/_render.py
+++ b/optype/infer/_render.py
@@ -51,7 +51,7 @@ _TUPLE_LIMIT = 16
 # `object`-typed so the `is` check isn't flagged (`Callable` is a special form)
 _CALLABLE_ORIGIN: object = Callable
 
-# the attribute polarity sigils of the fictional inline `Has['name', T]` form
+# the attribute variance signs of the fictional inline `Has['name', T]` form
 _READ = _ir.COVARIANT  # a read-only property suffices
 _WRITE = _ir.CONTRAVARIANT  # the attribute only has to accept the value
 
@@ -69,7 +69,7 @@ def _sign_read(ret: _ir.Node) -> _ir.Node:
     """Mark a read covariant; a callable signs its return type instead: a method."""
     if isinstance(ret, _ir.Fn):
         return _ir.Fn(ret.params, _sign_read(ret.ret))
-    return ret if ret == _ir.Name(_OBJECT) else _ir.Polarity(_READ, ret)
+    return ret if ret == _ir.Name(_OBJECT) else _ir.Variance(_READ, ret)
 
 
 def _is_sentinel(x: object, /) -> bool:
@@ -405,7 +405,7 @@ class _Renderer:
         ):
             return pos
 
-        # require every call to splat the same trailing run, else order would decide
+        # require every call to star-unpack the same trailing run, else order decides
         count = self._count
         if not all(
             m.args[-1] is tail and spy_runs(m.args, tail)[-1] == count for m in members
@@ -446,7 +446,7 @@ class _Renderer:
         if (attr := members[0].attr) is not None:
             # a read is covariant (a property suffices) and a write contravariant
             # (the attribute only has to accept the value); existence renders bare
-            signed: tuple[_ir.Node, ...] = tuple(_ir.Polarity(_WRITE, a) for a in pos)
+            signed: tuple[_ir.Node, ...] = tuple(_ir.Variance(_WRITE, a) for a in pos)
             if ret is not None and ret != _ir.Name(_OBJECT):
                 signed = *signed, _sign_read(ret)
             if members[0].classvar:
@@ -654,7 +654,7 @@ class _Renderer:
         spy = self._varpos
         if spy is not None:
             if any(item is spy for item in items) and self._vartuple:
-                # every use is packed, so the placeholders splat into a single `*Ts`
+                # every use is packed, so the placeholders unpack into a single `*Ts`
                 start = next(i for i, item in enumerate(items) if item is spy)
                 parts = [self._value_type(item) for item in items if item is not spy]
                 parts.insert(start, _ir.Unpack(_ir.Name(_TYPEVAR_TUPLE_NAME)))

--- a/optype/infer/_spy.py
+++ b/optype/infer/_spy.py
@@ -45,18 +45,18 @@ class _Marker(StrEnum):
 
 _fork: ContextVar[Iterator[bool] | None] = ContextVar("_fork", default=None)
 
-# the yield count for a splatted-call iterator whose arity no bytecode pins: the exact
-# arity the splat demands, which `_explore_spies` grows into until the call succeeds
+# the yield count for a star-unpack iterator (`f(*x)`) whose arity no bytecode pins:
+# the arity it needs, which `_explore_spies` grows into until the call works
 _yield_budget: ContextVar[int] = ContextVar("_yield_budget", default=1)
-# set when a growable splatted-call iterator hits the budget, so `_explore_spies` only
-# grows the budget when a fixed-arity splat actually came up short
+# set when a growable star-unpack iterator hits the budget, so `_explore_spies` only
+# grows the budget when a fixed-arity star unpacking actually came up short
 _starved: ContextVar[bool] = ContextVar("_starved", default=False)
 
 # one element exercises no pairwise op, so `sorted`/`min` never reach their elements'
 # `__lt__` (#686); a pair suffices, and `_render` inlines the extra typevar away
 _DEFAULT_YIELD = 2
 
-# the caller's bytecode is a CPython detail; elsewhere fall back to two elements
+# star-unpack detection reads caller bytecode (CPython detail); else it never fires
 _CPYTHON = sys.implementation.name == "cpython"
 
 
@@ -66,45 +66,23 @@ def _co_code(code: CodeType) -> bytes:
     return code.co_code
 
 
-def _instruction_arg(code: bytes, i: int) -> int:
-    arg = code[i + 1]
-    shift = 8
-    j = i - 2
-    while j >= 0 and dis.opname[code[j]] == "EXTENDED_ARG":
-        arg |= code[j + 1] << shift
-        shift += 8
-        j -= 2
-    return arg
+def _iter_is_star_unpack() -> bool:
+    """Whether the caller iterates by star-unpacking into a call, as in `f(*x)`.
 
-
-def _iter_context() -> tuple[int | None, bool]:
-    """The fixed arity the caller's unpack demands, and whether it splats into a call.
-
-    `UNPACK_SEQUENCE`/`UNPACK_EX` pin an exact arity; `CALL_FUNCTION_EX` (`f(*x)`) has
-    no local arity signal, so its iterator grows via the `_yield_budget` instead.
+    `CALL_FUNCTION_EX` has no local arity signal, so its iterator grows via the
+    `_yield_budget` until the call's arity is met.
     """
     if not _CPYTHON:
-        return None, False
+        return False
 
     try:
-        frame = sys._getframe(2)  # _iter_context -> __iter__ -> the consuming frame  # noqa: SLF001
+        frame = sys._getframe(2)  # _iter_is_star_unpack -> __iter__ -> consuming frame  # noqa: SLF001
     except ValueError:
         frame = None
     if frame is None or (i := frame.f_lasti) < 0:
-        return None, False
+        return False
 
-    code = _co_code(frame.f_code)
-    match dis.opname[code[i]]:
-        case "UNPACK_SEQUENCE":
-            return _instruction_arg(code, i), False
-        case "UNPACK_EX":
-            # low byte: items before the star, high byte: after; +1 feeds the star
-            arg = _instruction_arg(code, i)
-            return (arg & 0xFF) + (arg >> 8) + 1, False
-        case "CALL_FUNCTION_EX":
-            return None, True
-        case _:
-            return None, False
+    return dis.opname[_co_code(frame.f_code)[i]] == "CALL_FUNCTION_EX"
 
 
 def _decide() -> bool:
@@ -238,7 +216,6 @@ class _SpyType(type):
 class _SpyObject(_Spy, metaclass=_SpyType):
     __optype_element__: "_SpyObject | None" = None
     __optype_iterator__: bool = False
-    __optype_arity__: "int | None" = None
     __optype_growable__: bool = False
     __optype_absent__: "frozenset[str]" = frozenset()
     # spies are descriptors (`__get__`), so only ever read through the class `__dict__`
@@ -371,17 +348,14 @@ class _SpyObject(_Spy, metaclass=_SpyType):
     # no need for `__missing__`
 
     def __iter__(self, /) -> "_SpyObject":
-        arity, growable = _iter_context()
+        growable = _iter_is_star_unpack()
 
         if self.__optype_iterator__:
-            if arity is not None:
-                self.__optype_arity__ = arity
             if growable:
                 self.__optype_growable__ = True
             return self  # an iterator is its own iterable (idempotent `iter()`)
 
         out = _iterator_of(self)
-        out.__optype_arity__ = arity
         out.__optype_growable__ = growable
         return self.__optype_trace_add__("__iter__", (), {}, out)
 
@@ -395,16 +369,10 @@ class _SpyObject(_Spy, metaclass=_SpyType):
     def __next__(self, /) -> Any:
         # count from the trace, not a field, so a forked run's rollback is reflected
         served = sum(1 for item in self.__optype_trace__ if item.attr == "__next__")
-        arity, growable = self.__optype_arity__, self.__optype_growable__
-        limit = (
-            arity
-            if arity is not None
-            else _yield_budget.get()
-            if growable
-            else _DEFAULT_YIELD
-        )
+        growable = self.__optype_growable__
+        limit = _yield_budget.get() if growable else _DEFAULT_YIELD
         if served >= limit:
-            if growable and arity is None:
+            if growable:
                 _starved.set(True)
             raise StopIteration
         return self.__optype_trace_add__("__next__", (), {}, _element_of(self))

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -14,15 +14,15 @@ import sys
 import warnings
 import weakref
 from collections.abc import Callable
-from inspect import Parameter, currentframe
+from inspect import currentframe, signature
 from types import MappingProxyType
 from typing import Any
 
 import pytest
 
-from optype.infer import InferError, InferWarning, _api, infer
+from optype.infer import InferError, InferWarning, infer
 from optype.infer._api import _Gap
-from optype.infer._explore import _doc_signatures, _GapKind, _parameter_forms
+from optype.infer._explore import _GapKind
 from optype.infer._ir import (
     App,
     Arg,
@@ -539,7 +539,7 @@ VARIADIC_CASES: list[tuple[Callable[..., Any], str]] = [
     (lambda *args: args, "[*Ts](*args: *Ts) -> tuple[*Ts]"),
     (lambda *args: (args, 1), "[*Ts](*args: *Ts) -> tuple[tuple[*Ts], Literal[1]]"),
     (_call_packed, "[*Ts, R](x: (tuple[*Ts]) -> R, *args: *Ts) -> R"),
-    # a splat splices the TypeVarTuple into the surrounding tuple
+    # a star-unpack splices the TypeVarTuple into the surrounding tuple
     (lambda *args: (1, *args), "[*Ts](*args: *Ts) -> tuple[Literal[1], *Ts]"),
     (
         lambda *args: (1, *args, 2),
@@ -802,11 +802,6 @@ def _unpack_pair(x: Any) -> Any:
     return a, b
 
 
-def _unpack_triple(x: Any) -> Any:
-    a, b, c = x
-    return a, b, c
-
-
 def _unpack_star(x: Any) -> Any:
     a, *b = x
     return a, b
@@ -820,12 +815,6 @@ def _unpack_iter(x: Any) -> Any:
 def _divmod_unpack(x: Any, y: Any) -> Any:
     div, mod = divmod(x, y)
     return div, mod
-
-
-def _unpack_two_seqs(x: Any, y: Any) -> Any:
-    a, b = x
-    c, d, e = y
-    return a, b, c, d, e
 
 
 ITERATOR_CASES: list[tuple[Callable[..., Any], str]] = [
@@ -879,21 +868,13 @@ ITERATOR_CASES: list[tuple[Callable[..., Any], str]] = [
     ),
     # fixed-size unpacking (#683)
     (_unpack_pair, "[R](x: CanIter[CanNext[R]]) -> tuple[R, R]"),
-    (_unpack_triple, "[R](x: CanIter[CanNext[R]]) -> tuple[R, R, R]"),
     (_unpack_star, "[R](x: CanIter[CanNext[R]]) -> tuple[R, list[R]]"),
     (_unpack_iter, "[R](x: CanIter[CanNext[R]]) -> tuple[R, R]"),
-    (
-        _unpack_two_seqs,
-        (
-            "[R, R2](x: CanIter[CanNext[R]], y: CanIter[CanNext[R2]]) "
-            "-> tuple[R, R, R2, R2, R2]"
-        ),
-    ),
     (
         lambda x: {k: v for k, v in x},  # noqa: C416
         "[R: CanHash](x: CanIter[CanNext[CanIter[CanNext[R]]]]) -> dict[R, R]",
     ),
-    # a splat into a fixed-arity call (#683)
+    # a star-unpack into a fixed-arity call (#683)
     (
         lambda x, y: divmod(*divmod(x, y)),  # type: ignore[misc]
         (
@@ -1093,7 +1074,8 @@ def test_method_descriptor_unsupported() -> None:
     # generators cannot be constructed, spy-rejecting parameters without a default
     # have nothing to fall back on, and an empty `self` cannot always run
     send = type(x for x in range(0)).send
-    with pytest.raises(InferError, match="cannot instantiate 'generator'"):
+    # before 3.13, `generator.send` has no `inspect.signature` to explore at all
+    with pytest.raises(InferError, match=r"instantiate 'generator'|no signature"):
         infer(send)
     with pytest.raises(InferError, match="expected str instance"):
         infer(str.join)
@@ -1529,8 +1511,18 @@ def test_variadic_exhausted() -> None:
         infer(lambda *args: args[10_000])
 
 
-def test_unpack_mixed_splat() -> None:
-    # two splats of different fixed arities can't share one budget
+def test_fixed_unpack_beyond_default_unsupported() -> None:
+    # an iterator yields two by default, so a 3+ target unpack can't be satisfied
+    def f(x: Any) -> Any:
+        a, b, c = x
+        return a, b, c
+
+    with pytest.raises(InferError):
+        infer(f)
+
+
+def test_mixed_star_unpack() -> None:
+    # two star unpackings of different fixed arities can't share one budget
     def f(a: Any, b: Any) -> Any:
         return divmod(*a), _takes3(*b)  # type: ignore[misc]
 
@@ -1538,8 +1530,8 @@ def test_unpack_mixed_splat() -> None:
         infer(f)
 
 
-def test_unpack_splat_no_budget_leak() -> None:
-    # the splat's grown budget (here 3) must not leak to `sum(z)`; isolated, `z` keeps
+def test_star_unpack_no_budget_leak() -> None:
+    # star-unpack's grown budget (here 3) must not leak to `sum(z)`; `z` alone keeps
     # the default yield of 2, so its `CanAdd` chain stays one level deep (#683, #686)
     assert infer(lambda x, z: (_takes3(*x), sum(z))) == (
         "[T: CanRAdd[Literal[0], CanAdd[T, R2]], R, R2]"
@@ -1550,14 +1542,14 @@ def test_unpack_splat_no_budget_leak() -> None:
     )
 
 
-def test_unpack_splat_gap_arity() -> None:
-    # a splat into a 9-ary call lands on a budget the old sparse range skipped (#683)
+def test_star_unpack_gap_arity() -> None:
+    # a star-unpack into a 9-ary call hits a budget the old sparse range skipped (#683)
     assert infer(lambda x: _takes9(*x)) == "[R](x: CanIter[CanNext[R]]) -> R"
 
 
-def test_unpack_args_and_splat() -> None:
-    # `*args` and a growable splat coexist: each grows its own budget instead of the
-    # `*args` retry starving the splat of yields (#683)
+def test_args_and_star_unpack() -> None:
+    # `*args` and a growable star-unpack coexist: each grows its own budget instead of
+    # the `*args` retry starving the star-unpack of yields (#683)
     def f(*args: Any) -> Any:
         return divmod(*divmod(args[0], args[1]))  # type: ignore[misc]
 
@@ -1566,9 +1558,9 @@ def test_unpack_args_and_splat() -> None:
     assert "CanRDivmod" in sig
 
 
-def test_unpack_splat_error_not_masked() -> None:
-    # a non-arity error from a splat target must surface as-is, not be buried under a
-    # bogus "got N args" after needlessly climbing the whole yield budget (#683)
+def test_star_unpack_error_not_masked() -> None:
+    # a non-arity error from a star-unpack target must surface as-is, not buried under
+    # a bogus "got N args" after needlessly climbing the whole yield budget (#683)
     def picky(_a: Any) -> Any:
         raise ValueError("domain error")
 
@@ -1951,49 +1943,6 @@ def test_not_callable() -> None:
         infer(not_callable)
 
 
-def test_doc_signatures() -> None:
-    def f() -> None: ...
-
-    f.__doc__ = "f(a) -> z\nf(a, b) -> z"
-    assert _doc_signatures(f) == [["a"], ["a", "b"]]
-
-    # defaults and optional-bracket groups reduce to bare parameter names
-    f.__doc__ = "f(a, b=1, [c]) -> z"
-    assert _doc_signatures(f) == [["a", "b", "c"]]
-
-    # same-arity forms render identically, so only the first is kept
-    f.__doc__ = "f(a) -> z\nf(b) -> z\nf(c, d) -> z"
-    assert _doc_signatures(f) == [["a"], ["c", "d"]]
-
-    # no arrow: fall back to the first form (e.g. `next`, `slice`)
-    f.__doc__ = "f(a, b)\nFor example, f(x, y)."
-    assert _doc_signatures(f) == [["a", "b"]]
-
-    # a usage example, not a signature: its keyword arg is no parameter name
-    f.__doc__ = "Apply f. For example, f(lambda x, y: x + y, [1, 2, 3])."
-    assert _doc_signatures(f) == []
-
-    f.__doc__ = "no signature line here"
-    assert _doc_signatures(f) == []
-
-
-def test_doc_signature() -> None:
-    # builtins like `int` have no signature; fall back to the docstring. The
-    # unsatisfiable `int(x, base)` form is dropped silently, without a warning.
-    with warnings.catch_warnings():
-        warnings.simplefilter("error", InferWarning)
-        assert infer(int) == "(x: CanInt | CanIndex) -> int"
-
-
-def _needs_doc(func: Callable[..., object]) -> pytest.MarkDecorator:
-    # some Python builds strip the call-form lines from a builtin's docstring, leaving
-    # no parameters to recover; only assert the output where the build provides them
-    return pytest.mark.skipif(
-        not _doc_signatures(func),
-        reason=f"{getattr(func, '__name__', func)!r} docstring carries no call forms",
-    )
-
-
 def test_iter() -> None:
     # the callable_iterator enrichment, independent of `iter`'s own docstring
     assert infer(lambda f, s: iter(f, s)) == "[R](f: () -> R, s: object) -> Iterator[R]"
@@ -2002,111 +1951,14 @@ def test_iter() -> None:
     assert infer(lambda s: iter(int, s)) == "(s: object) -> callable_iterator"
 
 
-@_needs_doc(iter)
-def test_iter_overloads() -> None:
-    assert infer(iter) == (
-        "[R](iterable: CanIter[R]) -> R\n"
-        "[R](callable: () -> R, sentinel: object) -> Iterator[R]"
-    )
-
-
-@_needs_doc(max)
-@_needs_doc(min)
-def test_max_min() -> None:
-    assert infer(max) == (
-        "[T, U: CanGt[T, CanBool], V: CanGt[U | T, CanBool]]"
-        "(iterable: T, default: U, key: V) -> V | U | T\n"
-        "[T, U: CanGt[T, CanBool], V: CanGt[U | T, CanBool], "
-        "W: CanGt[V | U | T, CanBool]]"
-        "(arg1: T, arg2: U, args: V, key: W) -> W | V | U | T"
-    )
-    assert infer(min) == (
-        "[T, U: CanLt[T, CanBool], V: CanLt[U | T, CanBool]]"
-        "(iterable: T, default: U, key: V) -> V | U | T\n"
-        "[T, U: CanLt[T, CanBool], V: CanLt[U | T, CanBool], "
-        "W: CanLt[V | U | T, CanBool]]"
-        "(arg1: T, arg2: U, args: V, key: W) -> W | V | U | T"
-    )
-
-
-@_needs_doc(max)
-def test_select_filters_forms() -> None:
-    # `iterable` belongs to the first form only; the second is filtered out silently,
-    # not reported as a form with "no satisfying placeholder"
-    with warnings.catch_warnings():
-        warnings.simplefilter("error", InferWarning)
-        assert infer(max, "iterable") == (
-            "[T, U: CanGt[T, CanBool], V: CanGt[U | T, CanBool]]"
-            "(iterable: T) -> V | U | T"
-        )
-    # a name in no form is still a clean selection error
-    with pytest.raises(ValueError, match="unknown parameter"):
-        infer(max, "zzz")
-
-
-@pytest.mark.parametrize(
-    ("func", "expected"),
-    [
-        # forms differing only in parameter name collapse to one (mapping/iterable/...)
-        pytest.param(
-            dict,
-            (
-                "[R: CanHash, R2](mapping: Has['keys', () -> +CanIter[CanNext[R]]]"
-                " & CanGetitem[R, R2]) -> dict[R, R2]"
-            ),
-            marks=_needs_doc(dict),
-        ),
-        pytest.param(str, "(object: CanStr) -> str", marks=_needs_doc(str)),
-        pytest.param(range, "(stop: CanIndex) -> range", marks=_needs_doc(range)),
-        pytest.param(
-            bytes,
-            "(iterable_of_ints: CanBytes) -> bytes",
-            marks=_needs_doc(bytes),
-        ),
-        # the second form raises during exploration and drops out
-        pytest.param(type, "[T](object: T) -> type[T]", marks=_needs_doc(type)),
-        # no arrow forms in the docstring: the single fallback form
-        pytest.param(
-            next,
-            "[R](iterator: CanNext[R], default: object) -> R",
-            marks=_needs_doc(next),
-        ),
-        pytest.param(slice, "(stop: object) -> slice", marks=_needs_doc(slice)),
-    ],
-)
-def test_single_form_builtins(func: Callable[..., Any], expected: str) -> None:
-    # the unsatisfiable forms are omitted silently; that silence is asserted below
-    assert infer(func) == expected
-
-
-@pytest.mark.skipif(
-    len(_parameter_forms(str)) < 2,
-    reason="this build's str docstring exposes a single call form",
-)
-def test_omitted_form_silent() -> None:
-    # dropping a form no placeholder can satisfy is routine, not warning-worthy
-    with warnings.catch_warnings():
-        warnings.simplefilter("error", InferWarning)
-        assert infer(str) == "(object: CanStr) -> str"
-
-
-def test_all_forms_unsatisfiable(monkeypatch: pytest.MonkeyPatch) -> None:
-    # every form fails exploration and yields no line: the reasons surface as one error
-    def boom(*_args: object) -> object:
-        raise TypeError("boom")
-
-    pos = Parameter.POSITIONAL_OR_KEYWORD
-    forms = [
-        {"a": Parameter("a", pos)},
-        {"a": Parameter("a", pos), "b": Parameter("b", pos)},
-    ]
-    monkeypatch.setattr(_api, "_parameter_forms", lambda _func: forms)
-    with pytest.raises(InferError, match="boom"):
-        infer(boom)
-
-
-def test_type() -> None:
-    assert infer(type) == "[T](object: T) -> type[T]"
+def test_builtin_without_signature() -> None:
+    try:
+        signature(iter)
+    except ValueError:
+        with pytest.raises(InferError):
+            infer(iter)
+    else:
+        pytest.skip("this build exposes an `inspect.signature` for `iter`")
 
 
 def test_dynamic_attr_name() -> None:


### PR DESCRIPTION
Mostly behavior preserving, with the notable exception that the very flaky signature-from-docstring regex parsing stuff is now also removed. This means that `optype infer type` now no  longer works, which I'll address in a follow-up.