### PR TITLE
`infer`: >2x faster inference

### DIFF
--- a/optype/infer/_explore.py
+++ b/optype/infer/_explore.py
@@ -34,8 +34,10 @@ from ._spy import (
     _AnyFunc,
     _Fork,
     _fork,
+    _journal,
     _Marker,
     _own_spy,
+    _Spy,
     _SpyBytes,
     _SpyObject,
     _SpyStr,
@@ -44,6 +46,7 @@ from ._spy import (
     _Traces,
     _yield_budget,
     as_spy,
+    journal_rollback,
     set_driver_code,
 )
 from ._values import (
@@ -56,7 +59,6 @@ from ._values import (
     _Rec,
     _RecRef,
     _RecVar,
-    _walk,
     fn_spies,
 )
 
@@ -253,29 +255,6 @@ def _explore_key(func: object) -> int:
     return id(getattr(base, "__code__", base))
 
 
-def _closed_over(func: object, seen: set[int] | None = None) -> Generator[object]:
-    # every value a function can reach besides its arguments, transitively
-    seen = set() if seen is None else seen
-    if id(func) in seen:
-        return
-    seen.add(id(func))
-    values: list[object] = []
-    while isinstance(func, functools.partial):
-        values += func.args
-        values += func.keywords.values()
-        func = func.func
-    values += getattr(func, "__defaults__", None) or ()
-    values += (getattr(func, "__kwdefaults__", None) or {}).values()
-    for cell in getattr(func, "__closure__", None) or ():
-        with suppress(ValueError):  # an unset cell
-            values.append(cell.cell_contents)
-    for value in values:
-        for node in _walk(value):
-            yield node
-            if isinstance(_unwrap(node), _FUNCTION_TYPES):
-                yield from _closed_over(node, seen)
-
-
 def _explore_func(func: _AnyFunc) -> object:
     """Explore a returned function, so it renders in signature syntax."""
     if _explore_key(func) in _exploring.get():
@@ -428,11 +407,6 @@ def _with_next_default(
     return merged if awaitable else [*results, default]
 
 
-def _rollback(marks: Iterable[tuple[_SpyObject, int]]) -> None:
-    for spy, length in marks:
-        del spy.__optype_trace__[length:]
-
-
 @set_driver_code
 def _run[T](
     func: Callable[..., T] | Callable[..., Coroutine[Any, None, T]],
@@ -472,14 +446,13 @@ def _explore[T](  # noqa: C901
         if not stack:
             break
         plan = stack.pop()
-        # a failed run must also roll back its traces on the closed-over spies
-        marks = [
-            (spy, len(spy.__optype_trace__))
-            for spy in _reachable((*args, *kwds.values(), *_closed_over(func)))
-        ]
         # `_starved` is a per-run star-unpack flag, so no prior run leaks into this one
         _starved.set(False)
-        token = _fork.set(iter(plan))
+        fork_token = _fork.set(iter(plan))
+        # a rejected run rolls back its trace appends, including on closed-over spies
+        marks: dict[int, tuple[_Spy, int]] = {}
+        journal_token = _journal.set(marks)
+        undo = False
 
         try:
             result, message = _run(func, args, kwds)
@@ -492,19 +465,21 @@ def _explore[T](  # noqa: C901
                 dropped = True
         except _AbsentError:
             # the dunder is genuinely needed, so this run (and its marker) never was
-            _rollback(marks)
+            undo = True
         except (InferError, IndexError, KeyError, TypeError):
             raise  # signals the driver acts on, not a rejected run
         except ValueError as exc:
             # a forked value the target rejected (e.g. `range`'s zero step); defer
             value_exc = exc
-            _rollback(marks)
+            undo = True
         except (Exception, SystemExit) as exc:  # noqa: BLE001
             # the target rejected these spy values or exited (e.g. `exit()`); skip
             last_exc = exc
-            _rollback(marks)
+            undo = True
         finally:
-            _fork.reset(token)
+            _fork.reset(fork_token)
+            _journal.reset(journal_token)
+            journal_rollback(marks, undo=undo)
 
     if not results:
         if value_exc is not None:

--- a/optype/infer/_spy.py
+++ b/optype/infer/_spy.py
@@ -187,6 +187,7 @@ class _Spy:
         kwargs: _Kwargs,
         out: OutT,
     ) -> OutT:
+        _journal_touch(self)
         item = _TraceItem(attr, args, kwargs, out)
         self.__optype_trace__.append(item)
         if _state_buffer is not None:
@@ -195,6 +196,25 @@ class _Spy:
 
     def __init__(self, /, *_args: object, **_kwargs: object) -> None:
         self.__optype_trace__ = []
+
+
+# while a run explores, each touched spy's pre-run trace length, so `_explore` can
+# undo a rejected run by truncating only the spies it actually appended to
+_journal: ContextVar[dict[int, tuple[_Spy, int]] | None] = ContextVar(
+    "_journal",
+    default=None,
+)
+
+
+def _journal_touch(spy: _Spy) -> None:
+    if (marks := _journal.get()) is not None and id(spy) not in marks:
+        marks[id(spy)] = (spy, len(spy.__optype_trace__))
+
+
+def journal_rollback(marks: dict[int, tuple[_Spy, int]], /, *, undo: bool) -> None:
+    if undo:
+        for spy, length in marks.values():
+            del spy.__optype_trace__[length:]
 
 
 @final
@@ -271,6 +291,7 @@ class _SpyObject(_Spy, metaclass=_SpyType):
             # a `type(spy)(...)` sibling; the marker keeps it reachable from the spy
             self = super().__new__(cls)
             if (owner := _class_spy(cls)) is not None:
+                _journal_touch(owner)
                 owner.__optype_trace__.append(_TraceItem(_Marker.SIBLING, (), {}, self))
             return self
         # every spy gets a class of its own, so that `type(spy)` identifies the spy


### PR DESCRIPTION
### Test suite (`tests/test_infer.py`)

| Test | Before | After | Speedup |
|------|-------:|------:|--------:|
| `test_loop_signature_folds` | 24.85s | 9.92s | **2.5×** |
| `test_wide_literal_union_capped` | 4.36s | 0.53s | **8.2×** |
| `test_rich_return_chains_terminate` | 2.20s | 1.14s | **1.9×** |
| `test_fork_explosion` | 1.48s | 0.86s | **1.7×** |
| **Full suite** (462 tests) | **39.4s** | **18.7s** | **2.1×** |

### `infer()` on the worst-case targets

| Call | Before | After | Speedup |
|------|-------:|------:|--------:|
| `infer(Fraction.limit_denominator)` | 24.6s | 9.1s | **2.7×** |
| `infer(secrets.randbelow)` | 4.46s | 1.15s | **3.9×** |
| `infer(difflib.get_close_matches)` | 1.59s | 1.00s | **1.6×** |

### Phase breakdown for `Fraction.limit_denominator`

| Phase | Before | After | Speedup |
|-------|-------:|------:|--------:|
| Exploration (`explore_lenient`) | 5.82s | 0.46s | **12.7×** |
| `_reachable`/`marks` snapshot | ~17s | ~0s (removed) | — |
| Rendering (`resolve_defaults` + `signatures`) | ~8s | ~8s | unchanged |