### PR TITLE
`infer`: absorb empty container types

### DIFF
--- a/docs/infer.md
+++ b/docs/infer.md
@@ -652,6 +652,14 @@ $ optype infer "lambda x: [FileNotFoundError()] if x else [OSError()]"
 (x: CanBool) -> list[FileNotFoundError] | list[OSError]
 ```
 
+An *empty* container is the exception: its only inhabitant is the empty instance, which
+is a member of every same-base container, so it is absorbed even when invariant:
+
+```console
+$ optype infer "lambda x: [None] if x else []"
+(x: CanBool) -> list[None]
+```
+
 ## NumPy
 
 !!! info

--- a/optype/infer/_ir.py
+++ b/optype/infer/_ir.py
@@ -160,14 +160,19 @@ def subtype(sub: Node | Arg, sup: Node | Arg) -> bool:
             result = issubclass(cls, wider)
         case App(base, args), App(wider, wider_args) if base == wider:
             variances = _VARIANCES.get(base, "")
-            result = (
-                bool(variances)
-                and len(args) == len(wider_args)
-                and all(
-                    subtype(arg, wide)
-                    if variances[min(i, len(variances) - 1)] == COVARIANT
-                    else subtype(wide, arg)
-                    for i, (arg, wide) in enumerate(zip(args, wider_args, strict=True))
+            result = len(args) == len(wider_args) and (
+                # an all-`Never` container holds only `[]`, a member of any same base
+                (bool(args) and all(arg == Name("Never") for arg in args))
+                or (
+                    bool(variances)
+                    and all(
+                        subtype(arg, wide)
+                        if variances[min(i, len(variances) - 1)] == COVARIANT
+                        else subtype(wide, arg)
+                        for i, (arg, wide) in enumerate(
+                            zip(args, wider_args, strict=True),
+                        )
+                    )
                 )
             )
         case Fn(params, ret), Fn(wider_params, wider_ret):

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -1086,6 +1086,12 @@ SUBTYPE_CASES: list[tuple[Any, Any, bool]] = [
     (App("tuple", (Type(bool), Lit((1,)))), App("tuple", (Type(int),) * 2), True),
     (App("tuple", (Type(bool),)), App("tuple", (Type(int),) * 2), False),
     (App("list", (Type(bool),)), App("list", (Type(int),)), False),
+    # an empty container is the bottom of its base, even when invariant
+    (App("list", (Name("Never"),)), App("list", (Type(int),)), True),
+    (App("list", (Type(int),)), App("list", (Name("Never"),)), False),
+    (App("set", (Name("Never"),)), App("set", (Type(int),)), True),
+    (App("dict", (Name("Never"),) * 2), App("dict", (Type(str), Type(int))), True),
+    (App("list", (Name("Never"),)), App("set", (Type(int),)), False),
     # type is covariant
     (App("type", (Type(bool),)), App("type", (Type(int),)), True),
     (App("type", (Type(int),)), App("type", (Type(bool),)), False),
@@ -1473,6 +1479,19 @@ def test_infer_empty_container() -> None:
     assert infer(returns(set())) == "() -> set[Never]"
     assert infer(returns(frozenset())) == "() -> frozenset[Never]"
     assert infer(returns([[]])) == "() -> list[list[Never]]"
+
+
+def test_infer_empty_container_union() -> None:
+    # an empty container is absorbed by a non-empty sibling, even when invariant
+    assert infer(lambda x: [None] if x else []) == "(x: CanBool) -> list[None]"
+    assert infer(lambda x: {None} if x else set()) == "(x: CanBool) -> set[None]"
+    assert infer(lambda x: {None: None} if x else {}) == (
+        "(x: CanBool) -> dict[None, None]"
+    )
+    # a non-empty invariant container is still not absorbed
+    assert infer(lambda x: [1] if x else ["1"]) == (
+        "(x: CanBool) -> list[Literal[1]] | list[Literal['1']]"
+    )
 
 
 def test_infer_ellipsis() -> None:


### PR DESCRIPTION
before:

```console
$ optype infer "lambda x: [None] if x else []"
(x: CanBool) -> list[None] | list[Never]
```

after:

```console
$ optype infer "lambda x: [None] if x else []"
(x: CanBool) -> list[None]
```

closes #744