### PR TITLE
`infer`: signature simplification

### DIFF
--- a/optype/infer/_ir.py
+++ b/optype/infer/_ir.py
@@ -3,13 +3,15 @@
 import builtins
 import sys
 import types
-from collections.abc import Generator, Iterable
+from collections.abc import Generator, Iterable, Mapping
 from dataclasses import dataclass
 from typing import override
 
 type Node = (
     Lit | Type | Name | App | Fn | Union | Inter | Not | Variance | Unpack | Dots
 )
+type Term = Node | Arg
+type Terms = tuple[Term, ...]
 
 # the shared variance signs: covariant (read-only) and contravariant (write-only)
 COVARIANT = "+"
@@ -75,18 +77,18 @@ class App:
     """A (subscripted) named type, e.g. `CanAdd[Literal[1], R]`."""
 
     base: str
-    args: tuple[Node | Arg, ...]
+    args: Terms
 
 
 @dataclass(frozen=True, slots=True)
 class Fn:
     """A function type in signature syntax, e.g. `(x: T) -> R` or `(T) -> R`."""
 
-    params: tuple[Node | Arg, ...]
+    params: Terms
     ret: Node
 
 
-def _param_type(param: Node | Arg) -> Node:
+def _param_type(param: Term) -> Node:
     """The type of a (possibly keyword-labeled) parameter."""
     return param.value if isinstance(param, Arg) else param
 
@@ -171,7 +173,7 @@ def tuple_node_variadic(element: Node) -> App:
     return tuple_node((element, Dots()))
 
 
-def subtype(sub: Node | Arg, sup: Node | Arg) -> bool:
+def subtype(sub: Term, sup: Term) -> bool:
     """Whether `sub` is a subtype of `sup`, as far as can be told from the nodes."""
     if sub == sup or sub == Name("Never") or sup in {Name("object"), Type(object)}:
         return True
@@ -330,23 +332,70 @@ def inter(parts: Iterable[Node]) -> Node | None:
     return next(iter(flat)) if len(flat) == 1 else Inter(tuple(flat))
 
 
-def names(node: Node | Arg) -> Generator[str]:
+def names(node: Term) -> Generator[str]:
     # every type-name leaf, in order, so typevar uses can be counted
     match node:
         case Name(name):
             yield name
-        case Arg(value=value):
-            yield from names(value)
+        case Arg(value=part) | Not(part) | Variance(part=part) | Unpack(part):
+            yield from names(part)
         case App(args=parts) | Union(parts) | Inter(parts):
             for part in parts:
                 yield from names(part)
         case Fn(params, ret):
             for part in (*params, ret):
                 yield from names(part)
-        case Not(part) | Variance(part=part) | Unpack(part):
-            yield from names(part)
         case Lit() | Type() | Dots():
             return
+
+
+def rename(node: Node, m: Mapping[str, str]) -> Node:
+    """Simultaneously rename every `Name(n)` to `Name(m[n])`."""
+    if not m:
+        return node
+
+    match node:
+        case Name(name):
+            out = Name(m[name]) if name in m else node
+        case App(base, args):
+            out = App(base, tuple(_rename_term(arg, m) for arg in args))
+        case Fn(params, ret):
+            out = Fn(tuple(_rename_term(p, m) for p in params), rename(ret, m))
+        case Union(parts) | Inter(parts):
+            # renaming can collapse distinct members; drop the duplicates
+            renamed = tuple(dict.fromkeys(rename(p, m) for p in parts))
+            out = renamed[0] if len(renamed) == 1 else type(node)(renamed)
+        case Not(part) | Unpack(part):
+            out = type(node)(rename(part, m))
+        case Variance(sign, part):
+            out = Variance(sign, rename(part, m))
+        case _:
+            out = node
+    return out
+
+
+def _rename_term(term: Term, m: Mapping[str, str]) -> Term:
+    """`rename`, keeping any `Arg` wrapper of an `App`/`Fn` member."""
+    if isinstance(term, Arg):
+        return Arg(term.key, rename(term.value, m), term.default)
+    return rename(term, m)
+
+
+def _canonical_renaming(node: Node) -> dict[str, str]:
+    """Relabel each `Name` by first-occurrence order, to canonicalize via `rename`."""
+    m: dict[str, str] = {}
+    for name in names(node):
+        m.setdefault(name, f"\x00{len(m)}")
+    return m
+
+
+def alpha_equal(a: Node, b: Node) -> dict[str, str] | None:
+    """A `Name` bijection making `a` and `b` identical up to renaming, or `None`."""
+    ca, cb = _canonical_renaming(a), _canonical_renaming(b)
+    if rename(a, ca) != rename(b, cb):
+        return None
+    inv = {label: name for name, label in cb.items()}
+    return {name: inv[label] for name, label in ca.items()}
 
 
 # the two `types` members that alias another's type, so each type maps to one name
