### PR TITLE
`infer`: generic `functools` types

### DIFF
--- a/optype/infer/_explore.py
+++ b/optype/infer/_explore.py
@@ -1,5 +1,6 @@
 """Run a function against spy placeholders and record what happens."""
 
+import functools
 import gc
 import itertools
 import warnings
@@ -16,7 +17,6 @@ from collections.abc import (
 )
 from contextlib import suppress
 from contextvars import ContextVar
-from functools import partial
 from inspect import Parameter, isasyncgen, iscoroutine, isgenerator, signature
 from types import (
     BuiltinFunctionType,
@@ -95,6 +95,13 @@ _ITERATOR_TYPES: dict[type, str] = (
 
 # the lazy iterator returned by the 2-argument `iter(callable, sentinel)`
 _CALLABLE_ITERATOR = type(iter(int, None))
+
+# generic `functools` wrappers, by rendered name. `singledispatchmethod` is absent:
+# its `__init__` eagerly calls `singledispatch`, which a spy callable cannot satisfy
+_WRAPPER_TYPES: dict[type, str] = {
+    cls: f"functools.{cls.__qualname__}"
+    for cls in (functools.partial, functools.partialmethod, functools.cached_property)
+}
 
 
 def _reachable(params: Iterable[object]) -> Generator[_SpyObject]:
@@ -208,7 +215,7 @@ _exploring: ContextVar[frozenset[int]] = ContextVar("_exploring", default=frozen
 
 def _unwrap(obj: object) -> object:
     """The underlying callable of (nested) `functools.partial` wrappers."""
-    while isinstance(obj, partial):
+    while isinstance(obj, functools.partial):
         obj = obj.func
     return obj
 
@@ -227,7 +234,7 @@ def _closed_over(func: object, seen: set[int] | None = None) -> Generator[object
         return
     seen.add(id(func))
     values: list[object] = []
-    while isinstance(func, partial):
+    while isinstance(func, functools.partial):
         values += func.args
         values += func.keywords.values()
         func = func.func
@@ -261,6 +268,37 @@ def _explore_func(func: _AnyFunc) -> object:
         declared_defaults(params),
         exploration.results,
     )
+
+
+def _wrapped_return(result: object) -> object | None:
+    # only a spy is safe to call; a real callable (e.g. `print`) would actually run
+    if (fn := as_spy(getattr(result, "func", None))) is None:
+        return None
+
+    # `cached_property` has no `.args`: its getter binds the instance
+    args = getattr(result, "args", (_SpyObject(),))
+    return fn(*args, **getattr(result, "keywords", {}))
+
+
+def _wrapper(
+    cls: type,
+    name: str,
+    result: object,
+    path: dict[int, _RecVar | None],
+) -> object:
+    """A generic `functools` wrapper, parameterized by the wrapped return type."""
+
+    # a `partial` of a real function keeps its richer call signature; exploring a
+    # spy-wrapped one would pollute the spy with signature probes
+    if (
+        cls is functools.partial
+        and isinstance(_unwrap(result), _FUNCTION_TYPES)
+        and isinstance(explored := _explore_func(cast("_AnyFunc", result)), _Fn)
+    ):
+        return explored
+
+    ret = _wrapped_return(result)
+    return _Gen([] if ret is None else [_next(ret, path)], name)
 
 
 def _next(result: object, path: dict[int, _RecVar | None] | None = None) -> object:
@@ -298,6 +336,8 @@ def _next(result: object, path: dict[int, _RecVar | None] | None = None) -> obje
         # Calling `fn()` is deliberate: the recorded `__call__` is what renders the
         # parameter as `() -> R`, as `explore_spies` snapshots after this runs.
         out = _Gen([_next(fn(), path)], "Iterator")
+    elif (name := _WRAPPER_TYPES.get(cls)) is not None:
+        out = _wrapper(cls, name, result, path)
     elif isinstance(_unwrap(result), _FUNCTION_TYPES):
         out = _explore_func(cast("_AnyFunc", result))
     else:

--- a/optype/infer/_render.py
+++ b/optype/infer/_render.py
@@ -669,8 +669,8 @@ class _ResultTyper:
             # an awaitable yields objects and is sent `None`, as `CanAwait`
             out = self.type_union(result.yielded)
             return _ir.App(COROUTINE, (_ir.Name(_OBJECT), _ir.Name("None"), out))
-        if not result.yielded and result.kind.startswith("itertools."):
-            # element type unrecoverable, so drop the misleading `[Never]` arg
+        if not result.yielded and "." in result.kind:
+            # a qualified (`itertools`/`functools`) kind drops the misleading `[Never]`
             return _ir.Name(result.kind)
         return _ir.App(result.kind, (self.type_union(result.yielded),))
 

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -761,6 +761,54 @@ FUNCTION_CASES: list[tuple[Callable[..., Any], str]] = [
             "[T, R](x: T) -> (y: CanRAdd[T, R]) -> R"
         ),
     ),
+    # generic `functools` wrappers, parameterized by the wrapped return type (#724)
+    (
+        lambda f: functools.partial(f, 1),
+        "[R](f: (Literal[1]) -> R) -> functools.partial[R]",
+    ),
+    (
+        lambda f, x: functools.partial(f, x),
+        "[T, R](f: (T) -> R, x: T) -> functools.partial[R]",
+    ),
+    (
+        lambda f: functools.partialmethod(f, 1),
+        "[R](f: (Literal[1]) -> R) -> functools.partialmethod[R]",
+    ),
+    (
+        lambda f: functools.cached_property(f),
+        "[R](f: (object) -> R) -> functools.cached_property[R]",
+    ),
+    # the wrapper classes themselves: `func` is a callable, not `object`. `partial` is
+    # a C type whose signature is only introspectable on 3.13+; older versions probe
+    # arities and miss `**keywords`
+    (
+        functools.partial,
+        (
+            "[T, U, R]((*tuple[T, ...], U) -> R, *args: T, **keywords: U) "
+            "-> functools.partial[R]"
+            if sys.version_info >= (3, 13)
+            else "[T, R]((*tuple[T, ...]) -> R, *args: T) -> functools.partial[R]"
+        ),
+    ),
+    (
+        functools.partialmethod,
+        (
+            "[T, U, R]((*tuple[T, ...], U) -> R, *args: T, **keywords: U) "
+            "-> functools.partialmethod[R]"
+        ),
+    ),
+    (
+        functools.cached_property,
+        "[R](func: (object) -> R) -> functools.cached_property[R]",
+    ),
+    # a non-spy callable can't be called for its return, so the bare wrapper renders
+    (lambda: functools.partial(print, "a"), "() -> functools.partial"),
+    # but a `partial` of an explorable real function keeps its reduced call signature,
+    # rendered as a callable rather than as `functools.partial[R]`
+    (
+        lambda: functools.partial(divmod, 10),
+        "[R]() -> (CanRDivmod[Literal[10], R]) -> R",
+    ),
     # a function within a returned container is explored as well, but a set member
     # must stay hashable, so it is left as-is
     (
@@ -790,12 +838,10 @@ FUNCTION_CASES: list[tuple[Callable[..., Any], str]] = [
     ),
     (lambda *args: lambda: args, "[*Ts](*args: *Ts) -> () -> tuple[*Ts]"),
     # a recursive function (factory) has an inexpressible type, so it stays opaque,
-    # as do variadic parameters and a `partial` of a non-function
+    # as do variadic parameters
     (_self_return, "(x: object) -> FunctionType"),
     (_fn_factory, "(n: object) -> () -> FunctionType"),
     (lambda x: lambda *args: x, "(x: object) -> FunctionType"),  # noqa: ARG005
-    (lambda f: functools.partial(f, 1), "(f: object) -> partial"),
-    (lambda: functools.partial(print, "a"), "() -> partial"),
 ]
 
 


### PR DESCRIPTION
before:

```console
$ optype infer "import functools; functools.partial"
(object) -> partial

$ optype infer "import functools; functools.partialmethod"
(object) -> partialmethod
```

after:

```console
$ optype infer "import functools; functools.partial"
[T, U, R]((*tuple[T, ...], U) -> R, *args: T, **keywords: U) -> functools.partial[R]

$ optype infer "import functools; functools.partialmethod"
[T, U, R]((*tuple[T, ...], U) -> R, *args: T, **keywords: U) -> functools.partialmethod[R]
```

closes #724