### PR TITLE
`infer`: isolate all funciton calls and avoid phantom calls to spy `__repr__`

### DIFF
--- a/optype/infer/_api.py
+++ b/optype/infer/_api.py
@@ -3,7 +3,7 @@
 import warnings
 from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
-from inspect import Parameter, isfunction, ismethod, signature
+from inspect import Parameter, signature
 
 import optype.infer._numpy as _numpy
 from ._backends import BACKENDS, BackendName
@@ -168,5 +168,5 @@ def infer(
     def render() -> str:
         return _infer_render(func, params, strict=strict, backend=backend)
 
-    # functions/methods only raise; isolate the rest, which can fault in C (#738)
-    return render() if isfunction(func) or ismethod(func) else isolate(render)
+    # even a pure-python function can reach native code that can segfault (#738, #763)
+    return isolate(render)

--- a/optype/infer/_spy.py
+++ b/optype/infer/_spy.py
@@ -227,14 +227,21 @@ class _SpyBytes(bytes, _Spy):
     __slots__ = ()
 
 
-def _brief(value: object, /) -> str:
-    # never call a spy's own dunders while formatting it
+def _brief(value: Any, /) -> str:
+    # no arbitrary `repr` here: a container's repr reaches the dunders of its
+    # elements, recording phantom ops on any spy inside (#763)
     if isinstance(value, _Spy):
         return "spy"
-    try:
+
+    cls = type(value)  # pyright: ignore[reportUnknownVariableType]
+    if cls in {tuple, list}:
+        left, right = "()" if cls is tuple else "[]"
+        text = left + ", ".join(map(_brief, value)) + right
+    elif value is None or cls in {bool, int, float, complex, bytes, str}:
         text = repr(value)
-    except Exception:  # noqa: BLE001
-        return type(value).__name__
+    else:
+        text = cls.__name__
+
     return text if len(text) <= 32 else text[:31] + "..."
 
 

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -37,7 +37,7 @@ from typing import Any, override
 import pytest
 
 from optype.infer import InferError, InferWarning, _color, _gc, infer
-from optype.infer._api import _Gap
+from optype.infer._api import _Gap, _infer_render
 from optype.infer._backends import TERSE
 from optype.infer._ir import (
     App,
@@ -1289,6 +1289,17 @@ def test_infer_isolates_native_crash() -> None:
 
 
 @fork_only
+def test_infer_isolates_function_native_crash() -> None:
+    # gh-763: cython 3 compiles methods to real functions, so a `FunctionType`
+    # can fault in native code just like any other callable
+    def crash(x: object) -> None:  # noqa: ARG001
+        signal.raise_signal(signal.SIGSEGV)
+
+    with pytest.raises(InferError):
+        infer(crash)
+
+
+@fork_only
 def test_infer_crash_reports_spy_state() -> None:
     # the spy state note names the last operation before a native crash (#738)
     class _Crash:
@@ -1359,7 +1370,8 @@ def test_drained_spies_freed(monkeypatch: pytest.MonkeyPatch) -> None:
         del garbage
         return -x  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]  # ty:ignore[unsupported-operator]
 
-    infer(fn)
+    # the unisolated path: `infer` forks, which would hide host-side residue
+    _infer_render(fn, (), strict=False, backend="terse")
     residue = [
         cls
         for cls in gc.get_objects()


### PR DESCRIPTION
fixes #763