### PR TITLE
`infer`: improved performance (~2x faster)

### DIFF
--- a/optype/infer/_analyze.py
+++ b/optype/infer/_analyze.py
@@ -236,7 +236,9 @@ def all_packed(
 
 
 def reflect(params: Sequence[_SpyObject], traces: _Traces) -> _Traces:
-    """A copy of `traces` with each spy-spy binary op reflected onto its RHS."""
+    """A copy of `traces` with each spy-spy binary op reflected onto its RHS,
+    or `traces` itself when nothing reflects at all.
+    """
     kept: _Traces = dict(traces)
     added: defaultdict[int, list[_TraceItem]] = defaultdict(list)
     for spy in _trace_order(params, traces):
@@ -251,4 +253,6 @@ def reflect(params: Sequence[_SpyObject], traces: _Traces) -> _Traces:
             else:
                 keep.append(item)
         kept[id(spy)] = keep
+    if not added:
+        return traces
     return {spy_id: keep + added[spy_id] for spy_id, keep in kept.items()}

--- a/optype/infer/_api.py
+++ b/optype/infer/_api.py
@@ -9,6 +9,7 @@ import optype.infer._numpy as _numpy
 from ._backends import BACKENDS, BackendName
 from ._errors import WARN_SKIP_PREFIX, InferError, InferWarning
 from ._explore import explore_lenient, explore_tuple_params
+from ._gc import pause_gc
 from ._ir import Signature
 from ._isolate import isolate
 from ._overloads import dispatch_overloads, resolve_defaults
@@ -122,7 +123,8 @@ def _infer_render(
 ) -> str:
     gaps: set[_Gap] = set()
     try:
-        sigs = _infer(func, params, gaps)
+        with pause_gc():
+            sigs = _infer(func, params, gaps)
     except RecursionError as exc:
         raise InferError("the result is nested too deeply") from exc
 

--- a/optype/infer/_explore.py
+++ b/optype/infer/_explore.py
@@ -29,6 +29,7 @@ from types import (
 from typing import Any, cast
 
 from ._errors import InferError
+from ._gc import drain_gc
 from ._spy import (
     _AbsentError,
     _AnyFunc,
@@ -429,6 +430,18 @@ def _run[T](
     return value, message
 
 
+def _drain() -> None:
+    # the drain runs the target's finalizers; discard any spy ops they record,
+    # or a rolled-back branch's `__del__` pollutes the trace
+    marks: dict[int, tuple[_Spy, int]] = {}
+    token = _journal.set(marks)
+    try:
+        drain_gc()
+    finally:
+        _journal.reset(token)
+        journal_rollback(marks, undo=True)
+
+
 def _explore[T](  # noqa: C901
     func: Callable[..., T] | Callable[..., Coroutine[Any, None, T]],
     args: Sequence[object],
@@ -480,6 +493,8 @@ def _explore[T](  # noqa: C901
             _fork.reset(fork_token)
             _journal.reset(journal_token)
             journal_rollback(marks, undo=undo)
+
+        _drain()
 
     if not results:
         if value_exc is not None:

--- a/optype/infer/_gc.py
+++ b/optype/infer/_gc.py
@@ -1,0 +1,45 @@
+"""Pause and drain the cyclic garbage collector around exploration runs."""
+
+# ruff: noqa: PLW0603
+
+import gc
+from collections.abc import Generator
+from contextlib import contextmanager
+
+# pending allocations below this leave collection to the normal gc cadence
+_PENDING_MAX = 100_000
+
+# unlocked module state: one exploration at a time, like the collector it toggles
+_paused = False
+_promoted = False
+
+
+@contextmanager
+def pause_gc() -> Generator[None]:
+    """Hold automatic collection off while the trace graph is fully live.
+
+    Young-only sweeps between runs and on exit free the dead cycles without
+    scanning the host's older heap.
+    """
+    global _paused, _promoted
+    if _paused or not gc.isenabled():
+        yield
+        return
+    gc.disable()
+    _paused = True
+    _promoted = False
+    try:
+        yield
+    finally:
+        _paused = False
+        gc.enable()
+        # a drain promoted the live graph to the older generation; sweep it there
+        gc.collect(1 if _promoted else 0)
+
+
+def drain_gc() -> None:
+    """A young sweep once enough garbage pends while collection is paused."""
+    global _promoted
+    if _paused and gc.get_count()[0] > _PENDING_MAX:
+        gc.collect(0)
+        _promoted = True

--- a/optype/infer/_overloads.py
+++ b/optype/infer/_overloads.py
@@ -19,6 +19,8 @@ from ._ir import Signature
 from ._render import (
     Defaults,
     Names,
+    _renderers,
+    _signatures,
     signatures,
     union_signature,
     widened_signature,
@@ -91,8 +93,9 @@ def resolve_defaults(
 
     try:
         omitted = explore_spies(func, params, omit=defaults)
+        omitted_renderers = _renderers(omitted, params)
         # the comparison must see every required parameter, regardless of selection
-        observed = signatures(omitted, required, names)
+        observed = _signatures(omitted_renderers, names, deprecated=omitted.deprecated)
     except Exception:  # noqa: BLE001
         return {}, False, []
 
@@ -100,7 +103,12 @@ def resolve_defaults(
     if signatures(omitted_defaults, required, names) == observed:
         return defaults, False, []
 
-    overloads = signatures(omitted, params, selected, defaults)
+    overloads = _signatures(
+        omitted_renderers,
+        selected,
+        defaults,
+        deprecated=omitted.deprecated,
+    )
 
     if len(defaults) == 1:
         return defaults, True, overloads

--- a/optype/infer/_render.py
+++ b/optype/infer/_render.py
@@ -130,6 +130,11 @@ def _result_var(index: int) -> str:
     return "R" if not index else f"R{index + 1}"
 
 
+def _distinct[T](values: Iterable[T]) -> Collection[T]:
+    """Deduplicate by identity; holding the values keeps their ids from reuse."""
+    return {id(value): value for value in values}.values()
+
+
 @final
 class _Renderer:
     """Render an inferred `def` signature from the recorded spy traces."""
@@ -159,6 +164,8 @@ class _Renderer:
     _declared_spies: list[_SpyObject]
     _param_spies: list[_SpyObject]
     _group_traces: _Traces
+    _bound_nodes: dict[int, _ir.Node | None]  # rendered bound per representative
+    _ret_node: _ir.Node  # rendered return union, refreshed along with the bounds
 
     _typer: "_ResultTyper"  # renders explored result values into type nodes
 
@@ -187,6 +194,7 @@ class _Renderer:
             vartuple=self._vartuple,
             count=self._count,
         )
+        self._render_bounds()
         self._inline_single_use()
 
     def _configure(self, params: Mapping[str, Parameter]) -> None:
@@ -289,19 +297,24 @@ class _Renderer:
                 self._declared_spies.append(spy)
             self._vars[id(spy)] = var
 
+    def _render_bounds(self) -> None:
+        """Render and cache each named bound and the return union."""
+        self._bound_nodes = {
+            rep: self.traces(self._group_traces.get(rep, ())) for rep in self._named
+        }
+        self._ret_node = self._typer.type_union(self._results)
+
     def _inline_single_use(self) -> None:
         # a bounded typevar referenced once and absent from the return carries no more
         # than its bound, so it inlines back into the one spot that uses it
 
         vars_, reps = self._vars, self._reps
 
-        bounds = {
-            rep: self.traces(self._group_traces.get(rep, ())) for rep in self._named
-        }
+        bounds = self._bound_nodes
         rendered = [
             *(self._slot(spy) for spy in self._param_spies),
             *(node for node in bounds.values() if node is not None),
-            self._typer.type_union(self._results),
+            self._ret_node,
         ]
         counts = Counter(name for node in rendered for name in _ir.names(node))
 
@@ -340,6 +353,7 @@ class _Renderer:
             if var not in inline
         }
         self._group_traces = group_traces(self._vars, reps, self._traces)
+        self._render_bounds()  # the renaming invalidated the rendered nodes
 
     def _name_results(self, param_ids: set[int], reps: dict[int, int]) -> None:
         for result in self._results:
@@ -360,19 +374,17 @@ class _Renderer:
     def returns(self, members: Iterable[Op]) -> _ir.Node | None:
         named: list[str] = []
         items: list[_TraceItem] = []
-        returned = False
-        for m in members:
-            if not isinstance(m.ret, _SpyObject):
-                continue
-            returned = True
-            if (var := self._vars.get(id(m.ret))) is not None:
+        # a repeated op returns one spy; collect it once
+        rets = _distinct(r for m in members if isinstance(r := m.ret, _SpyObject))
+        for ret in rets:
+            if (var := self._vars.get(id(ret))) is not None:
                 named.append(var)
             else:
-                items.extend(self._traces[id(m.ret)])
+                items.extend(self._traces[id(ret)])
         parts: list[_ir.Node] = [_ir.Name(var) for var in dict.fromkeys(named)]
         if items and (node := self.traces(items)) is not None:
             parts.append(node)
-        if (out := _ir.inter(parts)) is None and returned:
+        if (out := _ir.inter(parts)) is None and rets:
             # an unused result is unconstrained, but omitting it would leave the
             # last argument in the return slot, e.g. the `R` of `(T) -> R`
             out = _ir.Name(_OBJECT)
@@ -452,7 +464,7 @@ class _Renderer:
 
     def traces(self, items: Iterable[_TraceItem]) -> _ir.Node | None:
         # dedup the re-collected return-chain items so they can't blow up (#734)
-        items = list({id(item): item for item in items}.values())
+        items = _distinct(items)
         # an absence marker means the op was optional; an attribute probe keys on its
         # name, so it spares the other reads
         optional = {item.args for item in items if item.attr == _Marker.ABSENT}
@@ -498,7 +510,12 @@ class _Renderer:
             # a PEP 646 typevar tuple takes no bound or default
             return _ir.TypeParam(var, unpack=True)
         rep = self._reps.get(id(spy), id(spy))
-        node = self.traces(self._group_traces.get(rep, ()))
+        if rep in self._bound_nodes:
+            node = self._bound_nodes[rep]
+        else:
+            node = self._bound_nodes[rep] = self.traces(
+                self._group_traces.get(rep, ()),
+            )
         default = defaulted.get(id(spy))
         if negate and default is not None:
             node = _ir.exclude(node, default)
@@ -540,7 +557,7 @@ class _Renderer:
             for name in selected
             if (param := self._param(name, defaults, negate=negate)) is not None
         ]
-        ret_node = self._typer.type_union(self._results) if ret is None else ret
+        ret_node = self._ret_node if ret is None else ret
         type_params, params, ret_node = _collapse_recursive(
             type_params,
             params,
@@ -619,12 +636,13 @@ class _ResultTyper:
     ) -> _ir.Node | None:
         """The union of `values` as literals; `type_union` widens them to types."""
         literals: list[object] = []
-        parts: list[_ir.Node] = []
+        others: list[object] = []
         for value in values:
             if isinstance(value, (int, str, bytes)) and not isinstance(value, _Spy):
                 literals.append(value)
             else:
-                parts.append(self.return_type(value))
+                others.append(value)
+        parts = [self.return_type(value) for value in _distinct(others)]
 
         nodes: list[_ir.Node] = []
         if len(literals) > _LITERAL_LIMIT:
@@ -676,7 +694,7 @@ class _ResultTyper:
 
     def type_union(self, values: Iterable[object]) -> _ir.Node:
         """The deduplicated union of the types of `values`, or `Never` if empty."""
-        parts = dict.fromkeys(map(self.return_type, values))
+        parts = dict.fromkeys(map(self.return_type, _distinct(values)))
         return _ir.union(parts, tuples=True) or _ir.Name(_NEVER)
 
     def value_type(self, value: object) -> _ir.Node:
@@ -963,7 +981,25 @@ def _renderers(
 ) -> list[_Renderer]:
     traces, results = exploration.traces, exploration.results
     reflected = reflect([*exploration.spies.values(), *fn_spies(results)], traces)
+    if reflected is traces:
+        # nothing reflected, so a second renderer would repeat the first verbatim
+        renderer = _Renderer(exploration, params, traces)
+        return [renderer, renderer]
     return [_Renderer(exploration, params, t) for t in (traces, reflected)]
+
+
+def _signatures(
+    renderers: Iterable[_Renderer],
+    selected: Names,
+    defaults: Defaults | None = None,
+    *,
+    negate: bool = False,
+    deprecated: str | None = None,
+) -> list[_ir.Signature]:
+    return [
+        r.signature(selected, defaults, negate=negate, deprecated=deprecated)
+        for r in renderers
+    ]
 
 
 def signatures(
@@ -974,15 +1010,13 @@ def signatures(
     *,
     negate: bool = False,
 ) -> list[_ir.Signature]:
-    return [
-        r.signature(
-            selected,
-            defaults,
-            negate=negate,
-            deprecated=exploration.deprecated,
-        )
-        for r in _renderers(exploration, params)
-    ]
+    return _signatures(
+        _renderers(exploration, params),
+        selected,
+        defaults,
+        negate=negate,
+        deprecated=exploration.deprecated,
+    )
 
 
 def widened_signature(

--- a/optype/infer/_spy.py
+++ b/optype/infer/_spy.py
@@ -601,14 +601,17 @@ for _name in _TRACED_OPS:
 # Free functions, not methods: a method would be an unrecorded hole in the proxy.
 def _class_spy(cls: object) -> _SpyObject | None:
     """The spy whose unique class `cls` is, if any."""
-    if isinstance(cls, type) and issubclass(cls, _SpyObject):
+    # only a spy's unique class carries `__optype_instance__` in its own `__dict__`;
+    # the marker must point back into the mro, or it is a copy on some foreign class.
+    # gate on the exact metaclass: a foreign `__dict__` can be a metaclass property
+    if type(cls) is _SpyType:
         spy = cls.__dict__.get("__optype_instance__")
-        if isinstance(spy, _SpyObject):
+        if isinstance(spy, _SpyObject) and issubclass(cls, type(spy)):
             return spy
     return None
 
 
-def _own_spy(spy: _SpyObject) -> _SpyObject:
+def _own_spy(spy: _SpyObject) -> _SpyObject:  # pyright: ignore[reportUnusedFunction]  # cross-module
     """The first spy of `spy`'s class: `type(spy)()` siblings collapse onto it."""
     owner = _class_spy(type(spy))  # `or spy` would trace a `__bool__` on the owner
     return spy if owner is None else owner
@@ -617,8 +620,8 @@ def _own_spy(spy: _SpyObject) -> _SpyObject:
 def as_spy(value: object) -> _SpyObject | None:
     """The (first-of-its-class) spy itself, or the spy whose class it is, if any."""
     # a `weakref.proxy` forwards `__class__`, so verify its real class is a spy's
-    if isinstance(value, _SpyObject) and _class_spy(type(value)) is not None:
-        return _own_spy(value)
+    if isinstance(value, _SpyObject) and (owner := _class_spy(type(value))) is not None:
+        return owner
     return _class_spy(value)
 
 

--- a/optype/infer/_values.py
+++ b/optype/infer/_values.py
@@ -6,7 +6,7 @@ from inspect import Parameter
 from itertools import chain
 from typing import NamedTuple, NewType, cast
 
-from ._spy import _SpyObject, _Traces
+from ._spy import _Spy, _SpyObject, _Traces
 
 VARIADIC_KINDS = frozenset({Parameter.VAR_POSITIONAL, Parameter.VAR_KEYWORD})
 
@@ -71,6 +71,9 @@ class _RecRef(NamedTuple):
 
 def _children(value: object) -> Iterable[object]:
     """The values directly contained in an explored result."""
+    # a spy is a leaf; its unique class defeats the `Mapping` check's negative cache
+    if isinstance(value, _Spy):
+        return ()
     match value:
         case _Gen():
             out: Iterable[object] = value.yielded
@@ -97,12 +100,15 @@ def _walk(value: object) -> Generator[object]:
         yield from _walk(child)
 
 
-def map_values(value: object, leaf: Callable[[object], object]) -> object:  # noqa: C901
+def map_values(value: object, leaf: Callable[[object], object]) -> object:  # noqa: C901, PLR0912
     """Rebuild `value` with each non-composite leaf replaced via `leaf`.
 
     Recurses into the same shapes as `_children`, but a `tuple` subclass (namedtuple)
     is a leaf, and a `dict` subclass (e.g. `defaultdict`) collapses to a plain `dict`.
     """
+    # a spy is a leaf; see `_children`
+    if isinstance(value, _Spy):
+        return leaf(value)
     match value:
         case _Gen():
             yielded = [map_values(item, leaf) for item in value.yielded]

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -8,6 +8,7 @@ import builtins
 import difflib
 import fractions
 import functools
+import gc
 import io
 import itertools
 import math
@@ -31,7 +32,7 @@ from typing import Any, override
 
 import pytest
 
-from optype.infer import InferError, InferWarning, _color, infer
+from optype.infer import InferError, InferWarning, _color, _gc, infer
 from optype.infer._api import _Gap
 from optype.infer._backends import TERSE
 from optype.infer._ir import (
@@ -56,6 +57,7 @@ from optype.infer._ir import (
 from optype.infer._isolate import isolate
 from optype.infer._numpy import array_function_node
 from optype.infer._render import _collapse_recursive
+from optype.infer._spy import _SpyObject
 from optype.infer._values import GapKind
 
 if sys.version_info >= (3, 13):
@@ -1303,6 +1305,62 @@ def test_rich_return_chains_terminate() -> None:
     lines = matches.splitlines()
     assert lines
     assert all("list[" in line.rsplit("->", 1)[-1] for line in lines)
+
+
+def test_foreign_metaclass_dict_property() -> None:
+    # a foreign metaclass may define `__dict__` as a property that raises
+    def boom(_cls: type) -> Any:
+        raise RuntimeError("never")
+
+    meta = type("Meta", (type,), {"__dict__": property(boom)})
+    evil = meta("Evil", (), {})
+
+    assert infer(lambda x: x + evil) == "[R](x: CanAdd[Meta, R]) -> R"
+
+
+def test_finalizer_ops_discarded(monkeypatch: pytest.MonkeyPatch) -> None:
+    # a collected cycle's `__del__` touching a spy must not leave a phantom op
+    monkeypatch.setattr(_gc, "_PENDING_MAX", 100)
+
+    class Finalized:
+        def __init__(self, x: object) -> None:
+            self.x: object = x
+            self.me: object = self  # only the cyclic collector can free this
+
+        def __del__(self) -> None:
+            # `x` is also explored as a non-spy (e.g. a tuple), so probe first
+            if (phantom := getattr(self.x, "phantom", None)) is not None:
+                phantom()
+
+    def fn(x: object) -> object:
+        garbage = [Finalized(x) for _ in range(100)]
+        del garbage
+        return -x  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]  # ty:ignore[unsupported-operator]
+
+    assert infer(fn) == "[R](x: CanNeg[R]) -> R"
+
+
+def test_drained_spies_freed(monkeypatch: pytest.MonkeyPatch) -> None:
+    # the dead spy graph must not outlive inference, even when sweeps promoted it
+    monkeypatch.setattr(_gc, "_PENDING_MAX", 100)
+    gc.collect()
+
+    def fn(x: object) -> object:
+        garbage: list[list[object]] = [[] for _ in range(200)]
+        for cycle in garbage:
+            cycle.append(cycle)  # only the cyclic collector can free these
+        del garbage
+        return -x  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]  # ty:ignore[unsupported-operator]
+
+    infer(fn)
+    residue = [
+        cls
+        for cls in gc.get_objects()
+        if isinstance(cls, type)
+        and issubclass(cls, _SpyObject)
+        and cls is not _SpyObject
+    ]
+    assert not residue
 
 
 def test_alpha_equal_and_rename() -> None:


### PR DESCRIPTION
- `Fraction.limit_denominator`: 10.1s -> 4.6s
- `secrets.randbelow`: 0.93s -> 0.57s
- `optype.infer` test suite: ~21s -> ~12s

this helps speed up test runs, which currently is the lefthook bottleneck