### PR TITLE
`infer`: fix enum and `*args` rendering

### DIFF
--- a/optype/infer/_backends/_base.py
+++ b/optype/infer/_backends/_base.py
@@ -4,7 +4,9 @@ A `Backend` turns the structured `Signature`s that `_render` builds into text: t
 default `TERSE` form (`[R](x: CanAdd[Literal[1], R]) -> R`), or valid `.pyi` Python.
 """
 
-from collections.abc import Sequence
+import enum
+import sys
+from collections.abc import Callable, Sequence
 from typing import Protocol
 
 # `from optype.infer import _ir` would re-enter the package, which imports this module
@@ -15,8 +17,47 @@ class Backend(Protocol):
     def render(self, sigs: Sequence[_ir.Signature], /) -> str: ...
 
 
-def default_text(value: object) -> str:
+def _enum_member_path(value: enum.Enum) -> tuple[str, str, str] | None:
+    """The `(module, class, member)` names of an importable enum member, or `None`.
+
+    A composite flag has no member name, and a local or nested class is not
+    importable.
+    """
+    if not (name := value.name or "").isidentifier():
+        return None
+
+    cls = type(value)
+    if getattr(sys.modules.get(cls.__module__), cls.__name__, None) is not cls:
+        return None
+
+    return cls.__module__, cls.__name__, name
+
+
+def value_text(value: object, rec: Callable[[str], None] | None = None) -> str:
+    """A single value's source text: an enum member's path, else its `repr`.
+
+    A `rec` records the enum class path to import and selects the qualified form;
+    an inexpressible enum member falls back to its data value.
+    """
+    if not isinstance(value, enum.Enum):
+        return repr(value)
+
+    if (found := _enum_member_path(value)) is None:
+        return repr(value.value)
+
+    module, cls, member = found
+    if rec is None:
+        return f"{cls}.{member}"
+
+    rec(path := f"{module}.{cls}")
+    return f"{path}.{member}"
+
+
+def default_text(value: object, rec: Callable[[str], None] | None = None) -> str:
     """The default's source text, in stub style: a literal `repr`, else `...`."""
