### PR TITLE
`infer`: some refactoring

### DIFF
--- a/optype/infer/_analyze.py
+++ b/optype/infer/_analyze.py
@@ -5,7 +5,7 @@ from collections.abc import Generator, Iterable, Mapping, Sequence
 from itertools import groupby
 from typing import cast
 
-from ._protocols import _DUNDER_ATTR, _DUNDER_CAN_R, _DUNDER_CLASS_ATTR
+from ._protocols import DUNDER_ATTR, DUNDER_CAN_R, DUNDER_CLASS_ATTR
 from ._spy import _Marker, _own_spy, _Spy, _SpyObject, _TraceItem, _Traces, as_spy
 from ._values import _children, _Fn, _Gen, _Rec, _RecRef, _walk
 
@@ -138,7 +138,7 @@ def _shape(spy: _SpyObject, made_by: _Producer, keys: dict[int, object]) -> obje
         attr = item.attr
         arity: object = (
             item.args[0]
-            if attr in _DUNDER_ATTR or attr in _DUNDER_CLASS_ATTR
+            if attr in DUNDER_ATTR or attr in DUNDER_CLASS_ATTR
             else len(item.args)
         )
         owner_key = _shape(owner, made_by, keys)
@@ -242,7 +242,7 @@ def reflect(params: Sequence[_SpyObject], traces: _Traces) -> _Traces:
         keep: list[_TraceItem] = []
         for item in traces[id(spy)]:
             rhs = item.args[0] if item.args else None
-            if item.attr in _DUNDER_CAN_R and isinstance(rhs, _SpyObject):
+            if item.attr in DUNDER_CAN_R and isinstance(rhs, _SpyObject):
                 reflected = _TraceItem("__r" + item.attr[2:], (spy,), {}, item.return_)
                 added[id(_own_spy(rhs))].append(reflected)
             else:

--- a/optype/infer/_api.py
+++ b/optype/infer/_api.py
@@ -7,37 +7,20 @@ from inspect import Parameter, signature
 
 # `from . import` would import the package itself, which imports this module
 import optype.infer._numpy as _numpy
-from ._analyze import (
-    absent_verdict,
-    dispatch_candidates,
-    requires_only_presence,
-    returns_concrete,
-)
 from ._errors import InferError, InferWarning
-from ._explore import (
-    _declared_defaults,
-    _Exploration,
-    _explore_lenient,
-    _explore_spies,
-    _GapKind,
-)
-from ._render import (
-    _Defaults,
-    _Names,
-    signatures,
-    union_signature,
-    widened_signature,
-)
+from ._explore import explore_lenient
+from ._overloads import dispatch_overloads, resolve_defaults
+from ._render import Names, signatures
 from ._signature import probe_signatures
-from ._spy import _AnyFunc, _TraceItem
-from ._values import map_values
+from ._spy import _AnyFunc
+from ._values import GapKind
 
 
 @dataclass(frozen=True, slots=True)
 class _Gap:
     """A coverage gap at a call form."""
 
-    kind: _GapKind
+    kind: GapKind
     where: str  # the call form, e.g. "(x, y)"
 
     def message(self) -> str:
@@ -48,7 +31,7 @@ class _SelectError(ValueError):
     """A selected parameter or position is absent from the signature."""
 
 
-def _select(params: Iterable[str | int], names: _Names) -> _Names:
+def _select(params: Iterable[str | int], names: Names) -> Names:
     selected: list[str] = []
     for p in params:
         if isinstance(p, int):
@@ -64,135 +47,7 @@ def _select(params: Iterable[str | int], names: _Names) -> _Names:
     return selected or names
 
 
