### PR TITLE
`infer`: generic `itertools` types

### DIFF
--- a/optype/infer/_explore.py
+++ b/optype/infer/_explore.py
@@ -1,6 +1,7 @@
 """Run a function against spy placeholders and record what happens."""
 
 import gc
+import itertools
 import warnings
 from collections.abc import (
     AsyncGenerator,
@@ -9,6 +10,7 @@ from collections.abc import (
     Coroutine,
     Generator,
     Iterable,
+    Iterator,
     Mapping,
     Sequence,
 )
@@ -16,7 +18,6 @@ from contextlib import suppress
 from contextvars import ContextVar
 from functools import partial
 from inspect import Parameter, isasyncgen, iscoroutine, isgenerator, signature
-from itertools import islice
 from types import (
     BuiltinFunctionType,
     FunctionType,
@@ -70,6 +71,30 @@ _YIELD_COUNTS = tuple(range(2, 17))
 
 # the `next`-like builtins, which return their trailing argument when exhausted
 _NEXT_BUILTINS = frozenset({next, anext})
+
+# single-arg lazy iterators, mapped to their rendered name; itertools entries are
+# derived from the module, so new ones register automatically
+_ITERATOR_TYPES: dict[type, str] = (
+    {  # type: ignore[assignment]
+        enumerate: "enumerate",
+        filter: "filter",
+        map: "map",
+        zip: "zip",
+    }
+    | {
+        cls: f"itertools.{cls.__qualname__}"
+        for name, cls in vars(itertools).items()
+        if isinstance(cls, type)
+        and issubclass(cls, Iterator)
+        and not name.startswith("_")
+        and cls is not itertools.groupby  # 2 type args
+    }
+    # typeshed types `tee()` as `tuple[Iterator[T], ...]`
+    | {type(itertools.tee(())[0]): "Iterator"}
+)
+
+# the lazy iterator returned by the 2-argument `iter(callable, sentinel)`
+_CALLABLE_ITERATOR = type(iter(int, None))
 
 
 def _reachable(params: Iterable[object]) -> Generator[_SpyObject]:
@@ -142,7 +167,7 @@ def _yield_key(value: object) -> tuple[str, *tuple[str, ...]]:
 def _yields[T](values: Iterable[T]) -> list[T]:
     seen: set[tuple[str, ...]] = set()
     out: list[T] = []
-    for value in islice(values, _YIELD_LIMIT):
+    for value in itertools.islice(values, _YIELD_LIMIT):
         if (key := _yield_key(value)) in seen:
             break
         seen.add(key)
@@ -157,13 +182,6 @@ def _sync[T](agen: AsyncGenerator[T, Any]) -> Generator[T]:
             yield _await(anext(agen))
         except StopAsyncIteration:
             return
-
-
-# lazy builtin iterators with a single type argument
-_ITERATOR_TYPES = frozenset({enumerate, filter, map, zip})
-
-# the lazy iterator returned by the 2-argument `iter(callable, sentinel)`
-_CALLABLE_ITERATOR = type(iter(int, None))
 
 
 def _ref0_is_callable() -> bool:
@@ -262,12 +280,12 @@ def _next(result: object, path: dict[int, _RecVar | None] | None = None) -> obje
     elif isinstance(result, Coroutine):
         # a returned coroutine value (e.g. 2-arg `anext`'s `anext_awaitable`)
         out = _Gen([_next(_await(result), path)], COROUTINE)
-    elif cls in _ITERATOR_TYPES:
+    elif (kind := _ITERATOR_TYPES.get(cls)) is not None:
         values = _yields(cast("Iterable[Any]", result))
         if cls is enumerate:
             # `enumerate[R]` is parameterized by the element type, not the yields
             values = [item for _, item in values]
-        out = _Gen([_next(v, path) for v in values], cls.__name__)
+        out = _Gen([_next(v, path) for v in values], kind)
     elif (
         cls is _CALLABLE_ITERATOR
         and _CALLABLE_FIRST

--- a/optype/infer/_render.py
+++ b/optype/infer/_render.py
@@ -645,13 +645,8 @@ class _ResultTyper:
                 node = _ir.Type(str)
             case _SpyBytes():
                 node = _ir.Type(bytes)
-            case _Gen() if result.kind == COROUTINE:
-                # an awaitable yields objects and is driven with `None`, as `CanAwait`
-                out = self.type_union(result.yielded)
-                yields, sends = _ir.Name(_OBJECT), _ir.Name("None")
-                node = _ir.App(COROUTINE, (yields, sends, out))
             case _Gen():
-                node = _ir.App(result.kind, (self.type_union(result.yielded),))
+                node = self._generator_type(result)
             case slice():
                 node = _ir.App(
                     _ir.render(_ir.Type(slice)),
@@ -668,6 +663,16 @@ class _ResultTyper:
             case _:
                 node = self._container(result)
         return node
+
+    def _generator_type(self, result: _Gen) -> _ir.Node:
+        if result.kind == COROUTINE:
+            # an awaitable yields objects and is sent `None`, as `CanAwait`
+            out = self.type_union(result.yielded)
+            return _ir.App(COROUTINE, (_ir.Name(_OBJECT), _ir.Name("None"), out))
+        if not result.yielded and result.kind.startswith("itertools."):
+            # element type unrecoverable, so drop the misleading `[Never]` arg
+            return _ir.Name(result.kind)
+        return _ir.App(result.kind, (self.type_union(result.yielded),))
 
     def type_union(self, values: Iterable[object]) -> _ir.Node:
         """The deduplicated union of the types of `values`, or `Never` if empty."""

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -6,6 +6,7 @@
 import builtins
 import functools
 import gc
+import itertools
 import math
 import operator
 import random
@@ -863,6 +864,53 @@ ITERATOR_CASES: list[tuple[Callable[..., Any], str]] = [
     ),
     (lambda: map(str, [1, 2]), "() -> map[str]"),
     (lambda: zip((), ()), "() -> zip[Never]"),  # noqa: B905
+    # generic `itertools` iterators (#722)
+    (
+        lambda xs: itertools.chain(xs),
+        "[R](xs: CanIter[CanNext[R]]) -> itertools.chain[R]",
+    ),
+    (
+        lambda *xss: itertools.chain(*xss),
+        "[R](*xss: CanIter[CanNext[R]]) -> itertools.chain[R]",
+    ),
+    (
+        lambda xs: itertools.cycle(xs),
+        "[R](xs: CanIter[CanNext[R]]) -> itertools.cycle[R]",
+    ),
+    (
+        lambda xs, sel: itertools.compress(xs, sel),
+        (
+            "[R](xs: CanIter[CanNext[R]], sel: CanIter[CanNext[CanBool]]) "
+            "-> itertools.compress[R]"
+        ),
+    ),
+    (
+        lambda f, xs: itertools.takewhile(f, xs),
+        "[R](f: (R) -> CanBool, xs: CanIter[CanNext[R]]) -> itertools.takewhile[R]",
+    ),
+    (
+        lambda xs: itertools.pairwise(xs),
+        "[R](xs: CanIter[CanNext[R]]) -> itertools.pairwise[tuple[R, R]]",
+    ),
+    (
+        lambda *xss: itertools.zip_longest(*xss),
+        "[R](*xss: CanIter[CanNext[R]]) -> itertools.zip_longest[tuple[R, ...]]",
+    ),
+    # `tee` yields `Iterator`, not `_tee` (#722); the list avoids `tee`'s `__copy__`
+    # shortcut, which varies across CPython 3.12 patches
+    (
+        lambda x: itertools.tee([x]),
+        "[T](x: T) -> tuple[Iterator[T], Iterator[T]]",
+    ),
+    # an unrecoverable element type renders bare (#722)
+    (
+        lambda f, xs: itertools.dropwhile(f, xs),
+        "[T](f: (T) -> CanBool, xs: CanIter[CanNext[T]]) -> itertools.dropwhile",
+    ),
+    (
+        lambda f, xs: itertools.filterfalse(f, xs),
+        "[T](f: (T) -> CanBool, xs: CanIter[CanNext[T]]) -> itertools.filterfalse",
+    ),
     (
         lambda x: ((i for i in x), 1),
         "[R](x: CanIter[CanNext[R]]) -> tuple[Generator[R], Literal[1]]",


### PR DESCRIPTION
before:

```console
$ optype infer "import itertools; itertools.cycle"
(CanIter[object]) -> cycle

$ optype infer "import itertools; itertools.tee"
(CanIter[object], Literal[2] = 2) -> tuple[_tee, _tee]
(CanIter[object], CanIndex & ~Literal[2]) -> tuple[_tee] | tuple[()]
```

after:

```console
$ optype infer "import itertools; itertools.cycle"
[R](CanIter[CanNext[R]]) -> itertools.cycle[R

$ optype infer "import itertools; itertools.tee"
[R](CanIter[CanNext[R]], Literal[2] = 2) -> tuple[Iterator[R], Iterator[R]]
[R](CanIter[CanNext[R]], CanIndex & ~Literal[2]) -> tuple[Iterator[R]] | tuple[()]
```

closes #722