### PR TITLE
`infer`: catch `KeyError`s

### DIFF
--- a/optype/infer/_api.py
+++ b/optype/infer/_api.py
@@ -57,7 +57,7 @@ def _form_signatures(
     where = f"({', '.join(parameters)})"
     try:
         exploration, fallback = explore_lenient(func, parameters)
-    except (IndexError, TypeError, ValueError) as exc:
+    except (IndexError, KeyError, TypeError, ValueError) as exc:
         raise InferError(str(exc)) from exc
     gaps.update(_Gap(kind, where) for kind in exploration.gaps)
     if fallback:

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -1195,6 +1195,8 @@ def test_method_descriptor_unsupported() -> None:
         infer(str.join)
     with pytest.raises(InferError, match="pop from empty list"):
         infer(list[Any].pop)
+    with pytest.raises(InferError, match="dictionary is empty"):
+        infer(dict.popitem)
 
 
 def test_ternary_pow() -> None:


### PR DESCRIPTION
`optype infer dict.popitem` now fails less awkwardly:


```console
$ optype infer dict.popitem
InferError: 'popitem(): dictionary is empty' (KeyError: 'popitem(): dictionary is empty')
```

(it used to print the full stacktrace)

closes #733