### PR TITLE
`infer`: signature probing

### DIFF
--- a/optype/infer/_api.py
+++ b/optype/infer/_api.py
@@ -3,7 +3,7 @@
 import warnings
 from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
-from inspect import Parameter
+from inspect import Parameter, signature
 
 # `from . import` would import the package itself, which imports this module
 import optype.infer._numpy as _numpy
@@ -20,7 +20,6 @@ from ._explore import (
     _explore_lenient,
     _explore_spies,
     _GapKind,
-    _parameters,
 )
 from ._render import (
     _Defaults,
@@ -29,6 +28,7 @@ from ._render import (
     union_signature,
     widened_signature,
 )
+from ._signature import probe_signatures
 from ._spy import _AnyFunc, _TraceItem
 from ._values import map_values
 
@@ -192,7 +192,7 @@ def _dispatch_overloads(
     return baseline + tail if tail else baseline
 
 
-def _infer_form(
+def _overloads(
     func: _AnyFunc,
     parameters: Mapping[str, Parameter],
     params: tuple[str | int, ...],
@@ -217,13 +217,34 @@ def _infer_form(
     return list(dict.fromkeys((*overloads, *lines)))
 
 
+def _candidate_parameters(func: _AnyFunc) -> list[dict[str, Parameter]]:
+    try:
+        return [dict(signature(func).parameters)]
+    except TypeError as exc:  # not callable
+        raise InferError(str(exc)) from exc
+    except ValueError as exc:  # callable but no signature (e.g. a C builtin)
+        if (probed := probe_signatures(func)) is None:
+            raise InferError(str(exc)) from exc
+        return probed
+
+
 def _infer(func: _AnyFunc, params: tuple[str | int, ...], gaps: set[_Gap]) -> str:
     if nin := _numpy.ufunc_nin(func):
         names = _numpy.ufunc_params(nin)
         return _numpy.infer_ufunc(func, names, _select(params, names))
 
-    parameters = _parameters(func)
-    return "\n".join(_infer_form(func, parameters, params, gaps))
+    lines: list[str] = []
+    last: Exception | None = None
+    for parameters in _candidate_parameters(func):
+        try:
+            lines += _overloads(func, parameters, params, gaps)
+        except (InferError, ValueError) as exc:
+            # a candidate arity may fail exploration (e.g. `int`'s base); drop it,
+            # re-raising below only if no candidate produced anything
+            last = exc
+    if not lines and last is not None:
+        raise last
+    return "\n".join(dict.fromkeys(lines))
 
 
 def infer(func: _AnyFunc, /, *params: str | int, strict: bool = False) -> str:

--- a/optype/infer/_signature.py
+++ b/optype/infer/_signature.py
@@ -1,0 +1,45 @@
+"""Recover a signatureless callable's parameters by trial and error.
+
+Many C builtins (`type`, `iter`, `min`, ...) have no `inspect.signature`. Calling them
+with spy placeholders at each arity reveals which arities the body accepts: a correct
+arity runs the body (records a trace or returns), while a wrong one raises `TypeError`
+before the body runs.
+"""
+
+from inspect import Parameter
+
+from ._spy import _AnyFunc, _Fork, _SpyObject
+
+_MAX_PROBE_ARITY = 8
+
+
+def _accepts(func: _AnyFunc, n: int) -> bool:
+    """Whether `func` runs its body when called with `n` positional placeholders."""
+    spies = [_SpyObject() for _ in range(n)]
+    try:
+        func(*spies)
+    except (_Fork, Exception, SystemExit) as exc:  # noqa: BLE001
+        # a wrong-arity `TypeError` is raised before the body runs, leaving the spies
+        # untouched; a touched spy or any other error (or exit) means the body ran
+        if type(exc) is TypeError:
+            return any(spy.__optype_trace__ for spy in spies)
+    return True
+
+
+def _params(n: int, *, var_positional: bool) -> dict[str, Parameter]:
+    params = {f"_{i}": Parameter(f"_{i}", Parameter.POSITIONAL_ONLY) for i in range(n)}
+    if var_positional:
+        params["args"] = Parameter("args", Parameter.VAR_POSITIONAL)
+    return params
+
+
+def probe_signatures(func: _AnyFunc) -> list[dict[str, Parameter]] | None:
+    """A synthetic parameter mapping per explorable arity, or `None` if none run."""
+    if not (arities := {n for n in range(_MAX_PROBE_ARITY + 1) if _accepts(func, n)}):
+        return None
+
+    if _MAX_PROBE_ARITY in arities:
+        # an unbounded arity is variadic: one `*args` the explorer grows into
+        return [_params(min(arities), var_positional=True)]
+
+    return [_params(n, var_positional=False) for n in arities]

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -1955,10 +1955,30 @@ def test_builtin_without_signature() -> None:
     try:
         signature(iter)
     except ValueError:
-        with pytest.raises(InferError):
-            infer(iter)
+        pass
     else:
         pytest.skip("this build exposes an `inspect.signature` for `iter`")
+    # the arity probe recovers a signatureless builtin instead of raising, exploring
+    # each accepted arity as a separate overload
+    assert infer(iter) == "[R](CanIter[R]) -> R\n[R](() -> R, object) -> Iterator[R]"
+
+
+def test_builtin_type() -> None:
+    # the metaclass `type` has no `inspect.signature`; the probe recovers its 1-argument
+    # form (the 3-argument metaclass call needs typed placeholders, out of scope)
+    assert infer(type) == "[T](T) -> type[T]"
+
+
+def test_builtin_variadic() -> None:
+    # an arity accepted all the way to the probe cap is rendered as `*args`
+    assert infer(min) == "[T, U: CanLt[T | U, CanBool]](T, *args: U) -> U | T"
+
+
+def test_builtin_typed_argument() -> None:
+    # `getattr` needs a real `str` name that an object spy cannot supply, so no arity
+    # explores and it raises rather than inferring a bogus signature
+    with pytest.raises(InferError):
+        infer(getattr)
 
 
 def test_dynamic_attr_name() -> None:
@@ -2040,6 +2060,13 @@ def test_cli_returned_function() -> None:
     out = _run_cli("-m", "optype", "infer", "lambda x: lambda y: (x, y)")
     assert out.returncode == 0
     assert out.stdout.strip() == "[T, U](x: T) -> (y: U) -> tuple[T, U]"
+
+
+def test_cli_builtin() -> None:
+    # a signatureless builtin is recovered by the arity probe instead of erroring out
+    out = _run_cli("-m", "optype", "infer", "type")
+    assert out.returncode == 0
+    assert out.stdout.strip() == "[T](T) -> type[T]"
 
 
 def test_cli_usage() -> None:


### PR DESCRIPTION
before:

```console
$ optype infer "type"
InferError: no signature found for builtin <class 'type'> (ValueError: no signature found for builtin <class 'type'>)
```

after:

```console
$ optype infer "type"
[T](T) -> type[T]
```

Note that the 3-argument `type` case isn't found with this, as that would significantly complicate the probing logic. Maybe I'll circle back to it later though.