### PR TITLE
`infer`: fix `collections.Counter` arity

### DIFF
--- a/optype/infer/_render.py
+++ b/optype/infer/_render.py
@@ -791,10 +791,18 @@ class _ResultTyper:
             case Mapping():
                 mapping = cast("Mapping[object, object]", result)
                 key = self.value_union(mapping, tuples=True) or _ir.Name(_NEVER)
-                val = self.value_union(mapping.values(), tuples=True) or _ir.Name(
-                    _NEVER,
-                )
-                return _ir.App(_ir.type_name(cls), (key, val))
+                args: tuple[_ir.Node, ...]
+                if isinstance(result, Counter):
+                    args = (key,)
+                else:
+                    args = (
+                        key,
+                        (
+                            self.value_union(mapping.values(), tuples=True)
+                            or _ir.Name(_NEVER)
+                        ),
+                    )
+                return _ir.App(_ir.type_name(cls), args)
             case list() | set() | frozenset():
                 inner = self.value_union(
                     cast("Collection[object]", result),

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -27,6 +27,7 @@ import sys
 import time
 import warnings
 import weakref
+from collections import Counter
 from collections.abc import Callable
 from inspect import Signature as PySignature, currentframe, signature
 from pathlib import Path
@@ -1793,6 +1794,13 @@ def test_infer_types_aliases() -> None:
     )
 
 
+def test_infer_counter() -> None:
+    assert infer(lambda: Counter("ab")) == (
+        "() -> collections.Counter[Literal['a', 'b']]"
+    )
+    assert infer(lambda: Counter()) == "() -> collections.Counter[Never]"
+
+
 class _MyGeneric[T]: ...  # module-level, so its name resolves
 
 
@@ -2164,6 +2172,14 @@ COMPAT_CASES: list[tuple[str, str]] = [
             "import collections\n"
             "from typing import Literal\n\n"
             "def f() -> collections.OrderedDict[Literal['a'], Literal[1]]: ..."
+        ),
+    ),
+    (
+        "import collections\nlambda: collections.Counter(a=1)",
+        (
+            "import collections\n"
+            "from typing import Literal\n\n"
+            "def f() -> collections.Counter[Literal['a']]: ..."
         ),
     ),
 ]


### PR DESCRIPTION
before:

```console
$ optype infer "import collections; collections.Counter"
[T](None = None, **kwds: T) -> collections.Counter[str, T]
[R: CanHash, R2](CanIter[CanNext[R]] & ~None, **kwds: CanAdd[Literal[0], R2]) -> collections.Counter[R | str, Literal[2] | R2]
```

after:

```console
$ optype infer "import collections; collections.Counter"
[T](None = None, **kwds: T) -> collections.Counter[str]
[R: CanHash, R2](CanIter[CanNext[R]] & ~None, **kwds: CanAdd[Literal[0], R2]) -> collections.Counter[R | str]
```

fixes #782