### PR TITLE
`infer`: template strings

### DIFF
--- a/docs/infer.md
+++ b/docs/infer.md
@@ -681,6 +681,19 @@ $ optype infer "lambda x: [None] if x else []"
 (x: CanBool) -> list[None]
 ```
 
+## Template strings
+
+A t-string (Python 3.14+) is a `string.templatelib.Template`, and an `Interpolation`
+tracks the type of its interpolated value:
+
+```console
+$ optype infer "lambda: t''"
+() -> string.templatelib.Template
+
+$ optype infer "lambda x: t'{x}'.interpolations[0]"
+[T](x: T) -> string.templatelib.Interpolation[T]
+```
+
 ## NumPy
 
 !!! info

--- a/optype/infer/_backends/_compat/_print.py
+++ b/optype/infer/_backends/_compat/_print.py
@@ -64,8 +64,8 @@ def _import_of(name: str) -> tuple[str, str | None] | None:  # noqa: PLR0911
     A `None` member means the module is imported whole, as in `import numpy as np`.
     """
     if "." in name:
-        root = name.partition(".")[0]
-        return ("numpy", None) if root == "np" else (root, None)
+        module = "numpy" if name.partition(".")[0] == "np" else name.rpartition(".")[0]
+        return module, None
     if hasattr(builtins, name):
         return None
     if name in _ABC:

--- a/optype/infer/_explore.py
+++ b/optype/infer/_explore.py
@@ -3,6 +3,7 @@
 import functools
 import gc
 import itertools
+import sys
 import warnings
 from collections.abc import (
     AsyncGenerator,
@@ -113,6 +114,20 @@ _WRAPPER_TYPES: dict[type, str] = {
     cls: f"functools.{cls.__qualname__}"
     for cls in (functools.partial, functools.partialmethod, functools.cached_property)
 }
+
+# `string.templatelib` types (3.14+): rendered name, and the single-type-arg attr
+if sys.version_info >= (3, 14):
+    from string.templatelib import (
+        Interpolation as _Interpolation,
+        Template as _Template,
+    )
+
+    _TEMPLATE_TYPES: dict[type, tuple[str, str | None]] = {
+        _Template: ("string.templatelib.Template", None),
+        _Interpolation: ("string.templatelib.Interpolation", "value"),
+    }
+else:
+    _TEMPLATE_TYPES: dict[type, tuple[str, str | None]] = {}
 
 
 def _reachable(params: Iterable[object]) -> Generator[_SpyObject]:
@@ -361,6 +376,10 @@ def _next(result: object, path: dict[int, _RecVar | None] | None = None) -> obje
         out = _Gen([_next(fn(), path)], "Iterator")
     elif (name := _WRAPPER_TYPES.get(cls)) is not None:
         out = _wrapper(cls, name, result, path)
+    elif (tpl := _TEMPLATE_TYPES.get(cls)) is not None:
+        kind, attr = tpl
+        yields = [] if attr is None else [_next(getattr(result, attr), path)]
+        out = _Gen(yields, kind)
     elif isinstance(_unwrap(result), _FUNCTION_TYPES):
         out = _explore_func(cast("_AnyFunc", result))
     else:

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -1892,6 +1892,51 @@ def test_compat_typechecks(tmp_path: Path) -> None:
     assert out.returncode == 0, out.stdout
 
 
+# `t''` is a syntax error before 3.14, so each source is compiled at runtime
+@pytest.mark.skipif(sys.version_info < (3, 14), reason="requires Python 3.14+")
+def test_infer_template_strings() -> None:
+    # a t-string result is the qualified, non-generic `Template`
+    assert infer(eval("lambda: t''")) == "() -> string.templatelib.Template"  # noqa: S307
+
+    # `Interpolation` is generic on its `.value`, tracked through a typevar
+    interp = eval("lambda x: t'{x}'.interpolations[0]")  # noqa: S307
+    assert infer(interp) == "[T](x: T) -> string.templatelib.Interpolation[T]"
+
+    literal = eval("lambda: t'{1}'.interpolations[0]")  # noqa: S307
+    assert infer(literal) == "() -> string.templatelib.Interpolation[int]"
+
+
+_TEMPLATE_COMPAT_CASES: list[tuple[str, str]] = [
+    (
+        "lambda: t''",
+        "import string.templatelib\n\ndef f() -> string.templatelib.Template: ...",
+    ),
+    (
+        "lambda x: t'{x}'.interpolations[0]",
+        (
+            "import string.templatelib\n\n"
+            "def f[T](x: T) -> string.templatelib.Interpolation[T]: ..."
+        ),
+    ),
+    (
+        "lambda: t'{1}'.interpolations[0]",
+        (
+            "import string.templatelib\n\n"
+            "def f() -> string.templatelib.Interpolation[int]: ..."
+        ),
+    ),
+]
+
+
+@pytest.mark.skipif(sys.version_info < (3, 14), reason="requires Python 3.14+")
+def test_compat_template_strings(tmp_path: Path) -> None:
+    for i, (source, expected) in enumerate(_TEMPLATE_COMPAT_CASES):
+        assert _compat(source) == expected
+        (tmp_path / f"case_{i}.pyi").write_text(f"{_compat(source)}\n")
+    out = _basedpyright(tmp_path)
+    assert out.returncode == 0, out.stdout
+
+
 # terse renderings whose compat stub does not type-check: each faithfully renders an
 # inference the type system (or the shipped `optype` API) cannot express, not a backend
 # bug. See docs/reference/experimental/infer.md.


### PR DESCRIPTION
before:

```console
$ optype infer "lambda: t''"
() -> Template
```

after:

```console
$ optype infer "lambda: t''"
() -> string.templatelib.Template
```

closes #751