+    if isinstance(value, enum.Enum):
+        return value_text(value, rec) if _enum_member_path(value) else "..."
+
     simple = (
         value is None
         or _ir.is_sentinel(value)  # a sentinel's repr is its declared name

--- a/optype/infer/_backends/_compat/_print.py
+++ b/optype/infer/_backends/_compat/_print.py
@@ -9,13 +9,13 @@ import builtins
 import types
 import typing
 from collections.abc import Sequence
-from typing import cast
+from typing import Literal, cast
 
 # `from optype.infer import _ir` would re-enter the package, which imports this module
 import optype.infer._ir as _ir  # noqa: PLR0402
 from ._model import _Alias, _Attr, _Func, _Member, _Method, _Protocol, _value
 from optype._core import _can, _has, _just
-from optype.infer._backends._base import default_text
+from optype.infer._backends._base import default_text, value_text
 
 __all__ = (
     "_OPTYPE",
@@ -42,6 +42,8 @@ _ABC = frozenset({
 _TYPING = frozenset({"Any", "ClassVar", "Literal", "Never", "Protocol", "overload"})
 _TYPING_EXT = frozenset({"TypeForm", "deprecated"})
 _OPTYPE = frozenset(_can.__all__) | frozenset(_has.__all__) | frozenset(_just.__all__)
+
+type _Prefix = Literal["", "*"]
 
 _numpy_names: frozenset[str] | None = None
 
@@ -94,7 +96,7 @@ def _type(node: _ir.Node, used: set[str] | None = None) -> str:  # noqa: C901, P
     match node:
         case _ir.Lit(values):
             rec("Literal")
-            return f"Literal[{', '.join(map(repr, values))}]"
+            return f"Literal[{', '.join(value_text(v, rec) for v in values)}]"
         case _ir.Type(cls):
             rec(name := _ir.type_name(cls))
             return name
@@ -164,7 +166,7 @@ def _params(params: Sequence[_ir.Param], used: set[str]) -> str:
         else:
             decl = f"{p.prefix}{p.name}: {_type(p.node, used)}"
         if p.default is not None and show[i]:
-            decl += f" = {default_text(p.default[0])}"
+            decl += f" = {default_text(p.default[0], used.add)}"
         items.append((decl, p.nameless))
     return _join_params(items)
 
@@ -186,21 +188,38 @@ def _default_mask(params: Sequence[_ir.Param]) -> list[bool]:
     return show
 
 
+def _prefixed_type(value: _ir.Node, used: set[str] | None) -> tuple[_Prefix, str]:
+    """A parameter's `(prefix, annotation)`; an unpack becomes a `*` parameter."""
+    match value:
+        case _ir.Unpack(_ir.App("tuple", (elem, _ir.Dots()))):
+            prefix, value = "*", _value(elem)
+        case _ir.Unpack():
+            prefix = "*"
+        case _:
+            prefix = ""
+    return prefix, _type(value, used)  # type:ignore[return-value]  # mypy fail
+
+
 def _call_params(
     params: Sequence[_ir.Node | _ir.Arg],
     used: set[str] | None = None,
 ) -> str:
+    rec = _noop if used is None else used.add
     auto = 0
     items: list[tuple[str, bool]] = []
     for p in params:
         if isinstance(p, _ir.Arg) and p.key:
             decl = f"{p.key}: {_type(p.value, used)}"
             if p.default is not None:
-                decl += f" = {default_text(p.default[0])}"
+                decl += f" = {default_text(p.default[0], rec)}"
             items.append((decl, False))
-        else:
-            items.append((f"_{auto}: {_type(_value(p), used)}", True))
-            auto += 1
+            continue
+
+        # a `*` parameter is not positional-only, so the `/` lands before it
+        prefix, ann = _prefixed_type(_value(p), used)
+        items.append((f"{prefix}_{auto}: {ann}", not prefix))
+        auto += 1
+
     return _join_params(items)
 
 

--- a/optype/infer/_backends/_terse.py
+++ b/optype/infer/_backends/_terse.py
@@ -5,7 +5,7 @@ from typing import Final, assert_never, final
 
 # `from optype.infer import _ir` would re-enter the package, which imports this module
 import optype.infer._ir as _ir  # noqa: PLR0402
-from ._base import Backend, default_text
+from ._base import Backend, default_text, value_text
 
 _NOT = "~"  # the type complement prefix
 _OR = "|"  # the union separator
@@ -34,7 +34,7 @@ class TerseBackend:
         """Format a type expression, parenthesized where precedence requires."""
         match node:
             case _ir.Lit(values):
-                out = f"Literal[{', '.join(map(repr, values))}]"
+                out = f"Literal[{', '.join(map(value_text, values))}]"
             case _ir.Type(cls):
                 out = _ir.type_name(cls)
             case _ir.Name(name):

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -6,9 +6,11 @@
 import ast
 import builtins
 import difflib
+import enum
 import fractions
 import functools
 import gc
+import http
 import io
 import itertools
 import math
@@ -1433,6 +1435,32 @@ def test_wide_literal_union_capped() -> None:
     assert all(lit.count(",") < 8 for lit in re.findall(r"Literal\[([^\]]*)\]", out))
 
 
+def test_enum_literal() -> None:
+    # #776: an importable enum member renders as its member path, not its repr
+    status = http.HTTPStatus.NOT_FOUND
+    assert infer(lambda x: x == status) == (
+        "[R](x: CanEq[Literal[HTTPStatus.NOT_FOUND], R]) -> R"
+    )
+
+    def d(x: http.HTTPStatus = status) -> http.HTTPStatus:
+        return x
+
+    assert infer(d) == (
+        "[T = Literal[HTTPStatus.NOT_FOUND]](x: T = HTTPStatus.NOT_FOUND) -> T"
+    )
+
+
+def test_enum_literal_inexpressible() -> None:
+    # #776: a composite flag and a local enum fall back to their plain data value
+    class Color(enum.IntEnum):
+        RED = 1
+
+    assert infer(lambda x: x == Color.RED) == "[R](x: CanEq[Literal[1], R]) -> R"
+
+    flags = re.IGNORECASE | re.MULTILINE
+    assert infer(lambda x: x != flags) == "[R](x: CanNe[Literal[10], R]) -> R"
+
+
 def test_method_descriptor_fixed_defaults() -> None:
     # a defaulted parameter whose spy the function rejects passes its default
     # instead, while the accepting parameters stay structural
@@ -2068,6 +2096,45 @@ COMPAT_CASES: list[tuple[str, str]] = [
     ),
     ("lambda *args: args", "def f[*Ts](*args: *Ts) -> tuple[*Ts]: ..."),
     ("str.upper", "def f(_0: str, /) -> str: ..."),
+    (
+        # a *args run forwarded into a method renders as a star parameter (#776)
+        "lambda x, f, *args: x.m(f, *args)",
+        (
+            "from typing import Protocol\n\n"
+            "class HasM[T, U, V](Protocol):\n"
+            "    def m(self, _0: T, /, *_1: U) -> V: ...\n\n"
+            "def f[T, U, R](x: HasM[T, U, R], f: T, *args: U) -> R: ..."
+        ),
+    ),
+    (
+        # a leading star parameter takes no `/`; a keyword after it is keyword-only
+        "lambda f, *args: f(*args, k=1)",
+        (
+            "from typing import Literal, Protocol\n\n"
+            "class CanCallP[T, U](Protocol):\n"
+            "    def __call__(self, *_0: T, k: Literal[1]) -> U: ...\n\n"
+            "def f[T, R](f: CanCallP[T, R], *args: T) -> R: ..."
+        ),
+    ),
+    (
+        # an enum member renders as its imported member path, not its repr (#776)
+        "import http\nlambda x: x == http.HTTPStatus.NOT_FOUND",
+        (
+            "import http\n"
+            "from typing import Literal\n"
+            "from optype import CanEq\n\n"
+            "def f[R](x: CanEq[Literal[http.HTTPStatus.NOT_FOUND], R]) -> R: ..."
+        ),
+    ),
+    (
+        "import http\ndef f(x=http.HTTPStatus.NOT_FOUND): return x",
+        (
+            "import http\n"
+            "from typing import Literal\n\n"
+            "def f[T = Literal[http.HTTPStatus.NOT_FOUND]]"
+            "(x: T = http.HTTPStatus.NOT_FOUND) -> T: ..."
+        ),
+    ),
 ]
 
 


### PR DESCRIPTION
```console
$ optype infer --format=compat "from asyncio.selector_events import BaseSelectorEventLoop as BSEL; BSEL.add_reader"
```

before:

```pyi
from typing import Protocol

class Has_ensure_fd_no_transport[T](Protocol):
    def _ensure_fd_no_transport(self, _0: T, /) -> object: ...
class Has_add_reader[T, U, V](Protocol):
    def _add_reader(self, _0: T, _1: U, _2: *tuple[V, ...], /) -> object: ...
class Has_ensure_fd_no_transport_add_reader[T, U, V](Has_ensure_fd_no_transport[T], Has_add_reader[T, U, V], Protocol): ...

def f[T, U, V](self: Has_ensure_fd_no_transport_add_reader[T, U, V], fd: T, callback: U, *args: V) -> None: ...
```

after:

```pyi
from typing import Protocol

class Has_ensure_fd_no_transport[T](Protocol):
    def _ensure_fd_no_transport(self, _0: T, /) -> object: ...
class Has_add_reader[T, U, V](Protocol):
    def _add_reader(self, _0: T, _1: U, /, *_2: V) -> object: ...
class Has_ensure_fd_no_transport_add_reader[T, U, V](Has_ensure_fd_no_transport[T], Has_add_reader[T, U, V], Protocol): ...

def f[T, U, V](self: Has_ensure_fd_no_transport_add_reader[T, U, V], fd: T, callback: U, *args: V) -> None: ...
```

closes #776