### PR TITLE
`infer`: fix `NameError` when inspecting PEP 649 signatures

### DIFF
--- a/optype/infer/_api.py
+++ b/optype/infer/_api.py
@@ -3,7 +3,7 @@
 import warnings
 from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
-from inspect import Parameter, signature
+from inspect import Parameter
 
 import optype.infer._numpy as _numpy
 from ._backends import BACKENDS, BackendName
@@ -14,7 +14,7 @@ from ._ir import Signature
 from ._isolate import isolate
 from ._overloads import dispatch_overloads, resolve_defaults
 from ._render import Names, signatures
-from ._signature import parse_text_signature, probe_signatures
+from ._signature import parse_text_signature, probe_signatures, signature
 from ._spy import _AnyFunc
 from ._values import GapKind
 

--- a/optype/infer/_explore.py
+++ b/optype/infer/_explore.py
@@ -20,7 +20,7 @@ from collections.abc import (
 )
 from contextlib import suppress
 from contextvars import Context, ContextVar
-from inspect import Parameter, isasyncgen, iscoroutine, isgenerator, signature
+from inspect import Parameter, isasyncgen, iscoroutine, isgenerator
 from types import (
     BuiltinFunctionType,
     FunctionType,
@@ -32,6 +32,7 @@ from typing import Any, cast
 
 from ._errors import InferError
 from ._gc import drain_gc
+from ._signature import signature
 from ._spy import (
     _AbsentError,
     _AnyFunc,

--- a/optype/infer/_numpy.py
+++ b/optype/infer/_numpy.py
@@ -1,11 +1,12 @@
 """NumPy-specific inference: NEP 13 ufuncs and NEP 18 `__array_function__`."""
 
 from collections.abc import Iterable, Sequence
-from inspect import Parameter, signature
+from inspect import Parameter
 from typing import cast
 
 # `from . import` would import the package itself, which imports this module
 import optype.infer._ir as _ir
+from ._signature import signature
 from ._spy import _AnyFunc
 from ._values import VARIADIC_KINDS
 

--- a/optype/infer/_signature.py
+++ b/optype/infer/_signature.py
@@ -10,11 +10,27 @@ and error: calling them with spy placeholders reveals which arities run the body
 import ast
 import itertools
 import re
+import sys
 from collections.abc import Iterator
 from inspect import Parameter
 from typing import Final, NamedTuple
 
 from ._spy import _AnyFunc, _Fork, _SpyObject
+
+if sys.version_info >= (3, 14):
+    import functools
+    import inspect
+
+    from annotationlib import Format
+
+    # PEP 649 annotations may not resolve in their own module, and `infer` only
+    # reads the parameter names, kinds, and defaults anyway
+    signature = functools.partial(
+        inspect.signature,
+        annotation_format=Format.FORWARDREF,
+    )
+else:
+    from inspect import signature as signature  # ruff:ignore[useless-import-alias]
 
 _MAX_PROBE_ARITY = 8
 

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -2857,6 +2857,14 @@ def test_not_callable() -> None:
         infer(not_callable)
 
 
+@pytest.mark.skipif(sys.version_info < (3, 14), reason="requires PEP 649 annotations")
+def test_unresolvable_deferred_annotations() -> None:
+    # deferred annotations that don't resolve must not fail the signature (#768)
+    ns: dict[str, Any] = {}
+    exec("def f(x: Undefined = 42) -> Undefined: return x", ns)  # noqa: S102
+    assert infer(ns["f"]) == "[T = Literal[42]](x: T = 42) -> T"
+
+
 def test_iter() -> None:
     # the callable_iterator enrichment, independent of `iter`'s own docstring
     assert infer(lambda f, s: iter(f, s)) == "[R](f: () -> R, s: object) -> Iterator[R]"


### PR DESCRIPTION
before:

```console
$ optype infer "from json.tool import get_theme; get_theme"
Traceback (most recent call last):
[...]
NameError: name 'IO' is not defined
```

after:

```console
$ optype infer "from json.tool import get_theme; get_theme"
(tty_file: Has['fileno', () -> +CanIndex] = None, force_color: CanBool = False, force_no_color: CanBool = False) -> _colorize.Theme
```

fixes #768