### PR TITLE
`infer`: fix second `next` and `anext` overloads

### DIFF
--- a/optype/infer/_explore.py
+++ b/optype/infer/_explore.py
@@ -43,6 +43,7 @@ from ._spy import (
     as_spy,
 )
 from ._values import (
+    COROUTINE,
     VARIADIC_KINDS,
     Exploration,
     GapKind,
@@ -58,13 +59,17 @@ from ._values import (
 _FORK_LIMIT = 64
 _RUN_LIMIT = 256
 _YIELD_LIMIT = 64
+_KWARGS_LIMIT = 8  # max injected `**kwargs` keys
+
 # the `*args` placeholder counts to try: exact arities first, then doubling so that
 # large indices stay within reach
 _VARIADIC_COUNTS = (2, 3, 4, 5, 6, 7, 8, 16, 32, 64, 128, 256, 512, 1024)
-_KWARGS_LIMIT = 8  # max injected `**kwargs` keys
 # yield budgets to try for a star-unpack into a fixed-arity call (e.g. `divmod`): an
 # exact arity is needed, so these stay contiguous; a sparse range would skip valid ones
 _YIELD_COUNTS = tuple(range(2, 17))
+
+# the `next`-like builtins, which return their trailing argument when exhausted
+_NEXT_BUILTINS = frozenset({next, anext})
 
 
 def _reachable(params: Iterable[object]) -> Generator[_SpyObject]:
@@ -256,7 +261,7 @@ def _next(result: object, path: dict[int, _RecVar | None] | None = None) -> obje
         out = _Gen([_next(v, path) for v in _yields(_sync(result))], "AsyncGenerator")
     elif isinstance(result, Coroutine):
         # a returned coroutine value (e.g. 2-arg `anext`'s `anext_awaitable`)
-        out = _Gen([_next(_await(result), path)], "Coroutine")
+        out = _Gen([_next(_await(result), path)], COROUTINE)
     elif cls in _ITERATOR_TYPES:
         values = _yields(cast("Iterable[Any]", result))
         if cls is enumerate:
@@ -298,6 +303,29 @@ def _next_container(
             return cls({key: _next(value, path) for key, value in result.items()})  # type:ignore[call-arg] # pyright:ignore[reportCallIssue,reportUnknownVariableType]
         case _:
             return result
+
+
+def _with_next_default(
+    func: _AnyFunc,
+    spies: Mapping[str, _SpyObject],
+    results: list[object],
+) -> list[object]:
+    # `next`/`anext` return `default` on an exhaustion branch the spies never reach
+    if func not in _NEXT_BUILTINS or (default := spies.get("_1")) is None:
+        return results
+
+    # `anext` resolves through an awaitable, so the default unions inside the coroutine
+    merged: list[object] = []
+    awaitable = False
+    for r in results:
+        if isinstance(r, _Gen) and r.kind == COROUTINE:
+            awaitable = True
+            merged.append(_Gen([*r.yielded, default], COROUTINE))
+        else:
+            merged.append(r)
+
+    # `next` returns the value directly, so the default joins as a sibling result
+    return merged if awaitable else [*results, default]
 
 
 def _rollback(marks: Iterable[tuple[_SpyObject, int]]) -> None:
@@ -473,7 +501,7 @@ def explore_spies(
             _force_absent(spies, forced_absent)
             try:
                 results, deprecated, gaps = _explore(func, args, kwds)
-                results = [_next(r) for r in results]
+                results = _with_next_default(func, spies, [_next(r) for r in results])
             except KeyError as exc:
                 key = exc.args[0] if exc.args else None
                 if (

--- a/optype/infer/_explore.py
+++ b/optype/infer/_explore.py
@@ -254,11 +254,14 @@ def _next(result: object, path: dict[int, _RecVar | None] | None = None) -> obje
         out = _Gen([_next(v, path) for v in _yields(result)], "Generator")
     elif isasyncgen(result):
         out = _Gen([_next(v, path) for v in _yields(_sync(result))], "AsyncGenerator")
+    elif isinstance(result, Coroutine):
+        # a returned coroutine value (e.g. 2-arg `anext`'s `anext_awaitable`)
+        out = _Gen([_next(_await(result), path)], "Coroutine")
     elif cls in _ITERATOR_TYPES:
-        values = _yields(cast("Iterable[object]", result))
+        values = _yields(cast("Iterable[Any]", result))
         if cls is enumerate:
             # `enumerate[R]` is parameterized by the element type, not the yields
-            values = [item for _, item in cast("list[tuple[int, object]]", values)]
+            values = [item for _, item in values]
         out = _Gen([_next(v, path) for v in values], cls.__name__)
     elif (
         cls is _CALLABLE_ITERATOR

--- a/optype/infer/_render.py
+++ b/optype/infer/_render.py
@@ -55,7 +55,6 @@ _PARAM_PREFIX: dict[_ParameterKind, str] = {
 _TYPEVARS = "TUVWXYZ"
 _TYPEVAR_TUPLE_NAME = "Ts"  # the PEP 646 typevar-tuple binder, used as `*Ts`
 
-_ANY = "Any"
 _NEVER = "Never"
 _OBJECT = "object"
 
@@ -647,10 +646,10 @@ class _ResultTyper:
             case _SpyBytes():
                 node = _ir.Type(bytes)
             case _Gen() if result.kind == COROUTINE:
-                # `Coroutine` has no defaults, so its yield and send types render too
-                any_ = _ir.Name(_ANY)
+                # an awaitable yields objects and is driven with `None`, as `CanAwait`
                 out = self.type_union(result.yielded)
-                node = _ir.App(COROUTINE, (any_, any_, out))
+                yields, sends = _ir.Name(_OBJECT), _ir.Name("None")
+                node = _ir.App(COROUTINE, (yields, sends, out))
             case _Gen():
                 node = _ir.App(result.kind, (self.type_union(result.yielded),))
             case _Fn():

--- a/optype/infer/_render.py
+++ b/optype/infer/_render.py
@@ -53,8 +53,11 @@ _PARAM_PREFIX: dict[_ParameterKind, str] = {
 
 _TYPEVARS = "TUVWXYZ"
 _TYPEVAR_TUPLE_NAME = "Ts"  # the PEP 646 typevar-tuple binder, used as `*Ts`
+
+_ANY = "Any"
 _NEVER = "Never"
 _OBJECT = "object"
+
 _TUPLE_LIMIT = 16
 
 # `object`-typed so the `is` check isn't flagged (`Callable` is a special form)
@@ -633,7 +636,6 @@ class _ResultTyper:
         return _ir.union(nodes, tuples=tuples)
 
     def return_type(self, result: object) -> _ir.Node:
-        node: _ir.Node
         match result:
             case _RecRef() | _Rec():
                 node = _ir.Name(self._rec_vars[result.var])
@@ -643,6 +645,11 @@ class _ResultTyper:
                 node = _ir.Type(str)
             case _SpyBytes():
                 node = _ir.Type(bytes)
+            case _Gen(kind="Coroutine"):
+                # `Coroutine` has no defaults, so its yield and send types render too
+                any_ = _ir.Name(_ANY)
+                out = self.type_union(result.yielded)
+                node = _ir.App("Coroutine", (any_, any_, out))
             case _Gen():
                 node = _ir.App(result.kind, (self.type_union(result.yielded),))
             case _Fn():

--- a/optype/infer/_render.py
+++ b/optype/infer/_render.py
@@ -35,6 +35,7 @@ from ._spy import (
     as_spy,
 )
 from ._values import (
+    COROUTINE,
     Exploration,
     _Fn,
     _Gen,
@@ -645,11 +646,11 @@ class _ResultTyper:
                 node = _ir.Type(str)
             case _SpyBytes():
                 node = _ir.Type(bytes)
-            case _Gen(kind="Coroutine"):
+            case _Gen() if result.kind == COROUTINE:
                 # `Coroutine` has no defaults, so its yield and send types render too
                 any_ = _ir.Name(_ANY)
                 out = self.type_union(result.yielded)
-                node = _ir.App("Coroutine", (any_, any_, out))
+                node = _ir.App(COROUTINE, (any_, any_, out))
             case _Gen():
                 node = _ir.App(result.kind, (self.type_union(result.yielded),))
             case _Fn():

--- a/optype/infer/_values.py
+++ b/optype/infer/_values.py
@@ -37,7 +37,7 @@ class _Gen(NamedTuple):
     kind: str
 
 
-# the `_Gen.kind` of an awaited coroutine, rendered as `Coroutine[Any, Any, R]`
+# the `_Gen.kind` of an awaited coroutine, rendered as `Coroutine[object, None, R]`
 COROUTINE = "Coroutine"
 
 

--- a/optype/infer/_values.py
+++ b/optype/infer/_values.py
@@ -37,6 +37,10 @@ class _Gen(NamedTuple):
     kind: str
 
 
+# the `_Gen.kind` of an awaited coroutine, rendered as `Coroutine[Any, Any, R]`
+COROUTINE = "Coroutine"
+
+
 class _Fn(NamedTuple):
     """An explored function result, rendered in signature syntax."""
 

--- a/optype/infer/_values.py
+++ b/optype/infer/_values.py
@@ -31,7 +31,7 @@ class Exploration(NamedTuple):
 
 
 class _Gen(NamedTuple):
-    """An explored generator or lazy iterator result, e.g. `Generator[R]`."""
+    """An explored generator, iterator, or coroutine result, e.g. `Generator[R]`."""
 
     yielded: list[object]
     kind: str

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -1237,11 +1237,16 @@ def test_infer_async() -> None:
 
 
 def test_infer_anext() -> None:
-    # 2-arg `anext` returns a coroutine to await, so it renders as `Coroutine`
+    # 2-arg `anext` returns a coroutine resolving to the value or the default
     assert infer(anext) == (
         "[R](CanANext[R]) -> R\n"
-        "[R](CanANext[CanAwait[R]], object) -> Coroutine[Any, Any, R]"
+        "[T, R](CanANext[CanAwait[R]], T) -> Coroutine[Any, Any, R | T]"
     )
+
+
+def test_infer_next_default() -> None:
+    # 2-arg `next` returns the value or the default on exhaustion
+    assert infer(next) == ("[R](CanNext[R]) -> R\n[T, R](CanNext[R], T) -> R | T")
 
 
 def test_infer_generator() -> None:

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -1236,6 +1236,14 @@ def test_infer_async() -> None:
     assert infer(async_for) == "[R](x: CanAIter[CanANext[CanAwait[R]]]) -> R"
 
 
+def test_infer_anext() -> None:
+    # 2-arg `anext` returns a coroutine to await, so it renders as `Coroutine`
+    assert infer(anext) == (
+        "[R](CanANext[R]) -> R\n"
+        "[R](CanANext[CanAwait[R]], object) -> Coroutine[Any, Any, R]"
+    )
+
+
 def test_infer_generator() -> None:
     # generator expressions are lazy, so they are iterated to trace what they yield
     def gen(xs: Any) -> Any:

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -1240,7 +1240,7 @@ def test_infer_anext() -> None:
     # 2-arg `anext` returns a coroutine resolving to the value or the default
     assert infer(anext) == (
         "[R](CanANext[R]) -> R\n"
-        "[T, R](CanANext[CanAwait[R]], T) -> Coroutine[Any, Any, R | T]"
+        "[T, R](CanANext[CanAwait[R]], T) -> Coroutine[object, None, R | T]"
     )
 
 


### PR DESCRIPTION
before:

```console
$ optype infer "next"
[R](CanNext[R]) -> R
[R](CanNext[R], object) -> R

$ optype infer "anext"
[R](CanANext[R]) -> R
(CanANext[object], object) -> anext_awaitable
```

after:

```console
$ optype infer "next"
[R](CanNext[R]) -> R
[T, R](CanNext[R], T) -> R | T

$ optype infer "anext"
[R](CanANext[R]) -> R
[T, R](CanANext[CanAwait[R]], T) -> Coroutine[object, None, R | T]
```