-def _bind(value: object, binding: Mapping[int, object]) -> object:
-    """A deep copy of `value` with every bound spy replaced by its binding."""
-    return map_values(value, lambda v: binding.get(id(v), v))
-
-
-def _bind_exploration(exp: _Exploration, defaults: _Defaults) -> _Exploration:
-    """The exploration as it would look with every defaulted parameter omitted."""
-    spies = exp.spies
-    binding = {id(spies[name]): value for name, value in defaults.items()}
-    # so that a `type(spy)` result becomes `type(default)`
-    binding |= {id(type(spies[name])): type(value) for name, value in defaults.items()}
-    bound = {
-        spy_id: [
-            _TraceItem(
-                item.attr,
-                tuple(_bind(arg, binding) for arg in item.args),
-                {key: _bind(val, binding) for key, val in item.kwargs.items()},
-                item.return_,
-            )
-            for item in items
-        ]
-        for spy_id, items in exp.traces.items()
-    }
-    kept = {name: spy for name, spy in spies.items() if name not in defaults}
-    bound_results = [_bind(result, binding) for result in exp.results]
-    return _Exploration(
-        kept,
-        bound,
-        bound_results,
-        exp.var_count,
-        exp.fixed,
-        exp.deprecated,
-        exp.gaps,
-    )
-
-
-def _defaults(
-    func: _AnyFunc,
-    params: Mapping[str, Parameter],
-    selected: _Names,
-    exploration: _Exploration,
-) -> tuple[_Defaults, bool, list[str]]:
-    """The parameter defaults if expressible as typevar defaults, else overloads.
-
-    Omitting the defaulted parameters must behave like substituting their values
-    into the generic signature; the function is rerun without them to check. On a
-    mismatch the omitted calls are reported as separate overload lines, and a
-    single defaulted parameter's type is excluded from the generic signature.
-    """
-    defaults = _declared_defaults(params)
-    kinds = {p.kind for p in params.values()}
-    if not defaults or (
-        # `*args` placeholders would positionally fill an omitted default
-        Parameter.VAR_POSITIONAL in kinds
-        and any(params[n].kind is not Parameter.KEYWORD_ONLY for n in defaults)
-    ):
-        return {}, False, []
-
-    required = {name: p for name, p in params.items() if name not in defaults}
-    names = list(required)
-
-    try:
-        omitted = _explore_spies(func, params, omit=defaults)
-        # the comparison must see every required parameter, regardless of selection
-        observed = signatures(omitted, required, names)
-    except Exception:  # noqa: BLE001
-        return {}, False, []
-
-    omitted_defaults = _bind_exploration(exploration, defaults)
-    if signatures(omitted_defaults, required, names) == observed:
-        return defaults, False, []
-
-    overloads = signatures(omitted, params, selected, defaults)
-
-    if len(defaults) == 1:
-        return defaults, True, overloads
-
-    for name, value in defaults.items():
-        try:
-            variant = _explore_spies(func, params, omit={name})
-        except Exception:  # noqa: BLE001, S112
-            continue
-        overloads += signatures(variant, params, selected, {name: value})
-
-    return {}, False, overloads
-
-
-def _dispatch_overloads(
-    func: _AnyFunc,
-    params: Mapping[str, Parameter],
-    selected: _Names,
-    exploration: _Exploration,
-    baseline: list[str],
-) -> list[str]:
-    """The overloads for a presence-test on a single parameter's attribute.
-
-    Forcing the attribute absent surfaces the branch a placeholder hides. If the return
-    ignores the attribute's value, one overload covers it: the parameter widens to
-    `object`, the return unions both branches. If the present branch returns the value,
-    that overload stays over an `object` fallback. Otherwise the `baseline` holds.
-    """
-    candidates = (
-        dispatch_candidates(exploration.spies, exploration.traces)
-        if len(params) == 1
-        else ()
-    )
-    if len(candidates) != 1:
-        return baseline
-    ((param, name),) = candidates
-    if not requires_only_presence(exploration.spies, exploration.traces, param, name):
-        return baseline
-    try:
-        variant = _explore_spies(func, params, absent={param: (name,)})
-    except Exception:  # noqa: BLE001
-        return baseline
-    widens = absent_verdict(variant.spies, variant.traces, param, name)
-    if widens is None:
-        return baseline
-    if (
-        widens
-        and returns_concrete(exploration.results)
-        and returns_concrete(variant.results)
-    ):
-        return union_signature(exploration, variant, params, selected)
-    tail = widened_signature(variant, params, selected)
-    return baseline + tail if tail else baseline
-
-
-def _overloads(
+def _form_signatures(
     func: _AnyFunc,
     parameters: Mapping[str, Parameter],
     params: tuple[str | int, ...],
@@ -201,7 +56,7 @@ def _overloads(
     selected = _select(params, list(parameters))
     where = f"({', '.join(parameters)})"
     try:
-        exploration, fallback = _explore_lenient(func, parameters)
+        exploration, fallback = explore_lenient(func, parameters)
     except (IndexError, TypeError, ValueError) as exc:
         raise InferError(str(exc)) from exc
     gaps.update(_Gap(kind, where) for kind in exploration.gaps)
@@ -209,11 +64,16 @@ def _overloads(
         # the rejected parameters render from their defaults; skip the probing
         lines = signatures(exploration, parameters, selected, fallback)
         return list(dict.fromkeys(lines))
-    defaults, negate, overloads = _defaults(func, parameters, selected, exploration)
+    defaults, negate, overloads = resolve_defaults(
+        func,
+        parameters,
+        selected,
+        exploration,
+    )
     lines = signatures(exploration, parameters, selected, defaults, negate=negate)
     if not defaults and not overloads:
         # dispatch only when defaults didn't already split the form
-        lines = _dispatch_overloads(func, parameters, selected, exploration, lines)
+        lines = dispatch_overloads(func, parameters, selected, exploration, lines)
     return list(dict.fromkeys((*overloads, *lines)))
 
 
@@ -237,7 +97,7 @@ def _infer(func: _AnyFunc, params: tuple[str | int, ...], gaps: set[_Gap]) -> st
     last: Exception | None = None
     for parameters in _candidate_parameters(func):
         try:
-            lines += _overloads(func, parameters, params, gaps)
+            lines += _form_signatures(func, parameters, params, gaps)
         except (InferError, ValueError) as exc:
             # a candidate arity may fail exploration (e.g. `int`'s base); drop it,
             # re-raising below only if no candidate produced anything

--- a/optype/infer/_explore.py
+++ b/optype/infer/_explore.py
@@ -14,7 +14,6 @@ from collections.abc import (
 )
 from contextlib import suppress
 from contextvars import ContextVar
-from enum import StrEnum
 from functools import partial
 from inspect import Parameter, isasyncgen, iscoroutine, isgenerator, signature
 from itertools import islice
@@ -25,7 +24,7 @@ from types import (
     MethodType,
     WrapperDescriptorType,
 )
-from typing import Any, NamedTuple, cast
+from typing import Any, cast
 
 from ._errors import InferError
 from ._spy import (
@@ -43,7 +42,18 @@ from ._spy import (
     _yield_budget,
     as_spy,
 )
-from ._values import _Fn, _Gen, _Rec, _RecRef, _RecVar, _walk, fn_spies
+from ._values import (
+    VARIADIC_KINDS,
+    Exploration,
+    GapKind,
+    _Fn,
+    _Gen,
+    _Rec,
+    _RecRef,
+    _RecVar,
+    _walk,
+    fn_spies,
+)
 
 _FORK_LIMIT = 64
 _RUN_LIMIT = 256
@@ -55,25 +65,6 @@ _KWARGS_LIMIT = 8  # max injected `**kwargs` keys
 # yield budgets to try for a star-unpack into a fixed-arity call (e.g. `divmod`): an
 # exact arity is needed, so these stay contiguous; a sparse range would skip valid ones
 _YIELD_COUNTS = tuple(range(2, 17))
-
-
-class _GapKind(StrEnum):
-    """A reason the exploration could not cover every path."""
-
-    BRANCH_BUDGET = "branch budget exhausted"
-    RUN_BUDGET = "run budget exhausted"
-
-
-class _Exploration(NamedTuple):
-    """What one exploration of a function against spy placeholders produced."""
-
-    spies: Mapping[str, _SpyObject]
-    traces: _Traces
-    results: list[object]
-    var_count: int  # the `*args` placeholder count
-    fixed: Mapping[str, object]  # parameters passed as-is, not spies
-    deprecated: str | None = None  # a `DeprecationWarning` message raised when called
-    gaps: frozenset[_GapKind] = frozenset()  # kinds of unexplored path
 
 
 def _reachable(params: Iterable[object]) -> Generator[_SpyObject]:
@@ -112,7 +103,7 @@ def _parameters(func: _AnyFunc) -> Mapping[str, Parameter]:
         raise InferError(str(exc)) from exc
 
 
-def _declared_defaults(params: Mapping[str, Parameter]) -> dict[str, object]:
+def declared_defaults(params: Mapping[str, Parameter]) -> dict[str, object]:
     """The declared parameter defaults, by name."""
     return {n: p.default for n, p in params.items() if p.default is not Parameter.empty}
 
@@ -187,7 +178,6 @@ _FUNCTION_TYPES = (
     MethodDescriptorType,
     WrapperDescriptorType,
 )
-_VARIADIC_KINDS = frozenset({Parameter.VAR_POSITIONAL, Parameter.VAR_KEYWORD})
 
 # the (unwrapped) functions currently being explored, see `_explore_key`
 _exploring: ContextVar[frozenset[int]] = ContextVar("_exploring", default=frozenset())
@@ -236,16 +226,16 @@ def _explore_func(func: _AnyFunc) -> object:
         return func  # a recursive function type is inexpressible
     try:
         params = _parameters(func)
-        if any(p.kind in _VARIADIC_KINDS for p in params.values()):
+        if any(p.kind in VARIADIC_KINDS for p in params.values()):
             return func  # variadic parameters are not expressible (yet)
-        exploration, _ = _explore_lenient(func, params)
+        exploration, _ = explore_lenient(func, params)
     except Exception:  # noqa: BLE001  # an unexplorable function stays opaque
         return func
     return _Fn(
         params,
         exploration.spies,
         exploration.fixed,
-        _declared_defaults(params),
+        declared_defaults(params),
         exploration.results,
     )
 
@@ -280,7 +270,7 @@ def _next(result: object, path: dict[int, _RecVar | None] | None = None) -> obje
         # would stop at the sentinel and pollute it. Referent 0 is the callable (per
         # `_CALLABLE_FIRST`; not a spy-search, since the sentinel may be a spy too).
         # Calling `fn()` is deliberate: the recorded `__call__` is what renders the
-        # parameter as `() -> R`, as `_explore_spies` snapshots after this runs.
+        # parameter as `() -> R`, as `explore_spies` snapshots after this runs.
         out = _Gen([_next(fn(), path)], "Iterator")
     elif isinstance(_unwrap(result), _FUNCTION_TYPES):
         out = _explore_func(cast("_AnyFunc", result))
@@ -337,7 +327,7 @@ def _explore[T](
     func: Callable[..., T] | Callable[..., Coroutine[Any, None, T]],
     args: Sequence[object],
     kwds: Mapping[str, object],
-) -> tuple[list[T], str | None, frozenset[_GapKind]]:
+) -> tuple[list[T], str | None, frozenset[GapKind]]:
     results: list[T] = []
     deprecated: str | None = None
     stack: list[list[bool]] = [[]]
@@ -378,7 +368,7 @@ def _explore[T](
             _fork.reset(token)
     if not results:
         raise InferError("the function never ran to completion") from last_exc
-    hits = (dropped, _GapKind.BRANCH_BUDGET), (bool(stack), _GapKind.RUN_BUDGET)
+    hits = (dropped, GapKind.BRANCH_BUDGET), (bool(stack), GapKind.RUN_BUDGET)
     gaps = frozenset(kind for hit, kind in hits if hit)
     return results, deprecated, gaps
 
@@ -441,13 +431,13 @@ def _force_absent(
             spy.__optype_absent__ = frozenset(attrs)
 
 
-def _explore_spies(
+def explore_spies(
     func: _AnyFunc,
     params: Mapping[str, Parameter],
     omit: Collection[str] = (),
     fix: Collection[str] = (),
     absent: Mapping[str, Collection[str]] | None = None,
-) -> _Exploration:
+) -> Exploration:
     kinds = {p.kind for p in params.values()}
     forced_absent = absent or {}
 
@@ -507,7 +497,7 @@ def _explore_spies(
                 else:
                     raise
             else:
-                return _Exploration(
+                return Exploration(
                     spies,
                     _snapshot((*spies.values(), *fn_spies(results))),
                     results,
@@ -522,24 +512,24 @@ def _explore_spies(
         _exploring.reset(token)
 
 
-def _explore_lenient(
+def explore_lenient(
     func: _AnyFunc,
     params: Mapping[str, Parameter],
-) -> tuple[_Exploration, Mapping[str, object]]:
+) -> tuple[Exploration, Mapping[str, object]]:
     # if a spy placeholder is rejected, fall back to fixing the defaulted parameters,
     # and also return every parameter default for rendering
     try:
-        return _explore_spies(func, params), {}
+        return explore_spies(func, params), {}
     except (TypeError, ValueError):
-        defaults = _declared_defaults(params)
+        defaults = declared_defaults(params)
         if not defaults:
             raise
     # start from the all-fixed baseline and greedily promote one spy at a time
     fix = set(defaults)
-    exploration = _explore_spies(func, params, fix=fix)
+    exploration = explore_spies(func, params, fix=fix)
     for name in defaults:
         with suppress(Exception):
-            exploration = _explore_spies(func, params, fix=fix - {name})
+            exploration = explore_spies(func, params, fix=fix - {name})
             fix.discard(name)
     # a still-fixed default widens to its type; a promoted one keeps its literal
     return exploration, {

--- a/optype/infer/_numpy.py
+++ b/optype/infer/_numpy.py
@@ -7,6 +7,7 @@ from typing import cast
 # `from . import` would import the package itself, which imports this module
 import optype.infer._ir as _ir
 from ._spy import _AnyFunc
+from ._values import VARIADIC_KINDS
 
 DUNDER_CAN_MAP = {
     "__array_ufunc__": "CanArrayUFunc",
@@ -23,8 +24,6 @@ _DTYPE_RANK: dict[str, int] = {
     char: rank for rank, (chars, _) in enumerate(_DTYPE_KINDS) for char in chars
 }
 _DTYPE_ALIASES = [alias for _, alias in _DTYPE_KINDS]
-
-_PARAM_VAR = frozenset({Parameter.VAR_POSITIONAL, Parameter.VAR_KEYWORD})
 
 
 def ufunc_nin(func: _AnyFunc) -> int | None:
@@ -68,7 +67,7 @@ def _required_args(func: _AnyFunc) -> int | None:
         params = signature(func).parameters.values()
     except (TypeError, ValueError):
         return None
-    if any(p.kind in _PARAM_VAR for p in params):
+    if any(p.kind in VARIADIC_KINDS for p in params):
         return None
     return sum(
         p.kind is not Parameter.KEYWORD_ONLY and p.default is Parameter.empty

--- a/optype/infer/_overloads.py
+++ b/optype/infer/_overloads.py
@@ -1,0 +1,154 @@
+"""Synthesize the overload variants of a single call form.
+
+Two situations split one generic signature into separate overload lines: parameter
+defaults that cannot be expressed as typevar defaults, and a presence-test on a single
+parameter's attribute.
+"""
+
+from collections.abc import Mapping
+from inspect import Parameter
+
+from ._analyze import (
+    absent_verdict,
+    dispatch_candidates,
+    requires_only_presence,
+    returns_concrete,
+)
+from ._explore import declared_defaults, explore_spies
+from ._render import (
+    Defaults,
+    Names,
+    signatures,
+    union_signature,
+    widened_signature,
+)
+from ._spy import _AnyFunc, _TraceItem
+from ._values import Exploration, map_values
+
+
+def _bind(value: object, binding: Mapping[int, object]) -> object:
+    """A deep copy of `value` with every bound spy replaced by its binding."""
+    return map_values(value, lambda v: binding.get(id(v), v))
+
+
+def _bind_exploration(exp: Exploration, defaults: Defaults) -> Exploration:
+    """The exploration as it would look with every defaulted parameter omitted."""
+    spies = exp.spies
+    binding = {id(spies[name]): value for name, value in defaults.items()}
+    # so that a `type(spy)` result becomes `type(default)`
+    binding |= {id(type(spies[name])): type(value) for name, value in defaults.items()}
+    bound = {
+        spy_id: [
+            _TraceItem(
+                item.attr,
+                tuple(_bind(arg, binding) for arg in item.args),
+                {key: _bind(val, binding) for key, val in item.kwargs.items()},
+                item.return_,
+            )
+            for item in items
+        ]
+        for spy_id, items in exp.traces.items()
+    }
+    kept = {name: spy for name, spy in spies.items() if name not in defaults}
+    bound_results = [_bind(result, binding) for result in exp.results]
+    return Exploration(
+        kept,
+        bound,
+        bound_results,
+        exp.var_count,
+        exp.fixed,
+        exp.deprecated,
+        exp.gaps,
+    )
+
+
+def resolve_defaults(
+    func: _AnyFunc,
+    params: Mapping[str, Parameter],
+    selected: Names,
+    exploration: Exploration,
+) -> tuple[Defaults, bool, list[str]]:
+    """The parameter defaults if expressible as typevar defaults, else overloads.
+
+    Omitting the defaulted parameters must behave like substituting their values
+    into the generic signature; the function is rerun without them to check. On a
+    mismatch the omitted calls are reported as separate overload lines, and a
+    single defaulted parameter's type is excluded from the generic signature.
+    """
+    defaults = declared_defaults(params)
+    kinds = {p.kind for p in params.values()}
+    if not defaults or (
+        # `*args` placeholders would positionally fill an omitted default
+        Parameter.VAR_POSITIONAL in kinds
+        and any(params[n].kind is not Parameter.KEYWORD_ONLY for n in defaults)
+    ):
+        return {}, False, []
+
+    required = {name: p for name, p in params.items() if name not in defaults}
+    names = list(required)
+
+    try:
+        omitted = explore_spies(func, params, omit=defaults)
+        # the comparison must see every required parameter, regardless of selection
+        observed = signatures(omitted, required, names)
+    except Exception:  # noqa: BLE001
+        return {}, False, []
+
+    omitted_defaults = _bind_exploration(exploration, defaults)
+    if signatures(omitted_defaults, required, names) == observed:
+        return defaults, False, []
+
+    overloads = signatures(omitted, params, selected, defaults)
+
+    if len(defaults) == 1:
+        return defaults, True, overloads
+
+    for name, value in defaults.items():
+        try:
+            variant = explore_spies(func, params, omit={name})
+        except Exception:  # noqa: BLE001, S112
+            continue
+        overloads += signatures(variant, params, selected, {name: value})
+
+    return {}, False, overloads
+
+
+def dispatch_overloads(
+    func: _AnyFunc,
+    params: Mapping[str, Parameter],
+    selected: Names,
+    exploration: Exploration,
+    baseline: list[str],
+) -> list[str]:
+    """The overloads for a presence-test on a single parameter's attribute.
+
+    Forcing the attribute absent surfaces the branch a placeholder hides. If the return
+    ignores the attribute's value, one overload covers it: the parameter widens to
+    `object`, the return unions both branches. If the present branch returns the value,
+    that overload stays over an `object` fallback. Otherwise the `baseline` holds.
+    """
+    candidates = (
+        dispatch_candidates(exploration.spies, exploration.traces)
+        if len(params) == 1
+        else ()
+    )
+    if len(candidates) != 1:
+        return baseline
+    ((param, name),) = candidates
+    if not requires_only_presence(exploration.spies, exploration.traces, param, name):
+        return baseline
+    try:
+        variant = explore_spies(func, params, absent={param: (name,)})
+    except Exception:  # noqa: BLE001
+        return baseline
+    widens = absent_verdict(variant.spies, variant.traces, param, name)
+    if widens is None:
+        return baseline
+    if (
+        widens
+        and returns_concrete(exploration.results)
+        and returns_concrete(variant.results)
+    ):
+        return union_signature(exploration, variant, params, selected)
+    tail = widened_signature(variant, params, selected)
+    return baseline + tail if tail else baseline

--- a/optype/infer/_protocols.py
+++ b/optype/infer/_protocols.py
@@ -10,8 +10,8 @@ from optype._core import _can, _has
 from optype.inspect import get_protocol_members
 
 _DUNDER_ATTR_WRITE = frozenset({"__delattr__", "__setattr__"})
-_DUNDER_ATTR = frozenset({"__getattr__", "__getattribute__"}) | _DUNDER_ATTR_WRITE
-_DUNDER_CLASS_ATTR = frozenset({
+DUNDER_ATTR = frozenset({"__getattr__", "__getattribute__"}) | _DUNDER_ATTR_WRITE
+DUNDER_CLASS_ATTR = frozenset({
     _Marker.CLASS_DELATTR,
     _Marker.CLASS_GETATTR,
     _Marker.CLASS_SETATTR,
@@ -24,14 +24,14 @@ def _get_dunder_can_map() -> dict[str, str]:
         for name in _can.__all__
         if not name.endswith(("Self", "Same"))
         if len(members := get_protocol_members(getattr(_can, name))) == 1
-        if (dunder := next(iter(members))) not in _DUNDER_ATTR
+        if (dunder := next(iter(members))) not in DUNDER_ATTR
         # CanPow2, CanRound1, ... share their dunder; keep the canonical protocol
         if dunder.replace("_", "") == name.removeprefix("Can").lower()
     } | _numpy.DUNDER_CAN_MAP
 
 
 _DUNDER_CAN_MAP = _get_dunder_can_map()
-_DUNDER_CAN_R = frozenset(
+DUNDER_CAN_R = frozenset(
     dunder
     for dunder, proto in _DUNDER_CAN_MAP.items()
     if "CanR" + proto.removeprefix("Can") in _DUNDER_CAN_MAP.values()
@@ -58,11 +58,11 @@ _COERCION_PROTOS = {
     for dunder, fallback in _COERCION_FALLBACK.items()
 }
 
-type _Proto = str | tuple[str, ...]  # a tuple is rendered as a union of protocols
+type Proto = str | tuple[str, ...]  # a tuple is rendered as a union of protocols
 
 
-class _Op(NamedTuple):
-    proto: _Proto
+class Op(NamedTuple):
+    proto: Proto
     args: _Args
     kwargs: _Kwargs
     ret: object
@@ -70,8 +70,8 @@ class _Op(NamedTuple):
     classvar: bool = False  # a class-level attribute, i.e. a `ClassVar` member
 
 
-def resolve(trace: _TraceItem) -> _Op:
-    if trace.attr in _DUNDER_ATTR or trace.attr in _DUNDER_CLASS_ATTR:
+def resolve(trace: _TraceItem) -> Op:
+    if trace.attr in DUNDER_ATTR or trace.attr in DUNDER_CLASS_ATTR:
         name = trace.args[0]
         if not isinstance(name, str) or isinstance(name, _Spy):
             msg = "no protocol for a dynamic attribute name"
@@ -79,24 +79,24 @@ def resolve(trace: _TraceItem) -> _Op:
 
         # a class-level attribute mirrors a `ClassVar` protocol member, which no
         # shipped instance-member `Has*` protocol declares
-        if trace.attr in _DUNDER_CLASS_ATTR:
-            return _Op("Has", trace.args[1:], {}, trace.return_, name, classvar=True)
+        if trace.attr in DUNDER_CLASS_ATTR:
+            return Op("Has", trace.args[1:], {}, trace.return_, name, classvar=True)
 
         # a read of an attribute with a shipped single-member `Has*` protocol
         if name in _DUNDER_HAS_MAP and trace.attr not in _DUNDER_ATTR_WRITE:
-            return _Op(_DUNDER_HAS_MAP[name], (), {}, trace.return_)
+            return Op(_DUNDER_HAS_MAP[name], (), {}, trace.return_)
 
         # everything else synthesizes the inline `Has['name', T]` form; a write
         # binds the assigned value's type, which a bounded `Has*` could reject
-        return _Op("Has", trace.args[1:], {}, trace.return_, name)
+        return Op("Has", trace.args[1:], {}, trace.return_, name)
 
     # checked before _DUNDER_CAN_MAP, which also contains the coercion dunders
     if trace.attr in _COERCION_PROTOS:
-        return _Op(_COERCION_PROTOS[trace.attr], (), {}, trace.return_)
+        return Op(_COERCION_PROTOS[trace.attr], (), {}, trace.return_)
 
     if trace.attr in _DUNDER_CAN_MAP:
         proto = _DUNDER_CAN_MAP[trace.attr]
-        return _Op(proto, trace.args, trace.kwargs, trace.return_)
+        return Op(proto, trace.args, trace.kwargs, trace.return_)
 
     msg = f"no protocol for {trace.attr!r}"
     raise InferError(msg)

--- a/optype/infer/_render.py
+++ b/optype/infer/_render.py
@@ -7,6 +7,7 @@ from collections import Counter
 from collections.abc import Callable, Collection, Iterable, Mapping, Sequence
 from inspect import Parameter, _ParameterKind
 from typing import Any, cast, final
+from weakref import WeakMethod
 
 # `from . import` would import the package itself, which imports this module
 import optype.infer._ir as _ir
@@ -20,8 +21,7 @@ from ._analyze import (
     return_spies,
     spy_runs,
 )
-from ._explore import _Exploration
-from ._protocols import _Op, _Proto, resolve
+from ._protocols import Op, Proto, resolve
 from ._spy import (
     _AnyFunc,
     _class_spy,
@@ -34,7 +34,16 @@ from ._spy import (
     _Traces,
     as_spy,
 )
-from ._values import _Fn, _Gen, _Rec, _RecRef, _RecVar, _walk, fn_spies
+from ._values import (
+    Exploration,
+    _Fn,
+    _Gen,
+    _Rec,
+    _RecRef,
+    _RecVar,
+    _walk,
+    fn_spies,
+)
 from optype.inspect import is_generic_alias, is_union_type
 
 _PARAM_PREFIX: dict[_ParameterKind, str] = {
@@ -56,8 +65,8 @@ _READ = _ir.COVARIANT  # a read-only property suffices
 _WRITE = _ir.CONTRAVARIANT  # the attribute only has to accept the value
 
 type _Vars = dict[int, str]
-type _Names = Sequence[str]
-type _Defaults = Mapping[str, object]
+type Names = Sequence[str]
+type Defaults = Mapping[str, object]
 
 
 def _or_object(node: _ir.Node | None) -> _ir.Node:
@@ -77,7 +86,7 @@ def _is_sentinel(x: object, /) -> bool:
     return sys.version_info >= (3, 15) and isinstance(x, getattr(builtins, "sentinel"))  # noqa: B009
 
 
-def _suffix(defaults: _Defaults, name: str) -> str:
+def _suffix(defaults: Defaults, name: str) -> str:
     """The ` = <default>` suffix of a defaulted parameter, in stub style."""
     if name not in defaults:
         return ""
@@ -163,9 +172,11 @@ class _Renderer:
     _param_spies: list[_SpyObject]
     _group_traces: _Traces
 
+    _typer: "_ResultTyper"  # renders explored result values into type nodes
+
     def __init__(
         self,
-        exploration: _Exploration,
+        exploration: Exploration,
         params: Mapping[str, Parameter],
         traces: _Traces,
     ) -> None:
@@ -178,6 +189,15 @@ class _Renderer:
 
         self._configure(params)
         self._assign_typevars()
+        # the typer shares the live `_vars` map (mutated in place while inlining)
+        self._typer = _ResultTyper(
+            vars_=self._vars,
+            rec_vars=self._rec_vars,
+            slot=self._slot,
+            varpos=self._varpos,
+            vartuple=self._vartuple,
+            count=self._count,
+        )
         self._inline_single_use()
 
     def _configure(self, params: Mapping[str, Parameter]) -> None:
@@ -292,7 +312,7 @@ class _Renderer:
         rendered = [
             *(self._slot(spy) for spy in self._param_spies),
             *(node for node in bounds.values() if node is not None),
-            self._type_union(self._results),
+            self._typer.type_union(self._results),
         ]
         counts = Counter(name for node in rendered for name in _ir.names(node))
 
@@ -316,9 +336,12 @@ class _Renderer:
             for n, old in enumerate(var for var in pool_vars if var not in inline)
         }
 
-        self._vars = {
+        # mutate `_vars` in place so the typer's shared reference stays current
+        survivors = {
             sid: remap.get(var, var) for sid, var in vars_.items() if var not in inline
         }
+        self._vars.clear()
+        self._vars.update(survivors)
         self._declared_spies = [
             spy for spy in self._declared_spies if id(spy) in self._vars
         ]
@@ -345,28 +368,7 @@ class _Renderer:
                 self._result_spies.append(spy)
                 self._named[rep] = var
 
-    def _value_union(
-        self,
-        values: Iterable[object],
-        *,
-        tuples: bool = False,
-    ) -> _ir.Node | None:
-        """The union of `values` as literals; `_type_union` widens them to types."""
-        literals: list[object] = []
-        parts: list[_ir.Node] = []
-        for value in values:
-            if isinstance(value, int | str | bytes) and not isinstance(value, _Spy):
-                literals.append(value)
-            else:
-                parts.append(self.return_type(value))
-
-        nodes: list[_ir.Node] = []
-        if literals:
-            nodes.append(_ir.Lit(tuple(literals)))
-        nodes.extend(dict.fromkeys(parts))
-        return _ir.union(nodes, tuples=tuples)
-
-    def returns(self, members: Iterable[_Op]) -> _ir.Node | None:
+    def returns(self, members: Iterable[Op]) -> _ir.Node | None:
         named: list[str] = []
         items: list[_TraceItem] = []
         returned = False
@@ -389,7 +391,7 @@ class _Renderer:
 
     def _collapse_varargs(
         self,
-        members: Sequence[_Op],
+        members: Sequence[Op],
         pos: list[_ir.Node],
     ) -> list[_ir.Node]:
         # the variadic spreads `count` copies of one spy: the placeholder (`f(*args)`)
@@ -412,10 +414,10 @@ class _Renderer:
         ):
             return pos
 
-        inner = _ir.tuple_node_variadic(self.return_type(tail))
+        inner = _ir.tuple_node_variadic(self._typer.return_type(tail))
         return [*pos[: len(pos) - count], _ir.Unpack(inner)]
 
-    def group(self, proto: _Proto, members: Sequence[_Op]) -> _ir.Node:
+    def group(self, proto: Proto, members: Sequence[Op]) -> _ir.Node:
         if isinstance(proto, tuple):  # coercion protocols, which record no args
             return _ir.Union(tuple(map(_ir.Name, proto)))
 
@@ -427,14 +429,15 @@ class _Renderer:
         pos = [
             arg
             for i in range(len(members[0].args))
-            if (arg := self._value_union(m.args[i] for m in members)) is not None
+            if (arg := self._typer.value_union(m.args[i] for m in members)) is not None
         ]
         args = (
             *pos,
             *(
                 _ir.Arg(key, kw)
                 for key in members[0].kwargs
-                if (kw := self._value_union(m.kwargs[key] for m in members)) is not None
+                if (kw := self._typer.value_union(m.kwargs[key] for m in members))
+                is not None
             ),
         )
         ret = self.returns(members)
@@ -464,8 +467,8 @@ class _Renderer:
         # name, so it spares the other reads
         optional = {item.args for item in items if item.attr == _Marker.ABSENT}
         groups: dict[
-            tuple[_Proto, str | None, bool, int, tuple[str, ...]],
-            list[_Op],
+            tuple[Proto, str | None, bool, int, tuple[str, ...]],
+            list[Op],
         ] = {}
         for item in items:
             if item.attr == _Marker.ABSENT:
@@ -513,6 +516,122 @@ class _Renderer:
             decl += f" = {_ir.render(default)}"
         return decl
 
+    def return_types(self) -> str:
+        return _ir.render(self._typer.type_union(self._results))
+
+    def render(
+        self,
+        selected: Names,
+        defaults: Defaults | None = None,
+        *,
+        negate: bool = False,
+        ret: _ir.Node | None = None,
+    ) -> str:
+        defaults = defaults or {}
+        defaulted = {
+            spy_id: node
+            for name, value in defaults.items()
+            if (spy := self._spies.get(name)) is not None
+            if (spy_id := id(spy)) in self._vars
+            if (node := self._typer.value_union((value,))) is not None
+        }
+        ordered = self._declared_spies + self._result_spies
+        if not negate:
+            # PEP 696 requires defaulted type parameters to come last
+            ordered.sort(key=lambda spy: id(spy) in defaulted)
+        typevars = [self.typevar(spy, defaulted, negate=negate) for spy in ordered]
+
+        # a recursive typevar carries no default, so it precedes the defaulted tail
+        deferred = 0 if negate else sum(id(spy) in defaulted for spy in ordered)
+        cut = len(ordered) - deferred
+        typevars[cut:cut] = [
+            f"{name}: {_ir.render(self._typer.return_type(self._rec_body[var]))}"
+            for var, name in self._rec_vars.items()
+        ]
+
+        generics = f"[{', '.join(typevars)}]" if typevars else ""
+        decls = (self._param(name, defaults, negate=negate) for name in selected)
+        params = ", ".join(decl for decl in decls if decl is not None)
+        returns = self.return_types() if ret is None else _ir.render(ret)
+        return f"{generics}({params}) -> {returns}"
+
+    def _param(
+        self,
+        name: str,
+        defaults: Defaults,
+        *,
+        negate: bool,
+    ) -> str | None:
+        # a positional-only parameter cannot be passed by keyword, so no name shows
+        label = "" if name in self._nameless else f"{self._prefix[name]}{name}: "
+        if name in self._fixed and name not in self._optional:
+            # a fixed parameter without a default is a method descriptor's `self`
+            return f"{label}{_ir.render(_ir.Type(type(self._fixed[name])))}"
+        if (spy := self._spies.get(name)) is None:
+            # an omitted parameter binds its default, so passing it behaves the same
+            node = self._typer.value_type(defaults[name])
+            return f"{label}{_ir.render(node)}{_suffix(defaults, name)}"
+        node = self._slot(spy)
+        if negate and name in defaults:
+            if id(spy) not in self._vars and (
+                mark := self._typer.value_union((defaults[name],))
+            ):
+                node = _ir.exclude(self.spy(spy), mark)
+            return f"{label}{_ir.render(node)}"
+        if node == _ir.Name(_OBJECT) and name in self._optional:
+            return None
+        return f"{label}{_ir.render(node)}{_suffix(defaults, name)}"
+
+
+@final
+class _ResultTyper:
+    """Render an explored runtime value as a type node, against the renderer's binding.
+
+    Bridges back via the `slot` callback (and the shared live `_vars`), so renderer and
+    typer are mutually recursive.
+    """
+
+    def __init__(  # noqa: PLR0913
+        self,
+        *,
+        vars_: _Vars,
+        rec_vars: dict[_RecVar, str],
+        slot: Callable[[_SpyObject], _ir.Node],
+        varpos: _SpyObject | None,
+        vartuple: bool,
+        count: int,
+    ) -> None:
+        self._vars = vars_  # the live map the renderer mutates while inlining
+        self._rec_vars = rec_vars
+        # Weak, not strong: a renderer<->typer cycle delays the `_fixed` spies to cyclic
+        # GC, where a buffer-exporting spy's C-level `__release_buffer__` lookup fails
+        # uncatchably. See `test_buffer_spy_finalizes_without_cycle`.
+        self._slot = WeakMethod(slot)
+        self._varpos = varpos
+        self._vartuple = vartuple
+        self._count = count
+
+    def value_union(
+        self,
+        values: Iterable[object],
+        *,
+        tuples: bool = False,
+    ) -> _ir.Node | None:
+        """The union of `values` as literals; `type_union` widens them to types."""
+        literals: list[object] = []
+        parts: list[_ir.Node] = []
+        for value in values:
+            if isinstance(value, int | str | bytes) and not isinstance(value, _Spy):
+                literals.append(value)
+            else:
+                parts.append(self.return_type(value))
+
+        nodes: list[_ir.Node] = []
+        if literals:
+            nodes.append(_ir.Lit(tuple(literals)))
+        nodes.extend(dict.fromkeys(parts))
+        return _ir.union(nodes, tuples=tuples)
+
     def return_type(self, result: object) -> _ir.Node:
         node: _ir.Node
         match result:
@@ -525,7 +644,7 @@ class _Renderer:
             case _SpyBytes():
                 node = _ir.Type(bytes)
             case _Gen():
-                node = _ir.App(result.kind, (self._type_union(result.yielded),))
+                node = _ir.App(result.kind, (self.type_union(result.yielded),))
             case _Fn():
                 node = self._function(result)
             case _ if result is None or _is_sentinel(result):
@@ -534,14 +653,14 @@ class _Renderer:
                 node = self._container(result)
         return node
 
-    def _type_union(self, values: Iterable[object]) -> _ir.Node:
+    def type_union(self, values: Iterable[object]) -> _ir.Node:
         """The deduplicated union of the types of `values`, or `Never` if empty."""
         parts = dict.fromkeys(map(self.return_type, values))
         return _ir.union(parts, tuples=True) or _ir.Name(_NEVER)
 
-    def _value_type(self, value: object) -> _ir.Node:
+    def value_type(self, value: object) -> _ir.Node:
         """The type of a single `value`, or `Never` if unconstrained."""
-        return self._value_union((value,)) or _ir.Name(_NEVER)
+        return self.value_union((value,)) or _ir.Name(_NEVER)
 
     def _function(self, fn: _Fn) -> _ir.Node:
         """The signature-syntax type of an explored function result."""
@@ -553,15 +672,17 @@ class _Renderer:
             )
             for name, p in fn.params.items()
         )
-        return _ir.Fn(params, self._type_union(fn.results))
+        return _ir.Fn(params, self.type_union(fn.results))
 
     def _fn_param(self, fn: _Fn, name: str) -> _ir.Node:
         if (spy := fn.spies.get(name)) is not None:
-            return self._slot(spy)
+            slot = self._slot()  # the renderer outlives every typer call
+            assert slot is not None
+            return slot(spy)
         value = fn.fixed[name]
         if name in fn.defaults:
             # a pinned default renders as its value, like the outer parameters do
-            return self._value_type(value)
+            return self.value_type(value)
         return _ir.Type(type(value))  # a method descriptor's pinned `self`
 
     def _class_of(self, cls: type[Any]) -> _ir.Node | None:
@@ -630,13 +751,13 @@ class _Renderer:
         match result:
             case Mapping():
                 mapping = cast("Mapping[object, object]", result)
-                key = self._value_union(mapping, tuples=True) or _ir.Name(_NEVER)
-                val = self._value_union(mapping.values(), tuples=True) or _ir.Name(
+                key = self.value_union(mapping, tuples=True) or _ir.Name(_NEVER)
+                val = self.value_union(mapping.values(), tuples=True) or _ir.Name(
                     _NEVER,
                 )
                 return _ir.App(_ir.render(_ir.Type(cls)), (key, val))
             case list() | set() | frozenset():
-                inner = self._value_union(
+                inner = self.value_union(
                     cast("Collection[object]", result),
                     tuples=True,
                 )
@@ -656,7 +777,7 @@ class _Renderer:
             if any(item is spy for item in items) and self._vartuple:
                 # every use is packed, so the placeholders unpack into a single `*Ts`
                 start = next(i for i, item in enumerate(items) if item is spy)
-                parts = [self._value_type(item) for item in items if item is not spy]
+                parts = [self.value_type(item) for item in items if item is not spy]
                 parts.insert(start, _ir.Unpack(_ir.Name(_TYPEVAR_TUPLE_NAME)))
                 return _ir.tuple_node(parts)
 
@@ -672,79 +793,13 @@ class _Renderer:
                     return _ir.tuple_node_variadic(self.return_type(target))
 
         if len(items) > _TUPLE_LIMIT:  # e.g. `random.getstate`
-            return _ir.tuple_node_variadic(self._type_union(items))
+            return _ir.tuple_node_variadic(self.type_union(items))
 
-        return _ir.tuple_node(self._value_type(item) for item in items)
-
-    def return_types(self) -> str:
-        return _ir.render(self._type_union(self._results))
-
-    def render(
-        self,
-        selected: _Names,
-        defaults: _Defaults | None = None,
-        *,
-        negate: bool = False,
-        ret: _ir.Node | None = None,
-    ) -> str:
-        defaults = defaults or {}
-        defaulted = {
-            spy_id: node
-            for name, value in defaults.items()
-            if (spy := self._spies.get(name)) is not None
-            if (spy_id := id(spy)) in self._vars
-            if (node := self._value_union((value,))) is not None
-        }
-        ordered = self._declared_spies + self._result_spies
-        if not negate:
-            # PEP 696 requires defaulted type parameters to come last
-            ordered.sort(key=lambda spy: id(spy) in defaulted)
-        typevars = [self.typevar(spy, defaulted, negate=negate) for spy in ordered]
-
-        # a recursive typevar carries no default, so it precedes the defaulted tail
-        deferred = 0 if negate else sum(id(spy) in defaulted for spy in ordered)
-        cut = len(ordered) - deferred
-        typevars[cut:cut] = [
-            f"{name}: {_ir.render(self.return_type(self._rec_body[var]))}"
-            for var, name in self._rec_vars.items()
-        ]
-
-        generics = f"[{', '.join(typevars)}]" if typevars else ""
-        decls = (self._param(name, defaults, negate=negate) for name in selected)
-        params = ", ".join(decl for decl in decls if decl is not None)
-        returns = self.return_types() if ret is None else _ir.render(ret)
-        return f"{generics}({params}) -> {returns}"
-
-    def _param(
-        self,
-        name: str,
-        defaults: _Defaults,
-        *,
-        negate: bool,
-    ) -> str | None:
-        # a positional-only parameter cannot be passed by keyword, so no name shows
-        label = "" if name in self._nameless else f"{self._prefix[name]}{name}: "
-        if name in self._fixed and name not in self._optional:
-            # a fixed parameter without a default is a method descriptor's `self`
-            return f"{label}{_ir.render(_ir.Type(type(self._fixed[name])))}"
-        if (spy := self._spies.get(name)) is None:
-            # an omitted parameter binds its default, so passing it behaves the same
-            node = self._value_type(defaults[name])
-            return f"{label}{_ir.render(node)}{_suffix(defaults, name)}"
-        node = self._slot(spy)
-        if negate and name in defaults:
-            if id(spy) not in self._vars and (
-                mark := self._value_union((defaults[name],))
-            ):
-                node = _ir.exclude(self.spy(spy), mark)
-            return f"{label}{_ir.render(node)}"
-        if node == _ir.Name(_OBJECT) and name in self._optional:
-            return None
-        return f"{label}{_ir.render(node)}{_suffix(defaults, name)}"
+        return _ir.tuple_node(self.value_type(item) for item in items)
 
 
 def _renderers(
-    exploration: _Exploration,
+    exploration: Exploration,
     params: Mapping[str, Parameter],
 ) -> list[_Renderer]:
     traces, results = exploration.traces, exploration.results
@@ -753,10 +808,10 @@ def _renderers(
 
 
 def signatures(
-    exploration: _Exploration,
+    exploration: Exploration,
     params: Mapping[str, Parameter],
-    selected: _Names,
-    defaults: _Defaults | None = None,
+    selected: Names,
+    defaults: Defaults | None = None,
     *,
     negate: bool = False,
 ) -> list[str]:
@@ -771,9 +826,9 @@ def signatures(
 
 
 def widened_signature(
-    exploration: _Exploration,
+    exploration: Exploration,
     params: Mapping[str, Parameter],
-    selected: _Names,
+    selected: Names,
 ) -> list[str]:
     """The fallback overload for a value dispatch, deduplicated: the parameter as the
     absent branch leaves it, the return widened to `object` (the only sound supertype of
@@ -793,10 +848,10 @@ def widened_signature(
 
 
 def union_signature(
-    exploration: _Exploration,
-    variant: _Exploration,
+    exploration: Exploration,
+    variant: Exploration,
     params: Mapping[str, Parameter],
-    selected: _Names,
+    selected: Names,
 ) -> list[str]:
     """The single overload for a presence dispatch whose return ignores the attribute's
     value: the parameter (forced absent in `variant`) widens to `object`, and the return

--- a/optype/infer/_spy.py
+++ b/optype/infer/_spy.py
@@ -46,9 +46,9 @@ class _Marker(StrEnum):
 _fork: ContextVar[Iterator[bool] | None] = ContextVar("_fork", default=None)
 
 # the yield count for a star-unpack iterator (`f(*x)`) whose arity no bytecode pins:
-# the arity it needs, which `_explore_spies` grows into until the call works
+# the arity it needs, which `explore_spies` grows into until the call works
 _yield_budget: ContextVar[int] = ContextVar("_yield_budget", default=1)
-# set when a growable star-unpack iterator hits the budget, so `_explore_spies` only
+# set when a growable star-unpack iterator hits the budget, so `explore_spies` only
 # grows the budget when a fixed-arity star unpacking actually came up short
 _starved: ContextVar[bool] = ContextVar("_starved", default=False)
 

--- a/optype/infer/_values.py
+++ b/optype/infer/_values.py
@@ -1,11 +1,33 @@
-"""The composite shapes of explored results, and the traversal over them."""
+"""The shared data shapes of an exploration: its record, and the explored results."""
 
 from collections.abc import Callable, Collection, Generator, Iterable, Mapping
+from enum import StrEnum
 from inspect import Parameter
 from itertools import chain
 from typing import NamedTuple, NewType, cast
 
-from ._spy import _SpyObject
+from ._spy import _SpyObject, _Traces
+
+VARIADIC_KINDS = frozenset({Parameter.VAR_POSITIONAL, Parameter.VAR_KEYWORD})
+
+
+class GapKind(StrEnum):
+    """A reason the exploration could not cover every path."""
+
+    BRANCH_BUDGET = "branch budget exhausted"
+    RUN_BUDGET = "run budget exhausted"
+
+
+class Exploration(NamedTuple):
+    """What one exploration of a function against spy placeholders produced."""
+
+    spies: Mapping[str, _SpyObject]
+    traces: _Traces
+    results: list[object]
+    var_count: int  # the `*args` placeholder count
+    fixed: Mapping[str, object]  # parameters passed as-is, not spies
+    deprecated: str | None = None  # a `DeprecationWarning` message raised when called
+    gaps: frozenset[GapKind] = frozenset()  # kinds of unexplored path
 
 
 class _Gen(NamedTuple):

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -5,6 +5,7 @@
 
 import builtins
 import functools
+import gc
 import math
 import operator
 import random
@@ -22,7 +23,6 @@ import pytest
 
 from optype.infer import InferError, InferWarning, infer
 from optype.infer._api import _Gap
-from optype.infer._explore import _GapKind
 from optype.infer._ir import (
     App,
     Arg,
@@ -38,6 +38,7 @@ from optype.infer._ir import (
     union,
 )
 from optype.infer._numpy import array_function_node
+from optype.infer._values import GapKind
 
 if sys.version_info >= (3, 13):
     from warnings import deprecated
@@ -1056,6 +1057,25 @@ def test_method_descriptor() -> None:
     assert infer(memoryview.tobytes) == "(memoryview, order: str = 'C') -> bytes"
 
 
+def test_buffer_spy_finalizes_without_cycle() -> None:
+    # A cycle that holds a buffer-exporting spy until cyclic GC makes its C-level
+    # `__release_buffer__` lookup fail as an unraisable. Guards the weak typer->renderer
+    # link; a strong ref would regress this silently (pytest ignores unraisables).
+    captured: list[object] = []
+    hook = sys.unraisablehook
+    sys.unraisablehook = lambda args: captured.append(args.err_msg)
+    enabled = gc.isenabled()
+    gc.disable()
+    try:
+        infer(memoryview.tobytes)
+        gc.collect()
+    finally:
+        if enabled:
+            gc.enable()
+        sys.unraisablehook = hook
+    assert not captured
+
+
 def test_method_descriptor_fixed_defaults() -> None:
     # a defaulted parameter whose spy the function rejects passes its default
     # instead, while the accepting parameters stay structural
@@ -1630,10 +1650,10 @@ def test_strict_silent_when_complete() -> None:
 
 
 def test_gap_message_and_dedup() -> None:
-    gap = _Gap(_GapKind.RUN_BUDGET, "(x)")
+    gap = _Gap(GapKind.RUN_BUDGET, "(x)")
     assert gap.message() == "run budget exhausted in (x)"
     # frozen and slotted, so equal gaps collapse in a set
-    assert len({gap, _Gap(_GapKind.RUN_BUDGET, "(x)")}) == 1
+    assert len({gap, _Gap(GapKind.RUN_BUDGET, "(x)")}) == 1
 
 
 def test_dispatch_hasattr_collapses_to_object() -> None:


### PR DESCRIPTION
Behavior-preserving; no change to `infer` output or the CLI.

- split overload synthesis out of `_api` into a new `_overloads` module
- extracted value-to-type rendering from `_Renderer` into a `_ResultTyper`
- moved the shared `Exploration`/`GapKind` carriers into `_values`
- deduplicated the variadic-kind constant
- unprefixed the cross-module API in `_explore`/`_render`/`_protocols` to match `_analyze`/`_ir`/`_numpy`

The `_ResultTyper` holds the renderer's `slot` via a `weakref.WeakMethod` on purpose: a strong ref forms a cycle that delays GC and makes a buffer-exporting spy finalize mid-run (flaky `__release_buffer__`).
