### PR TITLE
`infer`: fix non-termination

### DIFF
--- a/optype/infer/_render.py
+++ b/optype/infer/_render.py
@@ -467,7 +467,8 @@ class _Renderer:
         return _ir.App(proto, args)
 
     def traces(self, items: Iterable[_TraceItem]) -> _ir.Node | None:
-        items = list(items)
+        # dedup the re-collected return-chain items so they can't blow up (#734)
+        items = list({id(item): item for item in items}.values())
         # an absence marker means the op was optional; an attribute probe keys on its
         # name, so it spares the other reads
         optional = {item.args for item in items if item.attr == _Marker.ABSENT}

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -4,12 +4,14 @@
 # pyright: reportUnusedParameter=false
 
 import builtins
+import difflib
 import functools
 import gc
 import itertools
 import math
 import operator
 import random
+import re
 import secrets
 import subprocess  # noqa: S404
 import sys
@@ -1168,6 +1170,18 @@ def test_buffer_spy_finalizes_without_cycle() -> None:
             gc.enable()
         sys.unraisablehook = hook
     assert not captured
+
+
+def test_rich_return_chains_terminate() -> None:
+    # #734: a deep return chain used to blow up into millions of trace items
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", InferWarning)
+        scanner = infer(getattr(re, "Scanner"))  # noqa: B009
+        matches = infer(difflib.get_close_matches)
+    assert scanner.splitlines()[-1].endswith("-> Scanner")
+    lines = matches.splitlines()
+    assert lines
+    assert all("list[" in line.rsplit("->", 1)[-1] for line in lines)
 
 
 def test_method_descriptor_fixed_defaults() -> None:


### PR DESCRIPTION
closes #734

```console
$ optype infer "import difflib; difflib.get_close_matches"
[R: CanLen & CanIter[CanNext[CanHash]]](word: CanIter[CanNext[CanHash]] & CanLen, possibilities: CanIter[CanNext[R]], n: Literal[3] = 3, cutoff: float = 0.6) -> list[Never] | list[R]
[T, R: CanIter[CanNext[CanHash]] & CanSequence[Literal[0], CanHash & CanEq[T, CanBool]]](word: CanIter[CanNext[CanHash]] & CanSequence[Literal[0], T & CanHash], possibilities: CanIter[CanNext[R]], n: Literal[3] = 3, cutoff: CanGe[float, CanBool] & CanLe[float, CanBool]) -> list[R] | list[Never]
[R: CanLen & CanIter[CanNext[CanHash]]](word: CanIter[CanNext[CanHash]] & CanLen, possibilities: CanIter[CanNext[R]], n: CanGt[Literal[0], CanBool] & CanEq[Literal[1], CanBool] & CanGe[Literal[0, 2], CanBool] & CanIndex & CanNeg[CanIndex], cutoff: float = 0.6) -> list[Never] | list[R]
[T, R: CanIter[CanNext[CanHash]] & CanSequence[Literal[0], CanHash & CanEq[T, CanBool]]](word: CanIter[CanNext[CanHash]] & CanSequence[Literal[0], T & CanHash], possibilities: CanIter[CanNext[R]], n: CanGt[Literal[0], CanBool] & CanEq[Literal[1], CanBool] & CanGe[Literal[2, 1, 0], CanBool] & CanIndex & CanNeg[CanIndex], cutoff: CanGe[float, CanBool] & CanLe[float, CanBool]) -> list[R] | list[Never]
warning: incomplete exploration: run budget exhausted in (word, possibilities, n, cutoff)
```