@@ -373,7 +422,16 @@ def type_name(cls: type) -> str:
     return prefix + cls.__name__
 
 
+_TVAR_LETTERS = "TUVWXYZ"
+
+
 def typevar_name(n: int) -> str:
     """The `n`-th generic parameter name: `T, U, ..., Z`, then `T7, T8, ...`."""
-    letters = "TUVWXYZ"
-    return letters[n] if n < len(letters) else f"T{n}"
+    return _TVAR_LETTERS[n] if n < len(_TVAR_LETTERS) else f"T{n}"
+
+
+def typevar_index(name: str) -> int | None:
+    """The index of a generated typevar `name` (`T..Z` or `T<n>`), or `None`."""
+    if len(name) == 1:
+        return _TVAR_LETTERS.index(name) if name in _TVAR_LETTERS else None
+    return int(name[1:]) if name[0] == "T" and name[1:].isdigit() else None

--- a/optype/infer/_render.py
+++ b/optype/infer/_render.py
@@ -2,7 +2,7 @@
 
 import sys
 import types
-from collections import Counter
+from collections import Counter, defaultdict
 from collections.abc import Callable, Collection, Iterable, Mapping, Sequence
 from inspect import Parameter, _ParameterKind
 from typing import Any, cast, final
@@ -56,6 +56,7 @@ _NEVER = "Never"
 _OBJECT = "object"
 
 _TUPLE_LIMIT = 16
+_LITERAL_LIMIT = 8
 
 # `object`-typed so the `is` check isn't flagged (`Callable` is a special form)
 _CALLABLE_ORIGIN: object = Callable
@@ -65,6 +66,10 @@ _READ = _ir.COVARIANT  # a read-only property suffices
 _WRITE = _ir.CONTRAVARIANT  # the attribute only has to accept the value
 
 type _Vars = dict[int, str]
+type _TypeParams = list[_ir.TypeParam]
+type _Params = list[_ir.Param]
+type _Sig = tuple[_TypeParams, _Params, _ir.Node]
+
 type Names = Sequence[str]
 type Defaults = Mapping[str, object]
 
@@ -536,6 +541,11 @@ class _Renderer:
             if (param := self._param(name, defaults, negate=negate)) is not None
         ]
         ret_node = self._typer.type_union(self._results) if ret is None else ret
