### PR TITLE
`infer`: subprocess isolation

### DIFF
--- a/docs/infer.md
+++ b/docs/infer.md
@@ -773,6 +773,13 @@ or an identity check (`is`) is reported as `object` rather than its real require
 same blind spot hides a branch on a derived integer: `len`, `int`, and `index` return a
 small placeholder, so `len(x) > 5` is never explored.
 
+A native callable (a C builtin, method descriptor, or callable object) can fault the
+interpreter outright during exploration rather than raise. Where `os.fork` is available,
+inferring one runs in a forked child, so such a crash surfaces as an `InferError` instead
+of taking the host process down. The error names the signal and the last spy operation
+before the fault. A pure-Python function that internally calls a crashing C function is
+not isolated.
+
 !!! warning "Generic bounds"
 
     An inferred typevar bound can itself be generic, such as `[T: CanAdd[T, R], R]` where

--- a/optype/infer/_api.py
+++ b/optype/infer/_api.py
@@ -3,14 +3,14 @@
 import warnings
 from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
-from inspect import Parameter, signature
+from inspect import Parameter, isfunction, ismethod, signature
 
-# `from . import` would import the package itself, which imports this module
 import optype.infer._numpy as _numpy
 from ._backends import BACKENDS, BackendName
-from ._errors import InferError, InferWarning
+from ._errors import WARN_SKIP_PREFIX, InferError, InferWarning
 from ._explore import explore_lenient, explore_tuple_params
 from ._ir import Signature
+from ._isolate import isolate
 from ._overloads import dispatch_overloads, resolve_defaults
 from ._render import Names, signatures
 from ._signature import probe_signatures
