### PR TITLE
`infer`: legacy CPython `__text_signature__` support

### DIFF
--- a/optype/infer/_api.py
+++ b/optype/infer/_api.py
@@ -14,7 +14,7 @@ from ._ir import Signature
 from ._isolate import isolate
 from ._overloads import dispatch_overloads, resolve_defaults
 from ._render import Names, signatures
-from ._signature import probe_signatures
+from ._signature import parse_text_signature, probe_signatures
 from ._spy import _AnyFunc
 from ._values import GapKind
 
@@ -88,9 +88,9 @@ def _candidate_parameters(func: _AnyFunc) -> list[dict[str, Parameter]]:
     except TypeError as exc:  # not callable
         raise InferError(str(exc)) from exc
     except ValueError as exc:  # callable but no signature (e.g. a C builtin)
-        if (probed := probe_signatures(func)) is None:
-            raise InferError(str(exc)) from exc
-        return probed
+        if candidates := parse_text_signature(func) or probe_signatures(func):
+            return candidates
+        raise InferError(str(exc)) from exc
 
 
 def _infer(

--- a/optype/infer/_explore.py
+++ b/optype/infer/_explore.py
@@ -391,8 +391,9 @@ def _with_next_default(
     results: list[object],
 ) -> list[object]:
     # `next`/`anext` return `default` on an exhaustion branch the spies never reach
-    if func not in _NEXT_BUILTINS or (default := spies.get("_1")) is None:
+    if func not in _NEXT_BUILTINS or len(spies) < 2:
         return results
+    default = list(spies.values())[1]
 
     # `anext` resolves through an awaitable, so the default unions inside the coroutine
     merged: list[object] = []

--- a/optype/infer/_signature.py
+++ b/optype/infer/_signature.py
@@ -1,16 +1,204 @@
-"""Recover a signatureless callable's parameters by trial and error.
+"""Recover a signatureless callable's parameters.
 
-Many C builtins (`type`, `iter`, `min`, ...) have no `inspect.signature`. Calling them
-with spy placeholders at each arity reveals which arities the body accepts: a correct
-arity runs the body (records a trace or returns), while a wrong one raises `TypeError`
-before the body runs.
+Many C builtins have no `inspect.signature`. Those with a legacy `__text_signature__`
+(`str.index`, `dict.pop`, ...) declare optional groups (`sub[, start[, end]]`) or
+`=<unrepresentable>` defaults that `inspect` rejects; `parse_text_signature` recovers
+their parameters directly. The rest (`type`, `iter`, `min`, ...) are probed by trial
+and error: calling them with spy placeholders reveals which arities run the body.
 """
 
+import ast
+import itertools
+import re
+from collections.abc import Iterator
 from inspect import Parameter
+from typing import Final, NamedTuple
 
 from ._spy import _AnyFunc, _Fork, _SpyObject
 
 _MAX_PROBE_ARITY = 8
+
+# at most 2 in practice; 4 caps the expansion at 16 candidates
+_MAX_TOGGLES = 4
+
+_NAME = re.compile(r"[A-Za-z_]\w*")
+_DEFAULT = re.compile(r"[^,()\[\]{}]+")
+
+# a non-literal (`<unrepresentable>`) default; the parameter becomes a toggle
+_UNKNOWN: Final = object()
+
+
+class _ParseError(ValueError):
+    """The text signature does not follow the (legacy) grammar."""
+
+
+class _RawParam(NamedTuple):
+    param: Parameter
+    group: int  # innermost enclosing optionality toggle, -1 when required
+
+
+def _positional_only(raw: list[_RawParam]) -> list[_RawParam]:
+    return [
+        _RawParam(p.param.replace(kind=Parameter.POSITIONAL_ONLY), p.group)
+        if p.param.kind is Parameter.POSITIONAL_OR_KEYWORD
+        else p
+        for p in raw
+    ]
+
+
+def _scan_group(parents: list[int], group: int, *, opens: bool) -> int:
+    if opens:
+        parents.append(group)
+        return len(parents) - 1
+    if group < 0:
+        raise _ParseError
+    return parents[group]
+
+
+def _scan_variadic(text: str, i: int, raw: list[_RawParam], group: int) -> int:
+    var_keyword = text.startswith("**", i)
+    i += 2 if var_keyword else 1
+    if match := _NAME.match(text, i):
+        var = Parameter.VAR_KEYWORD if var_keyword else Parameter.VAR_POSITIONAL
+        raw.append(_RawParam(Parameter(match[0], var), group))
+        return match.end()
+    if var_keyword:
+        raise _ParseError
+    return i
+
+
+def _scan_param(text: str, i: int, *, first: bool) -> tuple[str, object, bool, int]:
+    # `$self`/`$module` may only come first, at the top level
+    if (dollar := text[i] == "$") and not first:
+        raise _ParseError
+    i += dollar
+    if (match := _NAME.match(text, i)) is None:
+        raise _ParseError
+    i = match.end()
+    default: object = Parameter.empty
+    if text.startswith("=", i):
+        # defaults are literals, dotted names, or `<unrepresentable>`, never bracketed
+        if (expr := _DEFAULT.match(text, i + 1)) is None:
+            raise _ParseError
+        i = expr.end()
+        try:
+            default = ast.literal_eval(expr[0])
+        except (SyntaxError, ValueError, TypeError):
+            default = _UNKNOWN
+    return match[0], default, dollar, i
+
+
+def _scan(text: str) -> tuple[list[_RawParam], list[int], bool]:
+    """The raw parameters, the group-parent forest, and whether `$self` was seen.
+
+    Raises:
+        _ParseError: If the text signature does not follow the (legacy) grammar.
+    """
+    text = text.strip()
+    if not text.startswith("("):
+        raise _ParseError
+
+    raw: list[_RawParam] = []
+    parents: list[int] = []  # each group's parent group, -1 at the top level
+    group = -1
+    kind = Parameter.POSITIONAL_OR_KEYWORD
+    dollar = closed = False
+    i = 1
+    while i < len(text) and not closed:
+        c = text[i]
+        if c in " ,":
+            i += 1
+        elif c == ")":
+            closed = True
+        elif c in "[]":
+            group = _scan_group(parents, group, opens=c == "[")
+            i += 1
+        elif c == "/":
+            raw = _positional_only(raw)
+            i += 1
+        elif c == "*":
+            i = _scan_variadic(text, i, raw, group)
+            kind = Parameter.KEYWORD_ONLY
+        else:
+            first = not raw and group == -1
+            name, default, seen, i = _scan_param(text, i, first=first)
+            param_kind = Parameter.POSITIONAL_ONLY if seen else kind
+            raw.append(_RawParam(Parameter(name, param_kind, default=default), group))
+            dollar = dollar or seen
+
+    if not closed or group != -1:
+        raise _ParseError
+    return raw, parents, dollar
+
+
+def _combinations(parents: list[int]) -> Iterator[tuple[bool, ...]]:
+    # the valid toggle activations: a nested toggle requires its parent
+    for active in itertools.product((False, True), repeat=len(parents)):
+        if all(
+            parents[g] < 0 or active[parents[g]] for g, on in enumerate(active) if on
+        ):
+            yield active
+
+
+def _candidate(
+    raw: list[_RawParam],
+    active: tuple[bool, ...],
+    groups: int,
+) -> dict[str, Parameter] | None:
+    """The parameters of one toggle activation, or `None` if it cannot be called."""
+    params: dict[str, Parameter] = {}
+    gap = False
+    for param, group in raw:
+        if group >= 0 and not active[group]:
+            # an omitted default forces later parameters to keyword (as in the
+            # explorer's `_placeholders`); a dropped group shifts the arity instead
+            gap = gap or (group >= groups and param.kind is not Parameter.KEYWORD_ONLY)
+            continue
+        if gap:
+            match param.kind:
+                case Parameter.POSITIONAL_OR_KEYWORD:
+                    param = param.replace(kind=Parameter.KEYWORD_ONLY)  # noqa: PLW2901
+                case Parameter.POSITIONAL_ONLY | Parameter.VAR_POSITIONAL:
+                    return None
+                case _:
+                    pass
+        params[param.name] = param
+    return params
+
+
+def parse_text_signature(func: _AnyFunc) -> list[dict[str, Parameter]] | None:
+    """Candidate parameter mappings parsed from `__text_signature__`, or `None`.
+
+    Optional groups and unrepresentable defaults expand into one candidate per valid
+    combination, mirroring `probe_signatures`' per-arity candidates.
+    """
+    text: object = getattr(func, "__text_signature__", None)
+    if not isinstance(text, str):
+        return None
+    try:
+        raw, parents, dollar = _scan(text)
+    except _ParseError:
+        return None
+
+    if dollar and getattr(func, "__self__", None) is not None:
+        raw = raw[1:]  # the bound argument is not part of the call signature
+    if len({p.param.name for p in raw}) != len(raw):
+        return None
+
+    groups = len(parents)
+    toggles = list(parents)
+    for index, p in enumerate(raw):
+        if p.param.default is _UNKNOWN:
+            toggles.append(p.group)
+            raw[index] = _RawParam(
+                p.param.replace(default=Parameter.empty),
+                len(toggles) - 1,
+            )
+    if len(toggles) > _MAX_TOGGLES:
+        return None
+
+    combos = sorted(_combinations(toggles), key=sum)
+    return [c for on in combos if (c := _candidate(raw, on, groups)) is not None]
 
 
 def _accepts(func: _AnyFunc, n: int) -> bool:

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -25,9 +25,9 @@ import time
 import warnings
 import weakref
 from collections.abc import Callable
-from inspect import currentframe, signature
+from inspect import Signature as PySignature, currentframe, signature
 from pathlib import Path
-from types import MappingProxyType
+from types import MappingProxyType, SimpleNamespace
 from typing import Any, override
 
 import pytest
@@ -57,6 +57,7 @@ from optype.infer._ir import (
 from optype.infer._isolate import isolate
 from optype.infer._numpy import array_function_node
 from optype.infer._render import _collapse_recursive
+from optype.infer._signature import parse_text_signature
 from optype.infer._spy import _SpyObject
 from optype.infer._values import GapKind
 
@@ -2691,6 +2692,95 @@ def test_builtin_variadic() -> None:
     assert infer(min) == "[T, U: CanLt[T | U, CanBool]](T, *args: U) -> U | T"
 
 
+def _text_candidates(text: str, *, bound: bool = False) -> list[str] | None:
+    func: Any = SimpleNamespace(__text_signature__=text)
+    if bound:
+        func.__self__ = object()
+    parsed = parse_text_signature(func)
+    if parsed is None:
+        return None
+    return [str(PySignature(list(c.values()))) for c in parsed]
+
+
+def test_text_signature_groups() -> None:
+    # the legacy find-family grammar: each optional group level is a candidate (#646)
+    assert _text_candidates("($self, sub[, start[, end]], /)") == [
+        "(self, sub, /)",
+        "(self, sub, start, /)",
+        "(self, sub, start, end, /)",
+    ]
+
+
+def test_text_signature_bound() -> None:
+    # a bound callable's `$` parameter is not part of the call signature
+    assert _text_candidates(
+        "($module, aiterator, default=<unrepresentable>, /)",
+        bound=True,
+    ) == ["(aiterator, /)", "(aiterator, default, /)"]
+
+
+def test_text_signature_omitted_default() -> None:
+    # omitting an unrepresentable default forces later parameters to keyword-only
+    assert _text_candidates("($self, /, sep=<unrepresentable>, bytes_per_sep=1)") == [
+        "(self, /, *, bytes_per_sep=1)",
+        "(self, /, sep, bytes_per_sep=1)",
+    ]
+
+
+def test_text_signature_leading_group() -> None:
+    # a leading (curses-style) group shifts the positional arity instead
+    assert _text_candidates("([y, x,] ch[, attr])") == [
+        "(ch)",
+        "(ch, attr)",
+        "(y, x, ch)",
+        "(y, x, ch, attr)",
+    ]
+
+
+def test_text_signature_kinds() -> None:
+    # literal defaults, `*args`, keyword-only, and `**kwargs` parse as-is
+    assert _text_candidates("($self, /, x=0, *args, key, **kwargs)") == [
+        "(self, /, x=0, *args, key, **kwargs)",
+    ]
+
+
+def test_text_signature_invalid() -> None:
+    for text in ("no parens", "(unclosed", "(a[, b)", "(a, a)", "(a, $b)", "(=1)"):
+        assert _text_candidates(text) is None, text
+
+
+def _skip_if_signature(func: Any) -> None:
+    try:
+        signature(func)
+    except ValueError:
+        pass
+    else:
+        pytest.skip(
+            f"this build exposes an `inspect.signature` for `{func.__qualname__}`",
+        )
+
+
+def test_builtin_dict_pop() -> None:
+    _skip_if_signature(dict.pop)
+    # the 2-parameter form never completes (`KeyError` on an empty `dict`)
+    assert infer(dict.pop) == "[T](dict, object, T) -> T"
+
+
+def test_builtin_bytes_hex() -> None:
+    _skip_if_signature(bytes.hex)
+    # the str-typed `sep` rejects placeholders; the sep-less candidate renders
+    assert infer(bytes.hex) == "(bytes, bytes_per_sep: CanIndex = 1) -> str"
+
+
+def test_builtin_str_index() -> None:
+    _skip_if_signature(str.index)
+    if getattr(str.index, "__text_signature__", None) is None:
+        pytest.skip("this build has no `__text_signature__` for `str.index`")
+    # the text signature parses (#646), but the str-typed `sub` rejects placeholders
+    with pytest.raises(InferError, match="must be str"):
+        infer(str.index)
+
+
 def test_functools_reduce() -> None:
     # the iterable must yield a pair so `reduce` actually calls the function (#723)
     if sys.version_info >= (3, 15):
@@ -2700,6 +2790,12 @@ def test_functools_reduce() -> None:
             " initial: _initial_missing = _initial_missing) -> R\n"
             "[T: ~_initial_missing, U, R]"
             "((T | R, U) -> R, CanIter[CanNext[U]], initial: T) -> R"
+        )
+    elif getattr(functools.reduce, "__text_signature__", None) is not None:
+        # Python 3.14: the text signature names `initial`, which the probe could not
+        assert infer(functools.reduce) == (
+            "[T, R]((T, T) -> R, CanIter[CanNext[T]]) -> R\n"
+            "[T, U, R]((T | R, U) -> R, CanIter[CanNext[U]], initial: T) -> R"
         )
     else:
         assert infer(functools.reduce) == (


### PR DESCRIPTION
before:

```console
$ optype infer bytes.hex
InferError: <method 'hex' of 'bytes' objects> builtin has invalid signature (ValueError: <method 'hex' of 'bytes' objects> builtin has invalid signature)

$ optype infer dict.pop
InferError: <method 'pop' of 'dict' objects> builtin has invalid signature (ValueError: <method 'pop' of 'dict' objects> builtin has invalid signature)
```

after:

```console
$ optype infer bytes.hex
(bytes, bytes_per_sep: CanIndex = 1) -> str

$ optype infer dict.pop
[T](dict, object, T) -> T
```

closes #646