### PR TITLE
`infer`: generic `slice` builtin

### DIFF
--- a/optype/infer/_render.py
+++ b/optype/infer/_render.py
@@ -652,6 +652,15 @@ class _ResultTyper:
                 node = _ir.App(COROUTINE, (yields, sends, out))
             case _Gen():
                 node = _ir.App(result.kind, (self.type_union(result.yielded),))
+            case slice():
+                node = _ir.App(
+                    _ir.render(_ir.Type(slice)),
+                    (
+                        self.value_type(result.start),
+                        self.value_type(result.stop),
+                        self.value_type(result.step),
+                    ),
+                )
             case _Fn():
                 node = self._function(result)
             case _ if result is None or _is_sentinel(result):

--- a/optype/infer/_values.py
+++ b/optype/infer/_values.py
@@ -83,6 +83,8 @@ def _children(value: object) -> Iterable[object]:
             out = cast("Collection[object]", value)
         case Mapping():  # `dict`, and the `frozendict` builtin on Python 3.15+
             out = chain.from_iterable(cast("Mapping[object, object]", value).items())
+        case slice():
+            out = value.start, value.stop, value.step
         case _:
             out = ()
     return out
@@ -94,7 +96,7 @@ def _walk(value: object) -> Generator[object]:
         yield from _walk(child)
 
 
-def map_values(value: object, leaf: Callable[[object], object]) -> object:
+def map_values(value: object, leaf: Callable[[object], object]) -> object:  # noqa: C901
     """Rebuild `value` with each non-composite leaf replaced via `leaf`.
 
     Recurses into the same shapes as `_children`, but a `tuple` subclass (namedtuple)
@@ -134,6 +136,12 @@ def map_values(value: object, leaf: Callable[[object], object]) -> object:
                     type(value),  # pyright: ignore[reportUnknownArgumentType]
                 )
                 out = ctor(rebuilt)
+        case slice():
+            out = slice(
+                map_values(value.start, leaf),
+                map_values(value.stop, leaf),
+                map_values(value.step, leaf),
+            )
         case _:
             out = leaf(value)
     return out

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -2010,6 +2010,14 @@ def test_builtin_range() -> None:
     )
 
 
+def test_builtin_slice() -> None:
+    assert infer(slice) == (
+        "[T](T) -> slice[None, T, None]\n"
+        "[T, U](T, U) -> slice[T, U, None]\n"
+        "[T, U, V](T, U, V) -> slice[T, U, V]"
+    )
+
+
 def test_builtin_variadic() -> None:
     # an arity accepted all the way to the probe cap is rendered as `*args`
     assert infer(min) == "[T, U: CanLt[T | U, CanBool]](T, *args: U) -> U | T"


### PR DESCRIPTION
before:

```console
$ optype infer slice
(object) -> slice
(object, object) -> slice
(object, object, object) -> slice
```

after:

```console
$ optype infer slice
[T](T) -> slice[None, T, None]
[T, U](T, U) -> slice[T, U, None]
[T, U, V](T, U, V) -> slice[T, U, V]
```

This doesn't match with the typeshed `slice.__new__` signature ([src](https://github.com/python/typeshed/blob/8e6a886ca5b14742924be721d345a619762d6e93/stdlib/builtins.pyi#L1103-L1126)) because those don't match the runtime behavior and is needlessly type-unsafe (`Any` instead of `None`).

closes #721