@@ -107,12 +107,33 @@ def _infer(
         try:
             sigs += _form_signatures(func, parameters, params, gaps)
         except (InferError, ValueError) as exc:
-            # a candidate arity may fail exploration (e.g. `int`'s base); drop it,
-            # re-raising below only if no candidate produced anything
-            last = exc
+            last = exc  # re-raised below only if no arity produces anything
     if not sigs and last is not None:
         raise last
     return sigs
+
+
+def _infer_render(
+    func: _AnyFunc,
+    params: tuple[str | int, ...],
+    *,
+    strict: bool,
+    backend: BackendName,
+) -> str:
+    gaps: set[_Gap] = set()
+    try:
+        sigs = _infer(func, params, gaps)
+    except RecursionError as exc:
+        raise InferError("the result is nested too deeply") from exc
+
+    if gaps:
+        detail = "; ".join(sorted(g.message() for g in gaps))
+        msg = f"incomplete exploration: {detail}"
+        if strict:
+            raise InferError(msg)
+        warnings.warn(msg, InferWarning, skip_file_prefixes=(WARN_SKIP_PREFIX,))
+
+    return BACKENDS[backend].render(sigs)
 
 
 def infer(
@@ -140,16 +161,10 @@ def infer(
             operation without a matching protocol, or a parameter that requires
             a value that no placeholder can provide; or, with `strict=True`, if
             the function could not be explored exhaustively.
-    """
-    gaps: set[_Gap] = set()
-    try:
-        sigs = _infer(func, params, gaps)
-    except RecursionError as exc:
-        raise InferError("the result is nested too deeply") from exc
-    if gaps:
-        detail = "; ".join(sorted(g.message() for g in gaps))
-        msg = f"incomplete exploration: {detail}"
-        if strict:
-            raise InferError(msg)
-        warnings.warn(msg, InferWarning, stacklevel=2)
-    return BACKENDS[backend].render(sigs)
+    """  # noqa: DOC502
+
+    def render() -> str:
+        return _infer_render(func, params, strict=strict, backend=backend)
+
+    # functions/methods only raise; isolate the rest, which can fault in C (#738)
+    return render() if isfunction(func) or ismethod(func) else isolate(render)

--- a/optype/infer/_cli.py
+++ b/optype/infer/_cli.py
@@ -88,7 +88,8 @@ def run(*args: str) -> None:
     except (InferError, ValueError) as exc:
         cause = exc.__cause__
         detail = f" ({type(cause).__name__}: {cause})" if cause is not None else ""
-        sys.exit(f"{type(exc).__name__}: {exc}{detail}")
+        notes = "".join(f"\n  {note}" for note in getattr(exc, "__notes__", ()))
+        sys.exit(f"{type(exc).__name__}: {exc}{detail}{notes}")
 
     if _color.want_color(sys.stdout, color):
         signature = _color.highlight(signature)

--- a/optype/infer/_errors.py
+++ b/optype/infer/_errors.py
@@ -1,6 +1,11 @@
 """The `optype.infer` exceptions."""
 
+from pathlib import Path
+
 __all__ = ("InferError", "InferWarning")
+
+# the infer package dir, skipped when attributing an `InferWarning` to user code
+WARN_SKIP_PREFIX = str(Path(__file__).parent)
 
 
 class InferError(NotImplementedError):

--- a/optype/infer/_isolate.py
+++ b/optype/infer/_isolate.py
@@ -1,0 +1,106 @@
+"""Run inference in a forked subprocess so a native fault can't crash the host."""
+
+# ruff: noqa: BLE001
+
+import faulthandler
+import mmap
+import multiprocessing as mp
+import os
+import signal
+import warnings
+from collections.abc import Callable
+from contextlib import closing
+from multiprocessing.connection import Connection
+
+import optype.infer._spy as _spy  # noqa: PLR0402
+from ._errors import WARN_SKIP_PREFIX, InferError
+
+_MAX_STATE_SIZE = 4096
+_TIMEOUT = 60.0  # seconds
+
+
+def _child(work: Callable[[], object], send: Connection, buf: mmap.mmap) -> None:
+    faulthandler.disable()  # report a native crash via InferError, not a C-level dump
+    _spy.set_state_buffer(buf)
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        try:
+            payload, kind, cause = work(), "ok", None
+        except BaseException as exc:
+            payload, kind, cause = exc, "error", exc.__cause__
+
+        warns = [(str(w.message), w.category) for w in caught]
+
+        try:
+            send.send((kind, payload, cause, warns))
+        except Exception:
+            # a spy in the exception won't pickle
+            fallback = payload if kind == "ok" else InferError(str(payload))
+            send.send((kind, fallback, None, warns))
+
+
+def _read_state(buf: mmap.mmap) -> str:
+    buf.seek(0)
+    return buf.read().split(b"\x00", 1)[0].decode("utf-8", "replace")
+
+
+def _crash_error(sig: int, state: str) -> InferError:
+    exc = InferError("inference crashed the interpreter")
+    try:
+        exc.add_note(f"signal: {signal.Signals(sig).name} ({sig})")
+    except ValueError:
+        exc.add_note(f"signal: {sig}")
+    if state:
+        exc.add_note(f"spy state: {state}")
+    return exc
+
+
+def isolate[T](work: Callable[[], T]) -> T:
+    """Run `work` in a forked subprocess so a native crash becomes an `InferError`.
+
+    Raises:
+        InferError: If the child crashes, hangs past the timeout, or returns no result.
+    """  # noqa: DOC501
+    if not hasattr(os, "fork"):
+        return work()
+
+    ctx = mp.get_context("fork")
+    recv, send = ctx.Pipe(duplex=False)
+    with closing(recv), closing(mmap.mmap(-1, _MAX_STATE_SIZE)) as buf:
+        proc = ctx.Process(target=_child, args=(work, send, buf))
+        try:
+            with warnings.catch_warnings():
+                # multi-threaded fork warns; we'd otherwise error on it
+                warnings.simplefilter("ignore", DeprecationWarning)
+                proc.start()
+        except OSError:
+            return work()
+        finally:
+            # close the parent's write end so a dead child yields EOF, not a hang
+            send.close()
+
+        if not recv.poll(_TIMEOUT):
+            proc.terminate()
+            proc.join()
+            raise InferError("inference timed out")
+        try:
+            received = recv.recv()
+        except Exception:
+            # dead child: EOF or truncated pickle
+            received = None
+        proc.join()
+
+        if received is None:
+            code = proc.exitcode
+            if code and code < 0:
+                raise _crash_error(-code, _read_state(buf))
+            raise InferError("inference produced no result")
+
+        kind, payload, cause, warns = received
+        for message, category in warns:
+            warnings.warn(message, category, skip_file_prefixes=(WARN_SKIP_PREFIX,))
+
+        if kind == "error":
+            raise payload from cause
+
+        return payload

--- a/optype/infer/_spy.py
+++ b/optype/infer/_spy.py
@@ -1,6 +1,7 @@
 """Recording proxy objects that trace the operations performed on them."""
 
 import dis
+import mmap
 import sys
 from collections.abc import Callable, Generator, Iterator
 from contextvars import ContextVar
@@ -65,6 +66,16 @@ def set_driver_code[T: Callable[..., object]](fn: T, /) -> T:
     global _driver_code  # noqa: PLW0603
     _driver_code = fn.__code__  # ty: ignore[unresolved-attribute]
     return fn
+
+
+# a shared buffer into which each spy operation writes itself, so the last action
+# survives a native crash for `_isolate` to report (#738)
+_state_buffer: mmap.mmap | None = None
+
+
+def set_state_buffer(buf: mmap.mmap | None, /) -> None:
+    global _state_buffer  # noqa: PLW0603
+    _state_buffer = buf
 
 
 # star-unpack detection reads caller bytecode (CPython detail); else it never fires
@@ -176,7 +187,10 @@ class _Spy:
         kwargs: _Kwargs,
         out: OutT,
     ) -> OutT:
-        self.__optype_trace__.append(_TraceItem(attr, args, kwargs, out))
+        item = _TraceItem(attr, args, kwargs, out)
+        self.__optype_trace__.append(item)
+        if _state_buffer is not None:
+            _record_state(item, _state_buffer)
         return out
 
     def __init__(self, /, *_args: object, **_kwargs: object) -> None:
@@ -191,6 +205,26 @@ class _SpyStr(str, _Spy):
 @final
 class _SpyBytes(bytes, _Spy):
     __slots__ = ()  # pyrefly:ignore[implicit-any-attribute]
+
+
+def _brief(value: object, /) -> str:
+    # never call a spy's own dunders while formatting it
+    if isinstance(value, _Spy):
+        return "spy"
+    try:
+        text = repr(value)
+    except Exception:  # noqa: BLE001
+        return type(value).__name__
+    return text if len(text) <= 32 else text[:31] + "..."
+
+
+def _record_state(item: _TraceItem, buf: mmap.mmap, /) -> None:
+    # the last completed op; a crash strikes between ops, in native code (#738)
+    call = f"{item.attr}({', '.join(_brief(a) for a in item.args)})"
+    ret = "" if item.return_ is None else f" -> {_brief(item.return_)}"
+    data = (call + ret).encode("utf-8", "replace")[: len(buf) - 1] + b"\x00"
+    buf.seek(0)
+    buf.write(data)
 
 
 class _SpyType(type):

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -16,8 +16,10 @@ import random
 import re
 import secrets
 import shutil
+import signal
 import subprocess  # noqa: S404
 import sys
+import time
 import warnings
 import weakref
 from collections.abc import Callable
@@ -45,6 +47,7 @@ from optype.infer._ir import (
     subtype,
     union,
 )
+from optype.infer._isolate import isolate
 from optype.infer._numpy import array_function_node
 from optype.infer._values import GapKind
 
@@ -1171,10 +1174,11 @@ def test_method_descriptor() -> None:
 
 
 # #739: a buffer-exporting spy reclaimed by cyclic GC may tear down its class MRO before
-# the held memoryview's `__release_buffer__` lookup. The fabricated cycle below collects
-# silently on every supported interpreter, but a rare CPython buffer/GC use-after-free
-# can still fault under some heap layouts, so run it isolated: a fault is then a clean
-# subprocess failure rather than a crash of the whole test session.
+# the held memoryview's `__release_buffer__` lookup. Dropping `__release_buffer__` from
+# the spy keeps the fabricated cycle below collecting silently on every supported
+# interpreter, but a rare CPython buffer/GC use-after-free can still fault under some
+# heap layouts, so run it in a subprocess: a fault is then a clean subprocess failure
+# rather than a crash of the whole test session.
 _BUFFER_GC_SCRIPT = """
 import gc, sys
 from optype.infer import infer
@@ -1207,6 +1211,79 @@ def test_buffer_spy_release_silent_under_cyclic_gc() -> None:
         check=False,
     )
     assert out.returncode == 0, out.stderr or out.stdout
+
+
+fork_only = pytest.mark.skipif(not hasattr(os, "fork"), reason="requires os.fork")
+
+
+@fork_only
+def test_isolate_returns_value() -> None:
+    assert isolate(lambda: "ok") == "ok"
+
+
+@fork_only
+def test_isolate_reports_signal() -> None:
+    with pytest.raises(InferError) as excinfo:
+        isolate(lambda: signal.raise_signal(signal.SIGKILL))
+    assert any("SIGKILL (9)" in note for note in excinfo.value.__notes__)
+
+
+@fork_only
+def test_isolate_reports_silent_exit() -> None:
+    with pytest.raises(InferError, match="no result"):
+        isolate(lambda: os._exit(0))
+
+
+@fork_only
+def test_isolate_times_out(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("optype.infer._isolate._TIMEOUT", 0.1)
+    with pytest.raises(InferError, match="timed out"):
+        isolate(lambda: time.sleep(5))
+
+
+@fork_only
+def test_isolate_preserves_cause() -> None:
+    def work() -> None:
+        raise InferError("boom") from ValueError("root")
+
+    with pytest.raises(InferError, match="boom") as excinfo:
+        isolate(work)
+    assert isinstance(excinfo.value.__cause__, ValueError)
+
+
+@fork_only
+def test_isolate_forwards_warning() -> None:
+    def work() -> str:
+        warnings.warn("heads up", InferWarning, stacklevel=1)
+        return "ok"
+
+    with pytest.warns(InferWarning, match="heads up"):
+        assert isolate(work) == "ok"
+
+
+@fork_only
+def test_infer_isolates_native_crash() -> None:
+    # a native callable that faults is contained, not a session crash (#738)
+    class _Crash:
+        def __call__(self, x: object) -> None:  # noqa: ARG002
+            signal.raise_signal(signal.SIGKILL)
+
+    with pytest.raises(InferError):
+        infer(_Crash())
+
+
+@fork_only
+def test_infer_crash_reports_spy_state() -> None:
+    # the spy state note names the last operation before a native crash (#738)
+    class _Crash:
+        def __call__(self, x: object) -> None:
+            repr(x)
+            signal.raise_signal(signal.SIGSEGV)
+
+    with pytest.raises(InferError) as excinfo:
+        infer(_Crash())
+    notes = excinfo.value.__notes__
+    assert any("spy state: __repr__() -> spy" in note for note in notes)
 
 
 def test_rich_return_chains_terminate() -> None:


### PR DESCRIPTION
after:

```console
$ optype infer "import time; time.pthread_getcpuclockid"
InferError: inference crashed the interpreter
  signal: SIGSEGV (11)
  spy state: __index__() -> 1
```

closes #738