+        type_params, params, ret_node = _collapse_recursive(
+            type_params,
+            params,
+            ret_node,
+        )
         return _ir.Signature(
             tuple(type_params),
             tuple(params),
@@ -617,7 +627,10 @@ class _ResultTyper:
                 parts.append(self.return_type(value))
 
         nodes: list[_ir.Node] = []
-        if literals:
+        if len(literals) > _LITERAL_LIMIT:
+            # an enumerated run (e.g. randbelow's 256 bytes) is noise; widen to types
+            nodes.extend(dict.fromkeys(_ir.Type(type(v)) for v in literals))
+        elif literals:
             nodes.append(_ir.Lit(tuple(literals)))
         nodes.extend(dict.fromkeys(parts))
         return _ir.union(nodes, tuples=tuples)
@@ -804,6 +817,144 @@ class _ResultTyper:
             return _ir.tuple_node_variadic(self.type_union(items))
 
         return _ir.tuple_node(self.value_type(item) for item in items)
+
+
+_LOOP_MIN = 3  # unrolled iterations a run needs before it is rerolled
+
+
+def _shift_edges(bounded: Mapping[str, _ir.Node]) -> dict[str, str]:
+    """`x -> y` when `bound(y)` is `bound(x)` shifted one unrolled iteration deeper.
+
+    `y` is the copy `x` becomes next time round the loop: it appears in `bound(x)`, the
+    two bounds are equal up to a renaming, and that renaming carries `y` onto another
+    bounded copy (so `y` is the recursion pointer, not a shared outer typevar).
+    """
+    edge: dict[str, str] = {}
+    for x, bound in bounded.items():
+        for y in dict.fromkeys(_ir.names(bound)):
+            if y == x or y not in bounded:
+                continue
+
+            mapping = _ir.alpha_equal(bound, bounded[y])
+            if mapping is not None and mapping.get(y) in bounded:
+                edge[x] = y
+                break
+    return edge
+
+
+def _gc_tvars(tparams: _TypeParams, params: _Params, ret: _ir.Node) -> _TypeParams:
+    """Drop type parameters no longer reachable from the parameters or return."""
+    by_name = {tp.name: tp for tp in tparams}
+    reach: set[str] = set()
+    stack = [name for p in params for name in _ir.names(p.node)]
+    stack += _ir.names(ret)
+    while stack:
+        if (name := stack.pop()) in reach:
+            continue
+
+        reach.add(name)
+        if (tp := by_name.get(name)) is not None:
+            stack += _ir.names(tp.bound) if tp.bound is not None else ()
+            stack += _ir.names(tp.default) if tp.default is not None else ()
+
+    return [tp for tp in tparams if tp.name in reach]
+
+
+def _rename_sig(
+    tparams: _TypeParams,
+    params: _Params,
+    ret: _ir.Node,
+    remap: Mapping[str, str],
+) -> _Sig:
+    """Apply a `Name` remap across a signature's type params, params, and return."""
+    tps = [
+        _ir.TypeParam(
+            remap.get(tp.name, tp.name),
+            None if tp.bound is None else _ir.rename(tp.bound, remap),
+            None if tp.default is None else _ir.rename(tp.default, remap),
+            tp.unpack,
+        )
+        for tp in tparams
+    ]
+    args = [
+        _ir.Param(
+            p.name,
+            _ir.rename(p.node, remap),
+            p.prefix,
+            p.nameless,
+            p.default,
+        )
+        for p in params
+    ]
+    return tps, args, _ir.rename(ret, remap)
+
+
+def _renumber_tvars(tparams: _TypeParams, params: _Params, ret: _ir.Node) -> _Sig:
+    """Renumber the surviving `T, U, V, ...` typevars gaplessly, in their order."""
+    remap: dict[str, str] = {}
+    n = 0
+    for tp in tparams:
+        if _ir.typevar_index(tp.name) is not None:
+            if (new := _ir.typevar_name(n)) != tp.name:
+                remap[tp.name] = new
+            n += 1
+
+    if not remap:
+        return tparams, params, ret
+    return _rename_sig(tparams, params, ret, remap)
+
+
+def _reroll_remap(
+    bounded: Mapping[str, _ir.Node],
+    edge: Mapping[str, str],
+) -> dict[str, str]:
+    """Group each run of shift edges onto its earliest-declared copy (`min` order).
+
+    A name has one outgoing `edge` at most, so its chain to a terminal is a run.
+    """
+    order = {name: i for i, name in enumerate(bounded)}
+
+    def terminal(name: str) -> str:
+        seen: set[str] = set()
+        while name in edge and name not in seen:
+            seen.add(name)
+            name = edge[name]
+        return name
+
+    runs: defaultdict[str, list[str]] = defaultdict(list)
+    for name in bounded:
+        runs[terminal(name)].append(name)
+
+    remap: dict[str, str] = {}
+    for members in runs.values():
+        if len(members) < _LOOP_MIN:
+            continue
+        lead = min(members, key=order.__getitem__)
+        remap.update({name: lead for name in members if name != lead})
+    return remap
+
+
+def _collapse_recursive(tparams: _TypeParams, params: _Params, ret: _ir.Node) -> _Sig:
+    """Fold each run of self-similar typevars onto one (mutually) recursive typevar.
+
+    The explorer unrolls a loop into a run `T -> U -> V -> ...` of identical bounds,
+    one per iteration. Collapsing the run onto its leading copy closes it into the
+    recursive type the loop denotes (cf. `sum`, `-x + x`) rather than an N-deep
+    transcript, and keeps coupled loop variables as mutual recursion.
+    """
+    bounded = {
+        tp.name: tp.bound for tp in tparams if tp.bound is not None and not tp.unpack
+    }
+    if len(bounded) < _LOOP_MIN or not (edge := _shift_edges(bounded)):
+        return tparams, params, ret
+
+    remap = _reroll_remap(bounded, edge)
+    if not remap:
+        return tparams, params, ret
+
+    kept = [tp for tp in tparams if tp.name not in remap]
+    tparams, params, ret = _rename_sig(kept, params, ret, remap)
+    return _renumber_tvars(_gc_tvars(tparams, params, ret), params, ret)
 
 
 def _renderers(

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -6,6 +6,7 @@
 import ast
 import builtins
 import difflib
+import fractions
 import functools
 import io
 import itertools
@@ -41,14 +42,20 @@ from optype.infer._ir import (
     Lit,
     Name,
     Node,
+    Param,
     Signature,
     Type,
+    TypeParam,
+    Union,
+    alpha_equal,
     names,
+    rename,
     subtype,
     union,
 )
 from optype.infer._isolate import isolate
 from optype.infer._numpy import array_function_node
+from optype.infer._render import _collapse_recursive
 from optype.infer._values import GapKind
 
 if sys.version_info >= (3, 13):
@@ -1296,6 +1303,75 @@ def test_rich_return_chains_terminate() -> None:
     lines = matches.splitlines()
     assert lines
     assert all("list[" in line.rsplit("->", 1)[-1] for line in lines)
+
+
+def test_alpha_equal_and_rename() -> None:
+    # the fold's primitives: structural equality up to a consistent name bijection,
+    # and a simultaneous rename that drops union members which collapse together
+    a = App("CanAdd", (Name("A"), App("CanMul", (Name("B"), Name("A")))))
+    b = App("CanAdd", (Name("X"), App("CanMul", (Name("Y"), Name("X")))))
+    assert alpha_equal(a, b) == {"A": "X", "B": "Y"}
+    assert alpha_equal(a, App("CanAdd", (Name("X"), Name("X")))) is None
+    assert rename(a, {"A": "X", "B": "Y"}) == b
+    assert rename(Union((Name("A"), Name("B"))), {"A": "C", "B": "C"}) == Name("C")
+
+
+def test_collapse_recursive_reroll() -> None:
+    # #736: an unrolled loop's run of identical bounds folds to one recursive typevar
+    def link(leaf: str, nxt: str) -> Node:
+        return App("CanAdd", (Name(leaf), Name(nxt)))
+
+    type_params = [
+        TypeParam("T", link("T7", "U")),
+        TypeParam("U", link("T8", "V")),
+        TypeParam("V", link("T9", "W")),
+        TypeParam("W", link("T10", "T11")),  # the last copy points at the loop's exit
+        *(TypeParam(leaf) for leaf in ("T7", "T8", "T9", "T10", "T11")),
+    ]
+    params = [Param("x", Name("T"))]
+    folded, fparams, fret = _collapse_recursive(type_params, params, Name("T"))
+    # T, U, V, W collapse onto a single self-referential T; spent leaves are dropped
+    assert folded == [
+        TypeParam("T", App("CanAdd", (Name("U"), Name("T")))),
+        TypeParam("U"),  # the surviving per-iteration leaf, renumbered gaplessly
+    ]
+    assert fparams == params
+    assert fret == Name("T")
+
+
+def test_collapse_recursive_keeps_short_runs() -> None:
+    # #736: below the loop threshold, similar typevars are left intact (no false fold)
+    type_params = [
+        TypeParam("T", App("CanAdd", (Name("T7"), Name("U")))),
+        TypeParam("U", App("CanAdd", (Name("T8"), Name("T9")))),
+        *(TypeParam(leaf) for leaf in ("T7", "T8", "T9")),
+    ]
+    folded, _, _ = _collapse_recursive(type_params, [Param("x", Name("T"))], Name("T"))
+    assert folded == type_params
+
+
+# `Fraction.limit_denominator` calls `Fraction(self)`; only 3.14+ accepts a duck-typed
+# `as_integer_ratio` object there, so before then the spy is rejected, leaving nothing
+@pytest.mark.skipif(sys.version_info < (3, 14), reason="requires Python 3.14+")
+def test_loop_signature_folds() -> None:
+    # #736: a function whose loop the explorer unrolls used to emit a ~250-typevar,
+    # 80kb transcript; the run now folds into a small recursive signature
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", InferWarning)
+        out = infer(fractions.Fraction.limit_denominator)
+    assert len(out) < 10000  # was ~82kb
+    assert all(len(line) < 6000 for line in out.splitlines())  # no giant transcript
+
+
+def test_wide_literal_union_capped() -> None:
+    # #736: an enumerated run (randbelow samples 256 bytes) widens to its type, `int`,
+    # rather than a 256-member `Literal`
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", InferWarning)
+        out = infer(secrets.randbelow)
+    assert len(out) < 1200  # was ~3kb dominated by literal bytes
+    assert "int" in out
+    assert all(lit.count(",") < 8 for lit in re.findall(r"Literal\[([^\]]*)\]", out))
 
 
 def test_method_descriptor_fixed_defaults() -> None:


### PR DESCRIPTION
after:

```console
$ optype infer "import secrets; secrets.randbelow" | wc -c
warning: incomplete exploration: branch budget exhausted in (exclusive_upper_bound); run budget exhausted in (exclusive_upper_bound)
2985
```

```console
$ optype infer "import secrets; secrets.randbelow" | wc -c
warning: incomplete exploration: branch budget exhausted in (exclusive_upper_bound); run budget exhausted in (exclusive_upper_bound)
567
```

closes #736