### PR TITLE
`infer`: syntax highlighting for `--format=compat`

### DIFF
--- a/optype/infer/_cli.py
+++ b/optype/infer/_cli.py
@@ -4,7 +4,9 @@ import ast
 import sys
 import warnings
 
+from . import _color
 from ._backends import BackendName
+from ._color import ColorMode
 from optype.infer import InferError, InferWarning, infer
 
 
@@ -24,10 +26,45 @@ def _format(args: tuple[str, ...]) -> tuple[BackendName, list[str]]:
     sys.exit("--format must be one of: terse, compat")
 
 
+def _color_flag(args: tuple[str, ...]) -> tuple[ColorMode, list[str]]:
+    """Split off a leading `--color {auto,always,never}`, defaulting to auto."""
+    rest = list(args)
+    name = "auto"
+    if rest and rest[0] == "--color":
+        name, rest = (rest[1] if len(rest) > 1 else ""), rest[2:]
+    elif rest and rest[0].startswith("--color="):
+        name, rest = rest[0].removeprefix("--color="), rest[1:]
+    if name == "auto":
+        return "auto", rest
+    if name == "always":
+        return "always", rest
+    if name == "never":
+        return "never", rest
+    sys.exit("--color must be one of: auto, always, never")
+
+
+def _flags(args: tuple[str, ...]) -> tuple[BackendName, ColorMode, list[str]]:
+    """Strip leading `--format`/`--color` flags in any order."""
+    backend: BackendName = "terse"
+    color: ColorMode = "auto"
+    rest = list(args)
+    while rest and rest[0].startswith("--"):
+        if rest[0] == "--format" or rest[0].startswith("--format="):
+            backend, rest = _format(tuple(rest))
+        elif rest[0] == "--color" or rest[0].startswith("--color="):
+            color, rest = _color_flag(tuple(rest))
+        else:
+            break  # unrecognized flag: fall through to usage
+    return backend, color, rest
+
+
 def run(*args: str) -> None:
-    backend, rest = _format(args)
+    backend, color, rest = _flags(args)
     if not rest:
-        sys.exit("usage: optype infer [--format {terse,compat}] EXPR [PARAM ...]")
+        sys.exit(
+            "usage: optype infer [--format {terse,compat}] "
+            "[--color {auto,always,never}] EXPR [PARAM ...]",
+        )
 
     source, *selectors = rest
     params = [int(s) if s.removeprefix("-").isdigit() else s for s in selectors]
@@ -53,6 +90,8 @@ def run(*args: str) -> None:
         detail = f" ({type(cause).__name__}: {cause})" if cause is not None else ""
         sys.exit(f"{type(exc).__name__}: {exc}{detail}")
 
+    if _color.want_color(sys.stdout, color):
+        signature = _color.highlight(signature)
     print(signature)
     for entry in caught:
         if issubclass(entry.category, InferWarning):

--- a/optype/infer/_color.py
+++ b/optype/infer/_color.py
@@ -1,0 +1,37 @@
+"""ANSI colorization for the `optype infer` command-line output."""
+
+import keyword
+import os
+import re
+from typing import IO, Literal
+
+type ColorMode = Literal["auto", "always", "never"]
+
+_RESET = "\x1b[0m"
+_COLORS = {"str": "\x1b[32m", "num": "\x1b[36m", "kw": "\x1b[34m"}
+# `str` first so a keyword inside a literal stays a string; hard keywords only
+_HIGHLIGHT = re.compile(
+    r"(?P<str>'[^']*'|\"[^\"]*\")"
+    r"|(?P<num>\b\d[\w.]*)"
+    r"|(?P<kw>\b(?:" + "|".join(keyword.kwlist) + r")\b)",
+)
+
+
+def want_color(stream: IO[str], mode: ColorMode = "auto") -> bool:
+    if mode == "never":
+        return False
+    if mode == "always":
+        return True
+    if os.environ.get("NO_COLOR"):  # wins over FORCE_COLOR (no-color.org)
+        return False
+    if os.environ.get("FORCE_COLOR"):
+        return True
+    return stream.isatty()
+
+
+def highlight(signature: str) -> str:
+    def _wrap(m: re.Match[str]) -> str:
+        name = m.lastgroup
+        return f"{_COLORS[name]}{m.group()}{_RESET}" if name else m.group()
+
+    return _HIGHLIGHT.sub(_wrap, signature)

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -7,9 +7,11 @@ import ast
 import builtins
 import difflib
 import functools
+import io
 import itertools
 import math
 import operator
+import os
 import random
 import re
 import secrets
@@ -22,11 +24,11 @@ from collections.abc import Callable
 from inspect import currentframe, signature
 from pathlib import Path
 from types import MappingProxyType
-from typing import Any
+from typing import Any, override
 
 import pytest
 
