### PR TITLE
`ignore`: handle `SystemExit`

### DIFF
--- a/optype/infer/_explore.py
+++ b/optype/infer/_explore.py
@@ -425,7 +425,7 @@ def _explore[T](  # noqa: C901
     stack: list[list[bool]] = [[]]
     dropped = False
 
-    last_exc: Exception | None = None
+    last_exc: BaseException | None = None
     value_exc: ValueError | None = None
 
     for _ in range(_RUN_LIMIT):  # caps the exponential blowup of independent forks
@@ -459,8 +459,8 @@ def _explore[T](  # noqa: C901
             # a forked value the target rejected (e.g. `range`'s zero step); defer
             value_exc = exc
             _rollback(marks)
-        except Exception as exc:  # noqa: BLE001
-            # the target rejected these spy values (assert, zero-division, ...); skip
+        except (Exception, SystemExit) as exc:  # noqa: BLE001
+            # the target rejected these spy values or exited (e.g. `exit()`); skip
             last_exc = exc
             _rollback(marks)
         finally:

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -2342,3 +2342,26 @@ def test_cli_warns_on_stderr() -> None:
     assert out.stdout.startswith("(x: CanGetitem")
     assert "warning:" in out.stderr
     assert "incomplete exploration" in out.stderr
+
+
+def test_cli_exit() -> None:
+    # a callable that raises SystemExit when probed errors cleanly, not silently
+    out = _run_cli("-m", "optype", "infer", "exit")
+    assert out.returncode == 1
+    assert out.stderr.startswith("InferError:")
+
+
+def test_cli_quit() -> None:
+    out = _run_cli("-m", "optype", "infer", "quit")
+    assert out.returncode == 1
+    assert out.stderr.startswith("InferError:")
+
+
+def test_infer_systemexit() -> None:
+    # a SystemExit during a run is a rejected run, like any other raise, not a leak
+    class _Exiter:
+        def __call__(self, code: int = 0) -> None:
+            raise SystemExit(code)
+
+    with pytest.raises(InferError):
+        infer(_Exiter())


### PR DESCRIPTION
before:

```console
$ optype infer exit
```

after:

```console
$ optype infer exit
InferError: the function never ran to completion (SystemExit: )
```

closes #737