### PR TITLE
`infer`: fix `functools.reduce`

### DIFF
--- a/optype/infer/_explore.py
+++ b/optype/infer/_explore.py
@@ -42,6 +42,7 @@ from ._spy import (
     _Traces,
     _yield_budget,
     as_spy,
+    set_driver_code,
 )
 from ._values import (
     COROUTINE,
@@ -391,6 +392,7 @@ def _rollback(marks: Iterable[tuple[_SpyObject, int]]) -> None:
         del spy.__optype_trace__[length:]
 
 
+@set_driver_code
 def _run[T](
     func: Callable[..., T] | Callable[..., Coroutine[Any, None, T]],
     args: Iterable[object],

--- a/optype/infer/_spy.py
+++ b/optype/infer/_spy.py
@@ -56,6 +56,17 @@ _starved: ContextVar[bool] = ContextVar("_starved", default=False)
 # `__lt__` (#686); a pair suffices, and `_render` inlines the extra typevar away
 _DEFAULT_YIELD = 2
 
+# `_explore._run` unpacks a real arg list, so a spy `__iter__` charged to its frame is a
+# C builtin iterating internally, not a growable star-unpack (#723)
+_driver_code: CodeType | None = None
+
+
+def set_driver_code[T: Callable[..., object]](fn: T, /) -> T:
+    global _driver_code  # noqa: PLW0603
+    _driver_code = fn.__code__  # ty: ignore[unresolved-attribute]
+    return fn
+
+
 # star-unpack detection reads caller bytecode (CPython detail); else it never fires
 _CPYTHON = sys.implementation.name == "cpython"
 
@@ -79,7 +90,7 @@ def _iter_is_star_unpack() -> bool:
         frame = sys._getframe(2)  # _iter_is_star_unpack -> __iter__ -> consuming frame  # noqa: SLF001
     except ValueError:
         frame = None
-    if frame is None or (i := frame.f_lasti) < 0:
+    if frame is None or (i := frame.f_lasti) < 0 or frame.f_code is _driver_code:
         return False
 
     return dis.opname[_co_code(frame.f_code)[i]] == "CALL_FUNCTION_EX"

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -2117,6 +2117,41 @@ def test_builtin_variadic() -> None:
     assert infer(min) == "[T, U: CanLt[T | U, CanBool]](T, *args: U) -> U | T"
 
 
+def test_functools_reduce() -> None:
+    # the iterable must yield a pair so `reduce` actually calls the function (#723)
+    if sys.version_info >= (3, 15):
+        # `reduce` gained a signature with an `initial` sentinel default
+        assert infer(functools.reduce) == (
+            "[T, R]((T, T) -> R, CanIter[CanNext[T]],"
+            " initial: _initial_missing = _initial_missing) -> R\n"
+            "[T: ~_initial_missing, U, R]"
+            "((T | R, U) -> R, CanIter[CanNext[U]], initial: T) -> R"
+        )
+    else:
+        assert infer(functools.reduce) == (
+            "[T, R]((T, T) -> R, CanIter[CanNext[T]]) -> R\n"
+            "[T, U, R]((T | R, U) -> R, CanIter[CanNext[U]], T) -> R"
+        )
+
+
+def test_builtin_sorted() -> None:
+    # the iterable yields a pair, so the elements reach `__lt__` and the `key` result
+    # carries its own comparison constraint (#723)
+    assert infer(sorted) == (
+        "[R: CanLt[R, CanBool]]"
+        "(CanIter[CanNext[R]], key: None = None, reverse: Literal[False] = False)"
+        " -> list[R]\n"
+        "[R: CanLt[R, CanBool]]"
+        "(CanIter[CanNext[R]], key: None = None, reverse: CanBool) -> list[R]\n"
+        "[T, R]"
+        "(CanIter[CanNext[R]], key: (R) -> T & CanLt[T, CanBool],"
+        " reverse: Literal[False] = False) -> list[R]\n"
+        "[T, R]"
+        "(CanIter[CanNext[R]], key: (R) -> T & CanLt[T, CanBool], reverse: CanBool)"
+        " -> list[R]"
+    )
+
+
 def test_builtin_typed_argument() -> None:
     # `getattr` needs a real `str` name that an object spy cannot supply, so no arity
     # explores and it raises rather than inferring a bogus signature


### PR DESCRIPTION
before:

```console
$ optype infer "import functools; functools.reduce"
[R](object, CanIter[CanNext[R]]) -> R
[T, U, R]((T, U) -> R, CanIter[CanNext[U]], T) -> R
```

after:

```console
$ optype infer "import functools; functools.reduce"
[T, R]((T, T) -> R, CanIter[CanNext[T]]) -> R
[T, U, R]((T | R, U) -> R, CanIter[CanNext[U]], T) -> R
```

closes #723