-from optype.infer import InferError, InferWarning, infer
+from optype.infer import InferError, InferWarning, _color, infer
 from optype.infer._api import _Gap
 from optype.infer._backends import TERSE
 from optype.infer._ir import (
@@ -2641,3 +2643,121 @@ def test_infer_systemexit() -> None:
 
     with pytest.raises(InferError):
         infer(_Exiter())
+
+
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def _run_cli_env(*args: str, **env: str) -> subprocess.CompletedProcess[str]:
+    base = {k: v for k, v in os.environ.items() if k not in {"NO_COLOR", "FORCE_COLOR"}}
+    return subprocess.run(  # noqa: S603
+        [sys.executable, *args],
+        capture_output=True,
+        text=True,
+        check=False,
+        env=base | env,
+    )
+
+
+def test_cli_color_off_when_piped() -> None:
+    # a pipe is not a tty, so the default auto mode stays plain
+    out = _run_cli("-m", "optype.infer", "lambda x: x + 1")
+    assert out.returncode == 0
+    assert "\x1b[" not in out.stdout
+
+
+def test_cli_color_force() -> None:
+    out = _run_cli_env("-m", "optype.infer", "lambda x: x + 1", FORCE_COLOR="1")
+    assert out.returncode == 0
+    assert "\x1b[" in out.stdout
+    assert _ANSI_RE.sub("", out.stdout).strip() == "[R](x: CanAdd[Literal[1], R]) -> R"
+
+
+def test_cli_color_always_flag() -> None:
+    out = _run_cli("-m", "optype.infer", "--color", "always", "lambda x: x + 1")
+    assert out.returncode == 0
+    assert "\x1b[" in out.stdout
+
+
+def test_cli_color_never_beats_force() -> None:
+    args = ("-m", "optype.infer", "--color", "never", "lambda x: x + 1")
+    out = _run_cli_env(*args, FORCE_COLOR="1")
+    assert out.returncode == 0
+    assert "\x1b[" not in out.stdout
+
+
+def test_cli_no_color_beats_force() -> None:
+    args = ("-m", "optype.infer", "lambda x: x")
+    out = _run_cli_env(*args, NO_COLOR="1", FORCE_COLOR="1")
+    assert out.returncode == 0
+    assert "\x1b[" not in out.stdout
+
+
+def test_cli_color_compat() -> None:
+    args = ("-m", "optype.infer", "--format", "compat", "lambda x: x + 1")
+    out = _run_cli_env(*args, FORCE_COLOR="1")
+    assert out.returncode == 0
+    assert "\x1b[" in out.stdout
+    assert _ANSI_RE.sub("", out.stdout).strip() == (
+        "from typing import Literal\n"
+        "from optype import CanAdd\n\n"
+        "def f[R](x: CanAdd[Literal[1], R]) -> R: ..."
+    )
+
+
+def test_cli_color_invalid() -> None:
+    out = _run_cli("-m", "optype.infer", "--color", "json", "lambda x: x")
+    assert out.returncode != 0
+    assert "auto, always, never" in out.stderr
+
+
+class _Tty(io.StringIO):
+    @override
+    def isatty(self) -> bool:
+        return True
+
+
+def test_want_color_mode_overrides() -> None:
+    assert _color.want_color(io.StringIO(), "always")
+    assert not _color.want_color(_Tty(), "never")
+
+
+def test_want_color_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("NO_COLOR", raising=False)
+    monkeypatch.delenv("FORCE_COLOR", raising=False)
+    assert _color.want_color(_Tty())
+    assert not _color.want_color(io.StringIO())
+    monkeypatch.setenv("FORCE_COLOR", "1")
+    assert _color.want_color(io.StringIO())
+    monkeypatch.setenv("NO_COLOR", "1")
+    assert not _color.want_color(_Tty())
+
+
+def test_highlight_roundtrip() -> None:
+    samples = [
+        "[R](x: CanAdd[Literal[1], R]) -> R",
+        "[*Ts](*args: *Ts) -> tuple[*Ts]",
+        (
+            "from typing import Protocol, overload\n"
+            "@overload\n"
+            'def f[R](x: CanAdd[Literal[1], R], msg: str = "x") -> R: ...\n'
+            "class _H[T](Protocol):\n"
+            "    def __getattr__(self, k: str, /) -> int: ..."
+        ),
+    ]
+    for sig in samples:
+        assert _ANSI_RE.sub("", _color.highlight(sig)) == sig
+
+
+def _wrapped(token: str) -> bool:
+    out = _color.highlight(token)
+    return out != token and _ANSI_RE.sub("", out) == token
+
+
+def test_highlight_targets() -> None:
+    assert _wrapped("def")  # keyword
+    assert _wrapped("1")  # number
+    assert _wrapped('"x"')  # string literal
+    # names and soft keywords stay plain
+    assert _color.highlight("CanAdd") == "CanAdd"
+    assert _color.highlight("type") == "type"


### PR DESCRIPTION
no libs needed :)

closes #741