### PR TITLE
`infer`: better `isinstance`/`issubclass` inference

### DIFF
--- a/optype/infer/_api.py
+++ b/optype/infer/_api.py
@@ -8,7 +8,7 @@ from inspect import Parameter, signature
 # `from . import` would import the package itself, which imports this module
 import optype.infer._numpy as _numpy
 from ._errors import InferError, InferWarning
-from ._explore import explore_lenient
+from ._explore import explore_lenient, explore_tuple_params
 from ._overloads import dispatch_overloads, resolve_defaults
 from ._render import Names, signatures
 from ._signature import probe_signatures
@@ -64,6 +64,9 @@ def _form_signatures(
         # the rejected parameters render from their defaults; skip the probing
         lines = signatures(exploration, parameters, selected, fallback)
         return list(dict.fromkeys(lines))
+    exploration = exploration._replace(
+        tuple_params=explore_tuple_params(func, parameters, exploration),
+    )
     defaults, negate, overloads = resolve_defaults(
         func,
         parameters,

--- a/optype/infer/_explore.py
+++ b/optype/infer/_explore.py
@@ -39,6 +39,7 @@ from ._spy import (
     _SpyObject,
     _SpyStr,
     _starved,
+    _TraceItem,
     _Traces,
     _yield_budget,
     as_spy,
@@ -641,3 +642,51 @@ def explore_lenient(
     return exploration, {
         name: exploration.fixed.get(name, value) for name, value in defaults.items()
     }
+
+
+def _op_shape(items: Iterable[_TraceItem]) -> frozenset[str]:
+    return frozenset(item.attr for item in items if not isinstance(item.attr, _Marker))
+
+
+# dunders `tuple` delegates to its elements (`repr`, `hash`, ...), not distribution
+_TUPLE_DUNDERS = frozenset(
+    name for klass in tuple.__mro__ for name in vars(klass) if name.startswith("__")
+)
+
+
+def explore_tuple_params(
+    func: _AnyFunc,
+    params: Mapping[str, Parameter],
+    exploration: Exploration,
+) -> frozenset[str]:
+    """The parameters that also accept a homogeneous `tuple[<bound>, ...]`.
+
+    `isinstance`'s tuple recursion is a C-level check no spy sees, so each parameter is
+    re-explored as a real tuple of spies: it distributes when its elements get its ops.
+    """
+    tuple_params: set[str] = set()
+    for name, spy in exploration.spies.items():
+        param = params.get(name)
+        if param is None or param.kind in VARIADIC_KINDS:
+            continue
+        bare_shape = _op_shape(exploration.traces.get(id(spy), ()))
+        if not bare_shape or not bare_shape.isdisjoint(_TUPLE_DUNDERS):
+            continue
+
+        spies, args, kwds = _placeholders(params, 2, [], (), exploration.fixed)
+        if (target := spies.get(name)) is None:
+            continue
+        elems = (_SpyObject(), _SpyObject())
+        args = [elems if a is target else a for a in args]
+        kwds = {key: elems if value is target else value for key, value in kwds.items()}
+        try:
+            # a bare run: results aren't re-explored, so no recursion guard is needed
+            _explore(func, args, kwds)
+        except Exception:  # noqa: BLE001, S112
+            continue
+        traces = _snapshot(elems)
+        # an element skipped by short-circuit isn't traced; check only those that ran
+        elem_shapes = [s for e in elems if (s := _op_shape(traces.get(id(e), ())))]
+        if elem_shapes and all(s == bare_shape for s in elem_shapes):
+            tuple_params.add(name)
+    return frozenset(tuple_params)

--- a/optype/infer/_overloads.py
+++ b/optype/infer/_overloads.py
@@ -59,6 +59,7 @@ def _bind_exploration(exp: Exploration, defaults: Defaults) -> Exploration:
         exp.fixed,
         exp.deprecated,
         exp.gaps,
+        frozenset(name for name in exp.tuple_params if name not in defaults),
     )
 
 

--- a/optype/infer/_render.py
+++ b/optype/infer/_render.py
@@ -155,6 +155,7 @@ class _Renderer:
     _results: list[object]
     _traces: _Traces
     _count: int  # the `*args` placeholder count used during exploration
+    _tuple_params: frozenset[str]  # params that also accept `tuple[<bound>, ...]`
 
     _prefix: dict[str, str]
     _nameless: set[str]
@@ -189,6 +190,7 @@ class _Renderer:
         self._traces = traces
         self._count = exploration.var_count
         self._fixed = exploration.fixed
+        self._tuple_params = exploration.tuple_params
 
         self._configure(params)
         self._assign_typevars()
@@ -581,6 +583,9 @@ class _Renderer:
             ):
                 node = _ir.exclude(self.spy(spy), mark)
             return f"{label}{_ir.render(node)}"
+        if name in self._tuple_params and id(spy) not in self._vars:
+            # a typevar keeps its binding, so only an inlined bound widens to the union
+            node = _ir.union([node, _ir.tuple_node_variadic(node)]) or node
         if node == _ir.Name(_OBJECT) and name in self._optional:
             return None
         return f"{label}{_ir.render(node)}{_suffix(defaults, name)}"

--- a/optype/infer/_values.py
+++ b/optype/infer/_values.py
@@ -28,6 +28,7 @@ class Exploration(NamedTuple):
     fixed: Mapping[str, object]  # parameters passed as-is, not spies
     deprecated: str | None = None  # a `DeprecationWarning` message raised when called
     gaps: frozenset[GapKind] = frozenset()  # kinds of unexplored path
+    tuple_params: frozenset[str] = frozenset()  # params also accepting a tuple of self
 
 
 class _Gen(NamedTuple):

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -2166,14 +2166,40 @@ def test_dynamic_attr_name() -> None:
 
 
 def test_instance_subclass_check() -> None:
-    assert infer(lambda x: isinstance(0, x)) == "(x: CanInstancecheck) -> bool"
-    assert infer(lambda x: issubclass(int, x)) == "(x: CanSubclasscheck) -> bool"
+    # isinstance/issubclass recurse into a tuple classinfo, so the param widens (#716)
+    assert infer(lambda x: isinstance(0, x)) == (
+        "(x: CanInstancecheck | tuple[CanInstancecheck, ...]) -> bool"
+    )
+    assert infer(lambda x: issubclass(int, x)) == (
+        "(x: CanSubclasscheck | tuple[CanSubclasscheck, ...]) -> bool"
+    )
     assert infer(lambda x, y: isinstance(y, x)) == (
-        "(x: CanInstancecheck, y: object) -> bool"
+        "(x: CanInstancecheck | tuple[CanInstancecheck, ...], y: object) -> bool"
     )
     assert infer(lambda x, y: issubclass(y, x)) == (
-        "(x: CanSubclasscheck, y: object) -> bool"
+        "(x: CanSubclasscheck | tuple[CanSubclasscheck, ...], y: object) -> bool"
     )
+
+
+def test_instance_subclass_check_builtin() -> None:
+    assert infer(isinstance) == (
+        "(object, CanInstancecheck | tuple[CanInstancecheck, ...]) -> bool"
+    )
+    assert infer(issubclass) == (
+        "(object, CanSubclasscheck | tuple[CanSubclasscheck, ...]) -> bool"
+    )
+
+
+def test_instance_check_no_overwiden() -> None:
+    # a returned classinfo is a typevar (no widening); `in`/`len` do not distribute
+    assert (
+        infer(
+            lambda x, y: y.foo() if (isinstance(y, x) and not isinstance(y, x)) else x,
+        )
+        == "[T: CanInstancecheck](x: T, y: object) -> T"
+    )
+    assert infer(lambda x: 0 in x) == "(x: CanContains[Literal[0]]) -> bool"
+    assert infer(lambda x: len(x)) == "(x: CanLen) -> int"
 
 
 def _set_name(x: Any) -> object:


### PR DESCRIPTION
before:

```console
$ optype infer "isinstance"
(object, CanInstancecheck) -> bool
```

after:

```console
$ optype infer "isinstance"
(object, CanInstancecheck | tuple[CanInstancecheck, ...]) -> bool
```

closes #716