### PR TITLE
`infer`: fix internal `_Spy` signature render leaks

### DIFF
--- a/optype/infer/_explore.py
+++ b/optype/infer/_explore.py
@@ -36,6 +36,7 @@ from ._signature import signature
 from ._spy import (
     _AbsentError,
     _AnyFunc,
+    _DynamicNameError,
     _Fork,
     _fork,
     _journal,
@@ -433,6 +434,19 @@ def _run[T](
     return value, message
 
 
+def _scrub_deprecated(message: str | None, func: _AnyFunc) -> str | None:
+    """Replace a leaked spy identity in `message` with the target's owner (#777)."""
+    name = _SpyObject.__name__
+    if message is None or name not in message:
+        return message
+
+    qualname: str = getattr(func, "__qualname__", "")
+    owner = qualname.rpartition(".")[0]
+    module: str = getattr(func, "__module__", None) or ""
+    full = f"{module}.{owner}" if module and owner else owner
+    return message.replace(f"{_SpyObject.__module__}.{name}", full).replace(name, owner)
+
+
 def _drain() -> None:
     # the drain runs the target's finalizers; discard any spy ops they record,
     # or a rolled-back branch's `__del__` pollutes the trace
@@ -473,7 +487,7 @@ def _explore[T](  # noqa: C901
         try:
             result, message = _run(func, args, kwds)
             results.append(result)
-            deprecated = deprecated or message
+            deprecated = deprecated or _scrub_deprecated(message, func)
         except _Fork:
             if len(plan) < _FORK_LIMIT:
                 stack.extend(([*plan, False], [*plan, True]))
@@ -503,7 +517,12 @@ def _explore[T](  # noqa: C901
         if value_exc is not None:
             raise value_exc
 
-        raise InferError("the function never ran to completion") from last_exc
+        msg = (
+            str(last_exc)
+            if isinstance(last_exc, _DynamicNameError)
+            else "the function never ran to completion"
+        )
+        raise InferError(msg) from last_exc
 
     hits = (dropped, GapKind.BRANCH_BUDGET), (bool(stack), GapKind.RUN_BUDGET)
     gaps = frozenset(kind for hit, kind in hits if hit)

--- a/optype/infer/_protocols.py
+++ b/optype/infer/_protocols.py
@@ -5,7 +5,7 @@ from typing import NamedTuple
 # `from . import` would import the package itself, which imports this module
 import optype.infer._numpy as _numpy
 from ._errors import InferError
-from ._spy import _Args, _Kwargs, _Marker, _Spy, _TraceItem
+from ._spy import _Args, _dynamic_name, _Kwargs, _Marker, _TraceItem
 from optype._core import _can, _has
 from optype.inspect import get_protocol_members
 
@@ -73,7 +73,7 @@ class Op(NamedTuple):
 def resolve(trace: _TraceItem) -> Op:
     if trace.attr in DUNDER_ATTR or trace.attr in DUNDER_CLASS_ATTR:
         name = trace.args[0]
-        if not isinstance(name, str) or isinstance(name, _Spy):
+        if not isinstance(name, str) or _dynamic_name(name):
             msg = "no protocol for a dynamic attribute name"
             raise InferError(msg)
 

--- a/optype/infer/_render.py
+++ b/optype/infer/_render.py
@@ -32,6 +32,7 @@ from ._spy import (
     _TraceItem,
     _Traces,
     as_spy,
+    despy_class,
 )
 from ._values import (
     COROUTINE,
@@ -583,7 +584,7 @@ class _Renderer:
         prefix = self._prefix[name]
         if name in self._fixed and name not in self._optional:
             # a fixed parameter without a default is a method descriptor's `self`
-            node = _ir.Type(type(self._fixed[name]))
+            node = _ir.Type(despy_class(type(self._fixed[name])))
             return _ir.Param(name, node, prefix, nameless)
         if (spy := self._spies.get(name)) is None:
             # an omitted parameter binds its default, so passing it behaves the same
@@ -721,7 +722,7 @@ class _ResultTyper:
         if name in fn.defaults:
             # a pinned default renders as its value, like the outer parameters do
             return self.value_type(value)
-        return _ir.Type(type(value))  # a method descriptor's pinned `self`
+        return _ir.Type(despy_class(type(value)))  # a method descriptor's pinned `self`
 
     def _class_of(self, cls: type[Any]) -> _ir.Node | None:
         """The type of `cls`'s instances, if it is expressible."""

--- a/optype/infer/_spy.py
+++ b/optype/infer/_spy.py
@@ -26,11 +26,31 @@ def _internal(attr: str) -> bool:
     return attr.startswith("__optype")
 
 
+def _dynamic_name(attr: str) -> bool:
+    """Whether `attr` is spy-derived, e.g. built from a spy's type name (#777)."""
+    if isinstance(attr, _Spy):
+        return True
+    low = attr.lower()
+    return any(name in low for name in _SPY_NAMES)
+
+
 class _Fork(BaseException): ...
 
 
 class _AbsentError(TypeError):
     """A simulated missing dunder; subclasses `TypeError` so probes suppress it."""
+
+
+class _DynamicNameError(AttributeError):
+    """A spy-derived attribute name; subclasses `AttributeError` so fallbacks run."""
+
+    # the parameter keeps `cls(*args)` reconstruction working, e.g. unpickling
+    def __init__(
+        self,
+        message: str = "no protocol for a dynamic attribute name",
+        /,
+    ) -> None:
+        super().__init__(message)
 
 
 class _Marker(StrEnum):
@@ -260,6 +280,8 @@ class _SpyType(type):
     def __getattr__(cls, attr: str, /) -> "_SpyObject | None":
         if _internal(attr):
             return None
+        if _dynamic_name(attr):
+            raise _DynamicNameError
 
         if (owner := _class_spy(cls)) is None:
             msg = f"type object {cls.__name__!r} has no attribute {attr!r}"
@@ -313,6 +335,8 @@ class _SpyObject(_Spy, metaclass=_SpyType):
         # TODO: specialize for known special dunder attrs, e.g. `__name__: str`
         if _internal(attr):
             return None
+        if _dynamic_name(attr):
+            raise _DynamicNameError
 
         if attr in self.__optype_absent__:
             # the marker survives only if a completing run tolerates the absence
@@ -533,6 +557,12 @@ class _SpyObject(_Spy, metaclass=_SpyType):
         return self.__optype_trace_add__("__aexit__", args, {}, _SpyObject())
 
 
+# the observable class names for `_dynamic_name`; not the broader `_Spy`, so a
+# genuine `*_spy*` attribute never matches
+_SPY_NAMES = tuple(
+    cls.__name__.lower() for cls in (_SpyStr, _SpyBytes, _SpyType, _SpyObject)
+)
+
 # Operators that record their positional args and return a fresh spy. Generated onto
 # the type (not synthesized in `__getattr__`) because special-method lookup skips it.
 _TRACED_OPS = (
@@ -622,6 +652,11 @@ def _own_spy(spy: _SpyObject) -> _SpyObject:  # pyright: ignore[reportUnusedFunc
     """The first spy of `spy`'s class: `type(spy)()` siblings collapse onto it."""
     owner = _class_spy(type(spy))  # `or spy` would trace a `__bool__` on the owner
     return spy if owner is None else owner
+
+
+def despy_class(cls: type, /) -> type:
+    """The first non-spy base of `cls`, so internal spy classes never render."""
+    return next(c for c in cls.__mro__ if c.__module__ != __name__)
 
 
 def as_spy(value: object) -> _SpyObject | None:

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -19,6 +19,7 @@ import itertools
 import math
 import operator
 import os
+import pydoc
 import random
 import re
 import secrets
@@ -3053,6 +3054,32 @@ def test_dynamic_attr_name() -> None:
     # a spy-derived attribute name is not statically known
     with pytest.raises(InferError, match="no protocol"):
         infer(lambda x, y: getattr(x, str(y)))
+
+
+def test_dynamic_attr_name_class_name() -> None:
+    # a class-name-derived attribute simulates absence, so the fallback renders (#777)
+    assert infer(ast.NodeVisitor.visit) == (
+        "[T, R](self: Has['generic_visit', (T) -> +R], node: T) -> R"
+    )
+    assert "_Spy" not in infer(pydoc.TextRepr.repr1)
+
+
+def test_fixed_self_spy_class() -> None:
+    # the pinned `self` is a spy class, which renders as its first non-spy base (#777)
+    assert infer(type.__or__) == "(type, object) -> NotImplementedType"
+
+
+def test_deprecated_spy_identity() -> None:
+    # a message naming the spy's class substitutes the target's owner instead (#777)
+    class Legacy:
+        def old(self) -> None:
+            name = f"{self.__class__.__module__}.{self.__class__.__qualname__}"
+            warnings.warn(f"{name}.old()", DeprecationWarning, stacklevel=2)
+
+    out = infer(Legacy.old)
+    assert "_Spy" not in out
+    deprecated = f"@deprecated('{Legacy.__module__}.{Legacy.__qualname__}.old()')"
+    assert out.splitlines()[0] == deprecated
 
 
 def test_instance_subclass_check() -> None:


### PR DESCRIPTION
before:

```console
$ optype infer "type.__or__"
(_SpyType, object) -> NotImplementedType

$ optype infer "import ast; ast.NodeVisitor.visit"
[T, R](self: Has['generic_visit'] & Has['visit__SpyObject', (T) -> +R], node: T) -> R
```

after:

```console
$ optype infer "type.__or__"
(type, object) -> NotImplementedType

$ optype infer "import ast; ast.NodeVisitor.visit"
[T, R](self: Has['generic_visit', (T) -> +R], node: T) -> R
```

fixes #777